### PR TITLE
VP 233 Search by location

### DIFF
--- a/components/Op/OpDetailForm.js
+++ b/components/Op/OpDetailForm.js
@@ -439,7 +439,9 @@ class OpDetailForm extends Component {
                         message: 'A region must be provided'
                       }
                     ]
-                  })(<OpDetailLocation />)}
+                  })(<OpDetailLocation
+                    existingLocations={this.props.existingLocations}
+                  />)}
                 </Form.Item>
               </MediumInputContainer>
             </InputContainer>
@@ -550,7 +552,8 @@ OpDetailForm.propTypes = {
   }),
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  existingTags: PropTypes.arrayOf(PropTypes.string).isRequired
+  existingTags: PropTypes.arrayOf(PropTypes.string).isRequired,
+  existingLocations: PropTypes.arrayOf(PropTypes.string).isRequired
   // dispatch: PropTypes.func.isRequired,
 }
 

--- a/components/Op/OpDetailForm.js
+++ b/components/Op/OpDetailForm.js
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 import ImageUpload from '../UploadComponent/ImageUploadComponent'
 import { TextHeadingBold, TextP, Spacer } from '../VTheme/VTheme'
 import OpDetailTagsEditable from './OpDetailTagsEditable'
+import OpDetailLocation from './OpDetailLocation'
 const { TextArea } = Input
 
 // custom form components go here
@@ -432,8 +433,13 @@ class OpDetailForm extends Component {
               <MediumInputContainer>
                 <Form.Item label={opLocation}>
                   {getFieldDecorator('location', {
-                    rules: []
-                  })(<Input placeholder='school or somewhere else?' />)}
+                    rules: [
+                      {
+                        required: true,
+                        message: 'A region must be provided'
+                      }
+                    ]
+                  })(<OpDetailLocation />)}
                 </Form.Item>
               </MediumInputContainer>
             </InputContainer>

