### PR TITLE
Vp 168 uncaught exceptions when running tests on windows

### DIFF
--- a/docs/troubleshooting/ECONRESET in windows.md
+++ b/docs/troubleshooting/ECONRESET in windows.md
@@ -1,0 +1,10 @@
+Uncaught exceptions when running tests on windows
+https://voluntarily.atlassian.net/browse/VP-168
+
+Investigation
+
+    whether running tests in isolation has the same problem i.e. is one test killing another.
+
+    write simplest possible test
+
+    can we reproduce outside of windows

--- a/lib/auth/__test__/auth.spec.js
+++ b/lib/auth/__test__/auth.spec.js
@@ -42,18 +42,15 @@ const people = [
     role: ['tester']
   }
 ]
-let memMongo
 
-test.before('before connect to database', async () => {
+test.before('before connect to database', async (t) => {
   await appReady
-  memMongo = new MemoryMongo()
-  // console.log('App ready')
-  await memMongo.start()
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
 })
 
-test.after.always(async () => {
-  await memMongo.stop()
-  // console.log('stopped')
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
 })
 
 test.beforeEach('connect and add two person entries', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,6 +1962,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "atom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/atom/-/atom-1.1.0.tgz",
+      "integrity": "sha512-IlkHVhAmp0J9ioEAKRcpjNxylBbsObHlGZYy97yB0NrdDzLjmHWQ6RB2tekRKAxPsnNJLsWA8fgqIrP1H84Xyw=="
+    },
     "auth0-js": {
       "version": "9.10.4",
       "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-9.10.4.tgz",
@@ -2965,13 +2970,13 @@
       }
     },
     "browserslist": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.0.tgz",
-      "integrity": "sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+      "integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30000967",
-        "electron-to-chromium": "^1.3.133",
-        "node-releases": "^1.1.19"
+        "caniuse-lite": "^1.0.30000971",
+        "electron-to-chromium": "^1.3.137",
+        "node-releases": "^1.1.21"
       }
     },
     "bson": {
@@ -14225,11 +14230,6 @@
         "webpack-sources": "^1.3.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
-        },
         "schema-utils": {
           "version": "0.4.7",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "accepts": "^1.3.5",
     "acorn": "^6.1.1",
     "antd": "^3.5.4",
+    "atom": "^1.1.0",
     "auth0-js": "^9.10.2",
     "babel-plugin-import": "^1.7.0",
     "babel-plugin-react-intl": "^3.0.1",
@@ -115,8 +116,6 @@
       "server/**/*.js"
     ],
     "failFast": false,
