### PR TITLE
VP-41: Make New opportunity only available for op-providers

### DIFF
--- a/components/Op/OpAdd.js
+++ b/components/Op/OpAdd.js
@@ -1,0 +1,40 @@
+/*
+  Display an activity record in card format with a picture, title, and commitment.
+*/
+import React from 'react'
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+import { FormattedMessage } from 'react-intl'
+import { Button } from 'antd'
+import { connect } from 'react-redux'
+
+// todo if image is not present then use a fallback.
+const OpAdd = ({ roles, ...props }) => {
+  if (roles && roles.includes('op-provider')) {
+    return (
+      <Link href={'/op/new'}>
+        <Button type='primary' shape='round' size='large'>
+          <FormattedMessage
+            id='landing.newOp'
+            defaultMessage='New Opportunity'
+            description='Button to create a new opportunity on Landing page'
+          />
+        </Button>
+      </Link>
+    )
+  } else {
+    return null
+  }
+}
+
+OpAdd.propTypes = {
+  roles: PropTypes.array
+}
+
+const mapStateToProps = store => ({
+  roles: store.session.me.role
+})
+
+export default connect(
+  mapStateToProps
+)(OpAdd)

--- a/components/Op/__tests__/OpAdd.spec.js
+++ b/components/Op/__tests__/OpAdd.spec.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import test from 'ava'
+import OpAdd from '../OpAdd'
+import { mountWithIntl } from '../../../lib/react-intl-test-helper'
+import configureStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
+
+const mockStore = configureStore()(
+  {
+    session: {
+      me: {
+        role: ['volunteer']
+      }
+    }
+  }
+)
+
+test('render the opadd as null if not op-provider role', t => {
+  const wrapper = mountWithIntl(
+    <Provider store={mockStore}>
+      <OpAdd store={mockStore} />
+    </Provider>
+  )
+
+  t.falsy(wrapper.find('button').exists())
+})
+
+test('render the opadd correctly if op-provider role', t => {
+  mockStore.getState().session.me.role = ['op-provider']
+  const wrapper = mountWithIntl(
+    <Provider store={mockStore}>
+      <OpAdd store={mockStore} />
+    </Provider>
+  )
+
+  t.truthy(wrapper.find('button').exists())
+})

--- a/pages/landing/landing.js
+++ b/pages/landing/landing.js
@@ -1,12 +1,10 @@
-import { Button } from 'antd'
 import React, { Component } from 'react'
-import { FormattedMessage } from 'react-intl'
-import Link from 'next/link'
 
 import publicPage, { FullPage } from '../../hocs/publicPage'
 import Hero from '../../components/LandingPageComponents/Hero'
 import PersonaSection from '../../components/LandingPageComponents/PersonaSection'
 import OpListSection from '../../components/Op/OpListSection'
+import OpAdd from '../../components/Op/OpAdd'
 import TitleSectionSub from '../../components/LandingPageComponents/TitleSectionSub'
 
 // import bigimage from './landing-page-bg.jpg'
@@ -36,15 +34,7 @@ export class Landing extends Component {
           />
 
           <OpListSection store={this.props.store} />
-          <Link href={'/op/new'}>
-            <Button type='primary' shape='round' size='large'>
-              <FormattedMessage
-                id='landing.newOp'
-                defaultMessage='New Opportunity'
-                description='Button to create a new opportunity on Landing page'
-              />
-            </Button>
-          </Link>
+          <OpAdd {...this.props} />
         </FullPage>
       </div>
     )


### PR DESCRIPTION
I think this is correct behaviour, unless you want a non op-provider to be able to click the button and then have the opportunity to sigh in with a different account...