--- a/components/Op/OpDetailLocation.js
+++ b/components/Op/OpDetailLocation.js
@@ -5,32 +5,21 @@ import { Select } from 'antd'
 const { Option } = Select
 
 class OpDetailLocation extends React.Component {
-  state = {
-    selectedOption: this.props.value ? this.props.value : null
-  };
-
   handleChange = selectedOption => {
-    this.setState({ selectedOption })
     this.props.onChange(selectedOption)
   };
 
   render () {
-    const { selectedOption } = this.state
+    const { existingLocations } = this.props
+    const children = existingLocations.map(location => <Option key={location}>{location}</Option>)
 
     return (
       <Select
         showSearch
-        placeholder='Select a Region'
-        value={selectedOption}
+        placeholder='Select the most applicable region'
         onChange={this.handleChange}
       >
-        <Option value='Auckland' key='Auckland'>Auckland</Option>
-        <Option value='Northland' key='Northland'>Northland</Option>
-        <Option value='Wellington' key='Wellington'>Wellington</Option>
-        <Option value='Southland' key='Southland'>Southland</Option>
-        <Option value='Christchurch' key='Christchurch'>Christchurch</Option>
-        <Option value='West Coast' key='West Coast'>West Coast</Option>
-        <Option value='Wanaka' key='Wanaka'>Wanaka</Option>
+        {children}
       </Select>
     )
   }
@@ -38,7 +27,8 @@ class OpDetailLocation extends React.Component {
 
 OpDetailLocation.propTypes = {
   value: PropTypes.string,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  existingLocations: PropTypes.arrayOf(PropTypes.string).isRequired
 }
 
 export default OpDetailLocation

--- a/components/Op/OpDetailLocation.js
+++ b/components/Op/OpDetailLocation.js
@@ -4,25 +4,18 @@ import { Select } from 'antd'
 
 const { Option } = Select
 
-class OpDetailLocation extends React.Component {
-  handleChange = selectedOption => {
-    this.props.onChange(selectedOption)
-  };
-
-  render () {
-    const { existingLocations } = this.props
-    const children = existingLocations.map(location => <Option key={location}>{location}</Option>)
-
-    return (
-      <Select
-        showSearch
-        placeholder='Select the most applicable region'
-        onChange={this.handleChange}
-      >
-        {children}
-      </Select>
-    )
-  }
+const OpDetailLocation = ({ onChange, value, existingLocations }) => {
+  const children = existingLocations.map(location => <Option key={location}>{location}</Option>)
+  return (
+    <Select
+      showSearch
+      placeholder='Select the most applicable region'
+      onChange={onChange}
+      value={value}
+    >
+      {children}
+    </Select>
+  )
 }
 
 OpDetailLocation.propTypes = {

--- a/components/Op/OpDetailLocation.js
+++ b/components/Op/OpDetailLocation.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Select } from 'antd'
+
+const { Option } = Select
+
+class OpDetailLocation extends React.Component {
+  state = {
+    selectedOption: this.props.value ? this.props.value : null
+  };
+
+  handleChange = selectedOption => {
+    this.setState({ selectedOption })
+    this.props.onChange(selectedOption)
+  };
+
+  render () {
+    const { selectedOption } = this.state
+
+    return (
+      <Select
+        showSearch
+        placeholder='Select a Region'
+        value={selectedOption}
+        onChange={this.handleChange}
+      >
+        <Option value='Auckland' key='Auckland'>Auckland</Option>
+        <Option value='Northland' key='Northland'>Northland</Option>
+        <Option value='Wellington' key='Wellington'>Wellington</Option>
+        <Option value='Southland' key='Southland'>Southland</Option>
+        <Option value='Christchurch' key='Christchurch'>Christchurch</Option>
+        <Option value='West Coast' key='West Coast'>West Coast</Option>
+        <Option value='Wanaka' key='Wanaka'>Wanaka</Option>
+      </Select>
+    )
+  }
+}
+
+OpDetailLocation.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func
+}
+
+export default OpDetailLocation

--- a/components/Op/__tests__/OpDetailForm.spec.js
+++ b/components/Op/__tests__/OpDetailForm.spec.js
@@ -6,8 +6,10 @@ import { mountWithIntl, shallowWithIntl } from '../../../lib/react-intl-test-hel
 
 import OpDetailForm from '../OpDetailForm'
 import sinon from 'sinon'
-// Initial opportunities
 
+const locations = ['Auckland, Wellington, Christchurch']
+
+// Initial opportunities
 const op = {
   _id: '5cc903e5f94141437622cea7',
   title: 'Growing in the garden',
@@ -63,7 +65,12 @@ test.after.always(() => {
 
 test('shallow the detail with op', t => {
   const wrapper = shallowWithIntl(
-    <OpDetailForm op={op} onSubmit={() => {}} onCancel={() => {}} />
+    <OpDetailForm
+      op={op}
+      onSubmit={() => {}}
+      onCancel={() => {}}
+      existingLocations={locations}
+      existingTags={[]} />
   )
   // console.log(wrapper.debug())
   t.is(wrapper.find('OpDetailForm').length, 1)
@@ -74,7 +81,13 @@ test('render the detail with op', t => {
   const cancelOp = sinon.spy()
   const me = { _id: '5ccbffff958ff4833ed2188d' }
   const wrapper = mountWithIntl(
-    <OpDetailForm op={op} me={me} onSubmit={submitOp} onCancel={cancelOp} />
+    <OpDetailForm
+      op={op}
+      me={me}
+      onSubmit={submitOp}
+      onCancel={cancelOp}
+      existingLocations={locations}
+      existingTags={[]} />
   )
   // t.log(wrapper)
   // console.log(wrapper.html())
@@ -93,7 +106,13 @@ test.serial('render the detail with new blank op', t => {
   const me = { _id: '5ccbffff958ff4833ed2188d' }
 
   const wrapper = mountWithIntl(
-    <OpDetailForm op={noop} me={me} onSubmit={submitOp} onCancel={cancelOp} />
+    <OpDetailForm
+      op={noop}
+      me={me}
+      onSubmit={submitOp}
+      onCancel={cancelOp}
+      existingLocations={locations}
+      existingTags={[]} />
   )
   t.log(wrapper.first())
   const datePicker = wrapper.find('.ant-calendar-picker')
@@ -117,6 +136,10 @@ test.serial('render the detail with new blank op', t => {
   title
     .simulate('keydown', { which: 'a' })
     .simulate('change', { target: { value: 'My new value' } })
+
+  const locationInput = wrapper.find('OpDetailLocation').first()
+  locationInput.props().onChange('Auckland')
+
   wrapper.update()
 
   const duration = wrapper.find('input#opportunity_detail_form_duration').first()

--- a/components/Op/__tests__/OpDetailLocation.spec.js
+++ b/components/Op/__tests__/OpDetailLocation.spec.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import test from 'ava'
+import { mountWithIntl } from '../../../lib/react-intl-test-helper'
+import OpDetailLocation from '../OpDetailLocation'
+import sinon from 'sinon'
+const originalWarn = console.warn
+
+test.before('before test silence async-validator', () => {
+  console.warn = (...args) => {
+    if (typeof args[0] === 'string' && args[0].startsWith('async-validator:')) return
+    originalWarn(...args)
+  }
+})
+
+test.after.always(() => {
+  console.warn = originalWarn
+})
+
+test('render the location component, with pre-existing location', t => {
+  const existingLocations = ['Auckland', 'Christchurch', 'Wellington', 'Whangarei']
+  const mockOnChange = sinon.spy()
+
+  const wrapper = mountWithIntl(
+    <OpDetailLocation value={'Auckland'} onChange={mockOnChange} existingLocations={existingLocations} />
+  )
+
+  t.true(wrapper.html().includes('Auckland'))
+})
+
+test('render the location component, with an example input search', t => {
+  const existingLocations = ['Auckland', 'Christchurch', 'Wellington', 'Whangarei']
+  const inputSearch = 'Auck'
+  const mockOnChange = sinon.spy()
+
+  const wrapper = mountWithIntl(
+    <OpDetailLocation value={'Auckland'} onChange={mockOnChange} existingLocations={existingLocations} />
+  )
+
+  wrapper.find('input').simulate('change', { target: { value: inputSearch } })
+
+  const inputField = wrapper.find('input').first()
+  t.true(inputField.html().includes('Auck'))
+})

--- a/lib/redux/reduxApi.js
+++ b/lib/redux/reduxApi.js
@@ -72,6 +72,12 @@ const thisReduxApi = reduxApi({
     crud: true, // Make CRUD actions: https://github.com/lexich/redux-api/blob/master/docs/DOCS.md#crud
     options: config.jsonOptions,
     transformer: apiTransformer
+  },
+  locations: {
+    url: '/api/locations',
+    crud: true, // Make CRUD actions: https://github.com/lexich/redux-api/blob/master/docs/DOCS.md#crud
+    options: config.jsonOptions,
+    transformer: apiTransformer
   }
   // reducer (state, action) {
   //  console.log('reducer', action);
@@ -115,6 +121,6 @@ export const withReduxEndpoints = (PageComponent, endpointNames) => connect(mapS
 // Define custom endpoints/providers here:
 export const withOrgs = PageComponent => withReduxEndpoints(PageComponent, ['organisations'])
 export const withActs = PageComponent => withReduxEndpoints(PageComponent, ['activities'])
-export const withOps = PageComponent => withReduxEndpoints(PageComponent, ['opportunities', 'tags'])
+export const withOps = PageComponent => withReduxEndpoints(PageComponent, ['opportunities', 'tags', 'locations'])
 export const withPeople = PageComponent => withReduxEndpoints(PageComponent, ['people'])
 export const withInterests = PageComponent => withReduxEndpoints(PageComponent, ['interests'])

--- a/pages/op/opupdatepage.js
+++ b/pages/op/opupdatepage.js
@@ -27,15 +27,9 @@ export class OpUpdatePage extends Component {
     if (opExists) {
       await store.dispatch(reduxApi.actions.opportunities.get(query))
     }
+    await store.dispatch(reduxApi.actions.locations.get())
+    await store.dispatch(reduxApi.actions.tags.get())
     return { opExists }
-  }
-
-  async componentDidMount () {
-    try {
-      await this.props.dispatch(reduxApi.actions.tags.get())
-    } catch (err) {
-      console.log('error in getting tags', err)
-    }
   }
 
   handleCancel = op => {
@@ -109,6 +103,12 @@ export class OpUpdatePage extends Component {
 
     const me = this.props.me
     const existingTags = this.props.tags.data.map(tag => tag.tag)
+
+    const existingLocations = [
+      ...this.props.locations.data[0].regions.map(r => r.name),
+      ...this.props.locations.data[0].territories
+    ]
+
     return (
       <FullPage>
         <PageTitle
@@ -122,6 +122,7 @@ export class OpUpdatePage extends Component {
           onSubmit={this.handleAdd.bind(this, op)}
           onCancel={this.handleCancel}
           existingTags={existingTags}
+          existingLocations={existingLocations}
         />
 
         <br />

--- a/server/api/location/__tests__/location.spec.js
+++ b/server/api/location/__tests__/location.spec.js
@@ -1,0 +1,20 @@
+import test from 'ava'
+import request from 'supertest'
+import { server, appReady } from '../../../server'
+
+const locationData = require('../locationData')
+
+test.before('wait for server to be ready', async (t) => {
+  await appReady
+})
+
+test.serial('Should return the correct location data', async t => {
+  const res = await request(server)
+    .get('/api/locations')
+    .set('Accept', 'application/json')
+    .expect(200)
+    .expect('Content-Type', /json/)
+
+  t.is(locationData.regions.length, res.body.regions.length)
+  t.is(locationData.territories.length, res.body.territories.length)
+})

--- a/server/api/location/location.controller.js
+++ b/server/api/location/location.controller.js
@@ -1,0 +1,7 @@
+const { regions, territories } = require('./locationData')
+
+const getLocations = function (req, res) {
+  res.json({ regions, territories })
+}
+
+module.exports = getLocations

--- a/server/api/location/location.routes.js
+++ b/server/api/location/location.routes.js
@@ -1,0 +1,5 @@
+const getLocations = require('./location.controller')
+
+module.exports = (server) => {
+  server.get('/api/locations', getLocations)
+}

--- a/server/api/location/locationData.js
+++ b/server/api/location/locationData.js
@@ -1,0 +1,149 @@
+// for now, this is hardcoded to all TLAs and regions in NZ
+const regions = [
+  {
+    name: 'Northland',
+    containedTerritories: [
+      'Far North District',
+      'Whangarei District',
+      'Kaipara District'
+    ]
+  },
+  {
+    name: 'Auckland',
+    containedTerritories: [] // auckland is a TLA and a region
+  },
+  {
+    name: 'Waikato',
+    containedTerritories: [
+      'Thames-Coromandel District',
+      'Hauraki District',
+      'Waikato District',
+      'Matamata-Piako District',
+      'Hamilton City',
+      'Waipa District',
+      'Otorohanga District',
+      'South Waikato District',
+      'Waitomo District',
+      'Taupo District'
+    ]
+  },
+  {
+    name: 'Bay of Plenty',
+    containedTerritories: [
+      'Western Bay of Plenty District',
+      'Tauranga City',
+      'Rotorua District',
+      'Whakatane District',
+      'Kawerau District',
+      'Opotiki District'
+    ]
+  },
+  {
+    name: 'Gisborne',
+    containedTerritories: [] // gisborne is a TLA and a region
+  },
+  {
+    name: 'Hawke\'s Bay',
+    containedTerritories: [
+      'Wairoa District',
+      'Hastings District',
+      'Napier City',
+      'Central Hawke\'s Bay District'
+    ]
+  },
+  {
+    name: 'Taranaki',
+    containedTerritories: [
+      'New Plymouth District',
+      'Stratford District',
+      'South Taranaki District'
+    ]
+  },
+  {
+    name: 'Manawatu-Wanganui',
+    containedTerritories: [
+      'Ruapehu District',
+      'Whanganui District',
+      'Rangitikei District',
+      'Manawatu District',
+      'Palmerston North City',
+      'Tararua District',
+      'Horowhenua District'
+    ]
+  },
+  {
+    name: 'Wellington',
+    containedTerritories: [
+      'Kapiti Coast District',
+      'Porirua City',
+      'Upper Hutt City',
+      'Lower Hutt City',
+      'Wellington City',
+      'Masterton District',
+      'Carterton District',
+      'South Wairarapa District'
+    ]
+  },
+  {
+    name: 'Tasman',
+    containedTerritories: [] // tasman is a TLA and a region
+  },
+  {
+    name: 'Nelson',
+    containedTerritories: [] // Nelson is a TLA and a region
+  },
+  {
+    name: 'Marlborough',
+    containedTerritories: [] // Marlborough is a TLA and a region
+  },
+  {
+    name: 'West Coast',
+    containedTerritories: [
+      'Buller District',
+      'Grey District',
+      'Westland District'
+    ]
+  },
+  {
+    name: 'Canterbury',
+    containedTerritories: [
+      'Kaikoura District',
+      'Hurunui District',
+      'Waimakariri District',
+      'Christchurch City',
+      'Selwyn District',
+      'Ashburton District',
+      'Timaru District',
+      'Mackenzie District',
+      'Waimate District',
+      'Waitaki District'
+    ]
+  },
+  {
+    name: 'Otago',
+    containedTerritories: [
+      'Central Otago District',
+      'Queenstown-Lakes District',
+      'Dunedin City',
+      'Clutha District'
+    ]
+  },
+  {
+    name: 'Southland',
+    containedTerritories: [
+      'Southland District',
+      'Gore District',
+      'Invercargill City'
+    ]
+  }
+]
+
+// construct a list of territories from the regions
+const territories = regions.map(r => r.containedTerritories).reduce((acc, val) => {
+  return [...acc, ...val]
+})
+
+module.exports = {
+  regions,
+  territories
+}


### PR DESCRIPTION
Introduces a searchable location input component to both the update page for opportunities, as well as the page for creating new opportunities. Inputs are constrained currently to New Zealand TLAs and regions, as is retrieved from mongoDB via a newly made endpoint. BE/FE tests have been included as well. Example of the component in action is below! (To test, check out updating an opportunity/creating a new opportunity). 

***

![image](https://user-images.githubusercontent.com/31422519/60477878-c5f9e800-9cd4-11e9-9ad0-2a0a344b77f0.png)
