### PR TITLE
Vp 257 include tags in search

### DIFF
--- a/server/api/opportunity/__tests__/opportunity.fixture.js
+++ b/server/api/opportunity/__tests__/opportunity.fixture.js
@@ -8,7 +8,8 @@ const opList = [
     date: '20190401',
     offerOrg: 'Albany High School',
     location: 'Albany High School, Auckland',
-    status: 'active'
+    status: 'active',
+    tags: []
   },
   {
     title: '2 Self driving model cars',
@@ -17,7 +18,8 @@ const opList = [
     description: '# NZTA Innovation Centre\n \n We have 6 model cars with sensors for vision, proximity etc, \n controlled by Arduinos teach them to solve \n 4 challenges - move, follow a line, avoid obstacles, \n get to a destination etc. \n \n ## We need:\n * Open space with room for the test tracks - e.g a school hall\n * teams of 5 students\n * on adult helper per team, should be able to follow instructions and understand a little C++\n \n ## Learning outcomes:\n * programming a remote device\n * simple coding\n * algorithmic thinking\n * problem solving.\n \n',
     duration: '4 hours',
     location: 'NZTA Innovation Centre, 5 Cook St Auckland',
-    status: 'active'
+    status: 'active',
+    tags: []
   },
   {
     title: '3 Growing in the garden',
@@ -26,7 +28,8 @@ const opList = [
     description: 'Project to grow something in the garden',
     duration: '15 Minutes',
     location: 'Newmarket, Auckland',
-    status: 'draft'
+    status: 'draft',
+    tags: []
   },
   {
     title: '4 The first 100 metres',
@@ -35,7 +38,8 @@ const opList = [
     description: 'Project to build a simple rocket that will reach 100m',
     duration: '2 hours',
     location: 'Albany, Auckland',
-    status: 'draft'
+    status: 'draft',
+    tags: []
   }
 ]
 

--- a/server/api/opportunity/opportunity.controller.js
+++ b/server/api/opportunity/opportunity.controller.js
@@ -33,17 +33,21 @@ const getOpportunities = async (req, res) => {
     // find tag ids to include in the opportunity search
     const matchingTagIds = await Tag.find({ 'tag': tagSearchExpression }, '_id').exec()
 
-    const tagIdExpression = {
-      $or: matchingTagIds.map(id => ({ 'tags': id }))
-    }
     const searchExpression = new RegExp(req.query.search, 'i')
     const searchParams = {
       $or: [
         { 'title': searchExpression },
         { 'subtitle': searchExpression },
-        { 'description': searchExpression },
-        tagIdExpression
+        { 'description': searchExpression }
       ]
+    }
+
+    // mongoose isn't happy if we provide an empty array as an expression
+    if (matchingTagIds.length > 0) {
+      const tagIdExpression = {
+        $or: matchingTagIds.map(id => ({ 'tags': id }))
+      }
+      searchParams.$or.push(tagIdExpression)
     }
 
     query = {


### PR DESCRIPTION
Backend treats the search query as an array of keywords and will now include any opportunities with  one or more matching keywords, as well as any opps with a matching title, subtitle, or description (as before)