### PR TITLE
VP-358: Fixed display of date ranges

### DIFF
--- a/components/Search/BigSearch.js
+++ b/components/Search/BigSearch.js
@@ -111,7 +111,7 @@ class BigSearch extends PureComponent {
             onSearch={onSearch}
           />
         </SearchInputContainer>
-        <SearchFilterText>Filter by:</SearchFilterText>
+        <SearchFilterText>Filter by: </SearchFilterText>
         <FilterItem onClick={() => onClickDateFilter()}>{dateLabel}</FilterItem>
         <FilterItem onClick={this.showFilterDetails}>{ this.state.selectedLocation == null ? 'Location' : this.state.selectedLocation}</FilterItem>
       </SearchContainer>

--- a/pages/search/DatePickerComponent.js
+++ b/pages/search/DatePickerComponent.js
@@ -33,7 +33,7 @@ export const formatDateBaseOn = (datePickerType, value) => {
     case DatePickerType.MonthRange:
       return moment(value[0]).format('MM/YYYY')
     case DatePickerType.DateRange:
-      return `${moment(value[0].get('date'))}-${moment(value).format('DD/MM/YY')}`
+      return `${moment(value[0]).format('DD/MM/YY')} - ${moment(value[1]).format('DD/MM/YY')}`
     case DatePickerType.WeekRange:
       return `Week ${moment(value[0]).week()}`
     default:


### PR DESCRIPTION
Fixed the display of date ranges for the BigSearch component. The original JIRA suggested these be formatted as "14 Aug - 16 Aug", but here I've used DD/MM/YY to 
a) remain consistent with the single date selection display, and
b) keep the year displayed

Happy to switch formats if we prefer DD MMM overall.