### PR TITLE
Bug fix server crash when user click interested

### DIFF
--- a/components/Interest/RegisterInterestSection.js
+++ b/components/Interest/RegisterInterestSection.js
@@ -27,7 +27,7 @@ class RegisterInterestSection extends Component {
   // TODO do we need to change this to getInitialProps?
   async componentDidMount () {
     const op = this.props.op
-    const me = this.props.me
+    const me = this.props.meID
     try {
       await this.props.dispatch(reduxApi.actions.interests.get({ id: '', op, me }))
     } catch (err) {
@@ -45,7 +45,6 @@ class RegisterInterestSection extends Component {
       await this.props.dispatch(reduxApi.actions.interests.put({ id: interest._id }, { body: JSON.stringify(interest) }))
       message.success('Interest updated')
     } else {
-      // console.log('Adding interest')
       await this.props.dispatch(reduxApi.actions.interests.post({}, { body: JSON.stringify(interest) }))
       message.success('Interest added')
     }
@@ -81,7 +80,7 @@ class RegisterInterestSection extends Component {
       if (this.props.interests && this.props.interests.data && this.props.interests.data.length > 0) {
         interest = this.props.interests.data[0]
       } else { // If not, use a blank interest.
-        interest = getNewInterest(this.props.me, this.props.op)
+        interest = getNewInterest(this.props.meID, this.props.op)
       }
 
       return (

--- a/components/LandingPageComponents/__tests__/FeaturedTwoSection.spec.js
+++ b/components/LandingPageComponents/__tests__/FeaturedTwoSection.spec.js
@@ -36,7 +36,7 @@ test('shallow the list with ops', t => {
 
 test('renders the list with no ops', t => {
   const wrapper = renderWithIntl(
-    <FeaturedTwoSection handleShowOp={() => {}} handleDeleteOp={() => {}} />
+    <FeaturedTwoSection handleShowOp={() => {}} title='' handleDeleteOp={() => {}} />
   )
   t.is(wrapper.find('OpCard').length, 0)
   t.is(wrapper.find('span').text(), 'No matching opportunities')

--- a/components/Op/OpVolunteerInterestSection.js
+++ b/components/Op/OpVolunteerInterestSection.js
@@ -18,7 +18,7 @@ export default class OpVolunteerInterestSection extends Component {
           <Divider />
         </div>
         : this.props.canRegisterInterest && <div>
-          <RegisterInterestSection op={this.props.op} me={this.props.me._id} />
+          <RegisterInterestSection op={this.props.op} meID={this.props.meID} />
           <Divider />
         </div>
     )

--- a/components/Op/__tests__/OpCard.spec.js
+++ b/components/Op/__tests__/OpCard.spec.js
@@ -89,7 +89,7 @@ test('show card for a draft op', t => {
 test('Link on cards in history tab, points to archived Opportunities.', t => {
   const archivedOp = t.context.archivedOp
   const wrapper = mountWithIntl(
-    <OpCard op={archivedOp} />
+    <OpCard op={archivedOp} size='Small' />
   )
   let archivedOpLink = wrapper.find('#linkToOpportunity').props().href
   t.is((archivedOpLink), '/archivedops/' + archivedOp._id)

--- a/components/Op/__tests__/OpList.spec.js
+++ b/components/Op/__tests__/OpList.spec.js
@@ -60,8 +60,8 @@ test('renders the list with ops to get card coverage', t => {
 
 test('renders the list with no ops', t => {
   const wrapper = renderWithIntl(
-    <OpList handleShowOp={() => {}} handleDeleteOp={() => {}} />
+    <OpList handleShowOp={() => {}} handleDeleteOp={() => {}} ops={[]} />
   )
   t.is(wrapper.find('OpCard').length, 0)
-  t.is(wrapper.find('span').text(), 'No matching opportunities')
+  t.is(wrapper.find('span').text(), '')
 })

--- a/pages/op/opdetailpage.js
+++ b/pages/op/opdetailpage.js
@@ -192,7 +192,7 @@ export class OpDetailPage extends Component {
             isAuthenticated={this.props.isAuthenticated}
             canRegisterInterest={canRegisterInterest}
             op={op}
-            me={this.props.me._id}
+            meID={this.props.me._id}
           />
           <OpOwnerManageInterests
             canManageInterests={canManageInterests}


### PR DESCRIPTION
The reason is that the me props that got passed down to OpVolunteerInterestSection is only an ID string not an object. This caused the server reading an undefined variable then crash the server. 
Minor unit test fix so less warning in the log when unit test is running