### PR TITLE
[VP-213] Forward headers on server to server fetch call

### DIFF
--- a/hocs/publicPage.js
+++ b/hocs/publicPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Head from 'next/head'
 import Router from 'next/router'
-
+import Cookie from 'js-cookie'
 import {
   getUserFromServerCookie,
   getUserFromLocalCookie,
@@ -69,13 +69,14 @@ export const FillWindow = styled.div`
 export default Page =>
   class DefaultPage extends React.Component {
     static async getInitialProps (ctx) {
+      let cookies = ctx.req ? ctx.req.cookies : Cookie.get()
       let session = {}
       const loggedUser = process.browser
         ? getUserFromLocalCookie()
         : getUserFromServerCookie(ctx.req)
       if (loggedUser) {
         try {
-          session = await parseUserToSession(loggedUser)
+          session = await parseUserToSession(loggedUser, cookies)
           ctx.store.dispatch(setSession(session))
         } catch (err) {
           console.error()

--- a/lib/__test__/apiCaller.spec.js
+++ b/lib/__test__/apiCaller.spec.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import 'isomorphic-fetch'
-import callApi, { API_URL } from '../apiCaller'
+import callApi, { API_URL, convertCookiesToKvps } from '../apiCaller'
 const { fetchMock } = require('fetch-mock')
 // test('fetchMock works', async t => {
 // const health = {
@@ -51,3 +51,20 @@ test('getAPI ', async t => {
 //   console.log(error)
 //   t.is(error.message, 'These are not the pages you are looking for')
 // })
+
+test('Can convert cookie object to cookie KVPs', async t => {
+  const expectedCookieKvps = 'foo=bar;up=down;'
+  const cookies = {
+    foo: 'bar',
+    up: 'down'
+  }
+  const actualCookieKvps = convertCookiesToKvps(cookies)
+  t.is(actualCookieKvps, expectedCookieKvps)
+})
+
+test('Can handle missing cookie object when converting to cookie KVPs', async t => {
+  const expectedCookieKvps = ''
+  const cookies = undefined
+  const actualCookieKvps = convertCookiesToKvps(cookies)
+  t.is(actualCookieKvps, expectedCookieKvps)
+})

--- a/lib/apiCaller.js
+++ b/lib/apiCaller.js
@@ -9,11 +9,26 @@ export const APP_URL =
 
 export const API_URL = `${APP_URL}/api`
 
-const callApi = async (endpoint, method = 'get', body) => {
-  // console.log('callAPI', endpoint, method, body || '')
+export const convertCookiesToKvps = (cookies) => {
+  let cookieKvp = ''
+  if (cookies) {
+    Object.keys(cookies).map(key => {
+      cookieKvp += `${key}=${cookies[key]};`
+    })
+  }
+  return cookieKvp
+}
+
+const callApi = async (endpoint, method = 'get', body, cookies) => {
+  let headers = {
+    'content-type': 'application/json'
+  }
+  if (cookies) {
+    headers.Cookie = convertCookiesToKvps(cookies)
+  }
   try {
     const response = await fetch(`${API_URL}/${endpoint}`, {
-      headers: { 'content-type': 'application/json' },
+      headers,
       method,
       body: JSON.stringify(body)
     })

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -7,8 +7,8 @@ export const parseTokenToSession = async (idToken) => {
   return parseUserToSession(user)
 }
 
-export const parseUserToSession = async (user) => {
-  const me = await getPersonFromUser(user)
+export const parseUserToSession = async (user, cookies) => {
+  const me = await getPersonFromUser(user, cookies)
   return {
     isAuthenticated: !!user,
     user,
@@ -25,7 +25,7 @@ export const setToken = (idToken, accessToken) => {
   Cookie.set('accessToken', accessToken)
 }
 
-export const createPersonFromUser = async (user) => {
+export const createPersonFromUser = async (user, cookies) => {
   // console.log('createPersonFromUser')
   const person = {
     name: user.name,
@@ -34,7 +34,7 @@ export const createPersonFromUser = async (user) => {
     avatar: user.picture
   }
   try {
-    const newPerson = await callApi('people', 'post', person)
+    const newPerson = await callApi('people', 'post', person, cookies)
     // console.log('created person', newPerson)
     return newPerson
   } catch (err) {
@@ -43,19 +43,19 @@ export const createPersonFromUser = async (user) => {
   }
 }
 
-export const getPersonFromUser = async (user) => {
+export const getPersonFromUser = async (user, cookies) => {
   // console.log('getPersonFromUser', user.email)
   if (!user.email_verified) {
     // console.log('Warning: user email not verified')
     return false
   }
   try {
-    const person = await callApi(`person/by/email/${user.email}`)
+    const person = await callApi(`person/by/email/${user.email}`, 'get', null, cookies)
     // console.log('got person', person)
     return person
   } catch (err) {
     // console.log('did not get person, creating...')
-    const newPerson = await createPersonFromUser(user)
+    const newPerson = await createPersonFromUser(user, cookies)
     // console.log('newPerson', newPerson)
     return newPerson
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3745,6 +3745,22 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-import": "^1.7.0",
     "babel-plugin-react-intl": "^3.0.1",
     "babel-plugin-styled-components": "^1.10.0",
+    "cookie-parser": "^1.4.4",
     "cuid": "^2.1.6",
     "dotenv": "^7.0.0",
     "email-templates": "^5.0.5",
@@ -111,7 +112,8 @@
       "components/__tests__/*.spec.js",
       "components/**/__tests__/*.spec.js",
       "!components/**/__tests__/*.fixture.js",
-      "lib/**/__test__/*.spec.js"
+      "lib/**/__test__/*.spec.js",
+      "lib/__test__/*.spec.js"
     ],
     "helpers": [
       "**/__tests__/**/*.fixture.js",

--- a/pages/op/opdetailpage.js
+++ b/pages/op/opdetailpage.js
@@ -25,7 +25,7 @@ export class OpDetailPage extends Component {
 
   // Called when the user confirms they want to delete an op
   async handleDelete (op) {
-    console.log('deleting op', op)
+    // console.log('deleting op', op)
     if (!op) return
     // Actual data request
     await this.props.dispatch(reduxApi.actions.opportunities.delete({ id: op._id }))

--- a/server/api/image/__tests__/image.spec.js
+++ b/server/api/image/__tests__/image.spec.js
@@ -33,7 +33,7 @@ test('Should upload a small file', async t => {
   const res = await sendImageToAPI(__dirname, '194px-Testcard_F.jpg')
     .expect(200)
     .expect('Content-Type', /json/)
-  console.log(res)
+  // console.log(res)
   t.regex(res.body.imageUrl, /.*194px-testcard_f.jpg/)
 
   // get the image back from server

--- a/server/server.js
+++ b/server/server.js
@@ -16,11 +16,12 @@ const bodyParser = require('body-parser')
 const mongoose = require('mongoose')
 const glob = require('glob')
 const next = require('next')
-
+const cookieParser = require('cookie-parser')
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 server.use(bodyParser.urlencoded({ limit: UPLOAD_LIMIT, extended: true }))
 server.use(bodyParser.json({ limit: UPLOAD_LIMIT, extended: true }))
+server.use(cookieParser())
 const routes = require('./routes')
 const routerHandler = routes.getRequestHandler(app)
 const { config } = require('../config/config')


### PR DESCRIPTION
We want to know if any calls to our backend are authenticated, and if so, by who. We currently use auth0 for authentication and they give us a token we can use. Unfortunately, this token gets "lost" when making server to server calls (during SSR). Before we move forward with an Authentication and Authorization framework, we need to ensure cookies are consistently available. This PR is a baby step towards that end.