### PR TITLE
service vly -> vly2 with load balancer

### DIFF
--- a/x/aws/deploy-alpha
+++ b/x/aws/deploy-alpha
@@ -4,5 +4,5 @@ MY_DIR=$( dirname "${BASH_SOURCE[0]}" )
 # Get a docker login and run it
 source ${MY_DIR}/login
 
-aws ecs update-service --service vly --cluster vly-cluster1 --force-new-deployment --desired-count 3 --deployment-configuration maximumPercent=100,minimumHealthyPercent=50
+aws ecs update-service --service vly2 --cluster vly-cluster1 --force-new-deployment --desired-count 3 --deployment-configuration maximumPercent=100,minimumHealthyPercent=50
 


### PR DESCRIPTION
Added load balancer to AWS cluster.  Created a new service vly2. 
This change starts the service instead of the previous one.

Also logging to cloud watch is now on.