### PR TITLE
Add SMTP_ID and SMTP_PWD to docker env set at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN npm run prod-build
 
 FROM node:12-alpine as production
 ARG BUILD_REVISION=local-build
+ARG BUILD_SMTP_ID
+ENV SMTP_ID=${BUILD_SMTP_ID}
+ARG BUILD_SMTP_PWD
+ENV SMTP_PWD=${BUILD_SMTP_PWD}
 ENV REVISION=${BUILD_REVISION}
 ENV NODE_ENV=production
 COPY --from=production_build /usr/src/app /voluntarily

--- a/x/aws/buildimage
+++ b/x/aws/buildimage
@@ -14,7 +14,7 @@ source ${MY_DIR}/login
 REVISION=`git describe --always --dirty`
 
 # build the docker image
-docker build --target production --build-arg BUILD_REVISION=${REVISION} --tag voluntarily/vly2:${ESCAPED_TAG_VERSION} .
+docker build --target production --build-arg BUILD_REVISION=${REVISION} --build-arg BUILD_SMTP_ID --build-arg BUILD_SMTP_PWD --tag voluntarily/vly2:${ESCAPED_TAG_VERSION} .
 
 # tag the image
 UPSTREAM_TAG=585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly2-alpha:${ESCAPED_TAG_VERSION}


### PR DESCRIPTION
Should work, but a bit tricky to test without end to end...

Still needs actual values added to the cirrus build, I will add a wiki page detailing that. They should be added as env vars

BUILD_SMTP_ID and BUILD_SMTP_PWD in the .cirrus.yml file in the env block as ENCRYPTED values