-    "verbose": true,
-    "concurrency": 0,
     "timeout": "5m",
     "babel": {
       "testOptions": {

--- a/server/api/interest/__tests__/interest.spec.js
+++ b/server/api/interest/__tests__/interest.spec.js
@@ -45,16 +45,14 @@ const interest = new Interest({
   comment: 'This is another test'
 })
 
-let memMongo
-
-test.before('before connect to database', async () => {
+test.before('before connect to database', async (t) => {
   await appReady
-  memMongo = new MemoryMongo()
-  await memMongo.start()
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
 })
 
-test.after.always(async () => {
-  await memMongo.stop()
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
 })
 
 test.beforeEach('connect and set up test fixture', async () => {

--- a/server/api/opportunity/__tests__/opportunity.spec.js
+++ b/server/api/opportunity/__tests__/opportunity.spec.js
@@ -7,16 +7,14 @@ import MemoryMongo from '../../../util/test-memory-mongo'
 import people from '../../person/__tests__/person.fixture'
 import ops from './opportunity.fixture.js'
 
-let memMongo
-
-test.before('before connect to database', async () => {
+test.before('before connect to database', async (t) => {
   await appReady
-  memMongo = new MemoryMongo()
-  await memMongo.start()
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
 })
 
-test.after.always(async () => {
-  await memMongo.stop()
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
 })
 
 test.beforeEach('connect and add two oppo entries', async (t) => {

--- a/server/api/organisation/__tests__/organisation.spec.js
+++ b/server/api/organisation/__tests__/organisation.spec.js
@@ -4,7 +4,6 @@ import { server, appReady } from '../../../server'
 import Organisation from '../organisation'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import orgs from './organisation.fixture.js'
-let memMongo
 
 const p = {
   name: 'International Testing Corporation',
@@ -13,14 +12,14 @@ const p = {
   about: 'Evil testing empire'
 }
 
-test.before('before connect to database', async () => {
+test.before('before connect to database', async (t) => {
   await appReady
-  memMongo = new MemoryMongo()
-  await memMongo.start()
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
 })
 
-test.after.always(async () => {
-  await memMongo.stop()
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
 })
 
 test.beforeEach('connect and add organisation entries', async () => {

--- a/server/api/person/__tests__/person.spec.js
+++ b/server/api/person/__tests__/person.spec.js
@@ -4,20 +4,17 @@ import { server, appReady } from '../../../server'
 import Person from '../person'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import people from '../__tests__/person.fixture'
-// Initial people added into test db
 
-let memMongo
-
-test.before('before connect to database', async () => {
+test.before('before connect to database', async (t) => {
   await appReady
-  memMongo = new MemoryMongo()
+  t.context.memMongo = new MemoryMongo()
   // console.log('App ready')
-  await memMongo.start()
+  await t.context.memMongo.start()
 })
 
-test.after.always(async () => {
-  await memMongo.stop()
-  // console.log('stopped')
+test.after.always(t => {
+  t.context.memMongo.stop()
+  console.log('stopped')
 })
 
 test.beforeEach('connect and add peopl fixture', async () => {

--- a/server/util/test-memory-mongo.js
+++ b/server/util/test-memory-mongo.js
@@ -25,7 +25,6 @@ class MemoryMongo {
       useCreateIndex: true
     }
     this.connection = await mongoose.connect(this.mongoUri, mongooseOpts)
-
   }
 
   async stop () {

--- a/server/util/test-memory-mongo.js
+++ b/server/util/test-memory-mongo.js
@@ -1,34 +1,43 @@
 // mockMongo
 // File for abstracting generic before, beforeEach, afterEach and after code
 import mongoose from 'mongoose'
-// mongoose.Promise = Promise
+mongoose.Promise = Promise
 const { MongoMemoryServer } = require('mongodb-memory-server')
 
 class MemoryMongo {
   constructor () {
     this.connection = null
     this.mms = new MongoMemoryServer({
-      // debug: false, // by default false
-      // binary: {
-      //   version: '4.0.5'
-      // }
+      debug: false, // by default false
+      binary: {
+        debug: false
+        // version: '4.0.5'
+      }
     })
   }
 
   async start () {
-    const mongoUri = await this.mms.getConnectionString()
-    // console.log('Test mongodb connecting to:', mongoUri)
+    this.mongoUri = await this.mms.getConnectionString()
+    // console.log('Test mongodb connecting to:', this.mongoUri)
     const mongooseOpts = {
       // options for mongoose 4.11.3 and above
       useNewUrlParser: true,
       useCreateIndex: true
     }
-    this.connection = await mongoose.connect(mongoUri, mongooseOpts)
+    this.connection = await mongoose.connect(this.mongoUri, mongooseOpts)
+
   }
 
-  stop () {
-    mongoose.disconnect()
-    return this.mms.stop()
+  async stop () {
+    try {
+      // await mongoose.disconnect()
+      this.connection = null
+      // console.log('test mongodb disconnected', this.mongoUri)
+      await this.mms.stop()
+      this.mms = null
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   cleanup () {


### PR DESCRIPTION
Cause:  mongoose disconnect. 

we are running tests in parallel.  Although we now use mongo-memory-server to give us multiple parallel databases mongoose is still a single thing.  So mongoose connect connects to different ports but when we call mongoose.disconnect it drops everything.   
Commenting out and the tests run ok.  there may be dangling connections but the tests don't care. 

Tested on Windows.  