### PR TITLE
VP-421 add member entity and api

### DIFF
--- a/server/api/interest/__tests__/interest.spec.js
+++ b/server/api/interest/__tests__/interest.spec.js
@@ -98,7 +98,7 @@ test.serial('Should return 404 code when queried non existing interest', async t
   t.is(res.status, expectedResponseStatus)
 })
 
-test.skip(
+test.serial(
   'Should not add an invalid interest where referenced person or opp is not in DB',
   async t => {
     const newInterest = new Interest({

--- a/server/api/interest/interest.controller.js
+++ b/server/api/interest/interest.controller.js
@@ -54,7 +54,7 @@ const createInterest = async (req, res) => {
   const newInterest = new Interest(req.body)
   newInterest.save(async (err, saved) => {
     if (err) {
-      res.status(500).send(err)
+      return res.status(500).send(err)
     }
     const volunteerID = req.body.person
     const { opportunity } = req.body

--- a/server/api/member/__tests__/member.spec.js
+++ b/server/api/member/__tests__/member.spec.js
@@ -1,0 +1,202 @@
+import test from 'ava'
+import request from 'supertest'
+import { server, appReady } from '../../../server'
+import Member from '../member'
+import { MemberStatus } from '../member.constants'
+import Organisation from '../../organisation/organisation'
+import Person from '../../person/person'
+// import { connectDB, dropDB } from '../../../util/test-helpers'
+import MemoryMongo from '../../../util/test-memory-mongo'
+import people from '../../person/__tests__/person.fixture'
+import orgs from '../../organisation/__tests__/organisation.fixture'
+
+test.before('before connect to database', async (t) => {
+  await appReady
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
+
+  t.context.people = await Person.create(people).catch((err) => `Unable to create people: ${err}`)
+  t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create organisations: ${err}`)
+
+  // Initial members added into test db
+  const members = [
+    {
+      person: t.context.people[0]._id,
+      organisation: t.context.orgs[0]._id,
+      validation: 'test follower',
+      status: MemberStatus.FOLLOWER
+    },
+    // person 1 is member of two orgs
+    // org 1 has two members
+    {
+      person: t.context.people[1]._id,
+      organisation: t.context.orgs[0]._id,
+      validation: 'test member 1',
+      status: MemberStatus.MEMBER
+    },
+    {
+      person: t.context.people[1]._id,
+      organisation: t.context.orgs[1]._id,
+      validation: 'test member 1',
+      status: MemberStatus.MEMBER
+    },
+    {
+      person: t.context.people[3]._id,
+      organisation: t.context.orgs[1]._id,
+      validation: 'test member 3',
+      status: MemberStatus.MEMBER
+    }
+  ]
+
+  t.context.members = await Member.create(members).catch(() => 'Unable to create members')
+})
+
+test.after.always(async (t) => {
+  // await Person.deleteMany()
+  await t.context.memMongo.stop()
+})
+
+test.serial('Should give number of Members', async t => {
+  t.plan(2)
+
+  const res = await request(server)
+    .get('/api/members')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+  t.is(res.status, 200)
+  t.deepEqual(4, res.body.length)
+})
+
+test.serial('Should give number of Members for an org', async t => {
+  const orgid = t.context.orgs[1]._id
+
+  const res = await request(server)
+    .get(`/api/members?org=${orgid}`)
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+  const members = res.body
+  t.deepEqual(2, members.length)
+})
+
+test.serial('Should give a list of orgs for a person', async t => {
+  const personid = t.context.people[1]._id
+
+  const res = await request(server)
+    .get(`/api/members?me=${personid}`)
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+  const members = res.body
+  t.deepEqual(2, members.length)
+
+  t.is(members[0].status, MemberStatus.MEMBER)
+  t.is(members[1].status, MemberStatus.MEMBER)
+})
+
+test.serial('Should give a specific membership for a person in org', async t => {
+  const personid = t.context.people[1]._id
+  const orgid = t.context.orgs[1]._id
+
+  const res = await request(server)
+    .get(`/api/members?me=${personid}&org=${orgid}`)
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+  const members = res.body
+  t.deepEqual(1, members.length)
+
+  t.is(members[0].status, MemberStatus.MEMBER)
+})
+
+test.serial('Should send correct data when queried against a _id', async t => {
+  const member = t.context.members[0]
+  const res = await request(server)
+    .get(`/api/members/${member._id}`)
+    .set('Accept', 'application/json')
+  t.is(200, res.status)
+  t.is(member.person.toString(), res.body.person)
+  t.is(member.organisation.toString(), res.body.organisation)
+  t.is(member.validation.toString(), res.body.validation)
+})
+
+test.serial('Should return 404 code when queried non existing member', async t => {
+  const res = await request(server)
+    .get(`/api/members/asodifklamd`)
+    .set('Accept', 'application/json')
+
+  // This test is not ready since the return status was 500 not 404
+  const expectedResponseStatus = 500
+  t.is(res.status, expectedResponseStatus)
+})
+
+test.serial(
+  'Should not add an invalid member where referenced person or opp is not in DB',
+  async t => {
+    const newMember = new Member({
+      person: '5cc8d60b8b16812b5babcdef',
+      organisation: '5cc8d60b8b16812b5babcdef'
+    })
+
+    await request(server)
+      .post('/api/members')
+      .send(newMember)
+      .set('Accept', 'application/json')
+
+    const savedMember = await Member.findOne({
+      person: newMember.person,
+      organisation: newMember.organisation
+    }).exec()
+
+    t.is(null, savedMember)
+  }
+)
+
+test.serial('Should add a valid follower', async t => {
+  const person = t.context.people[4]
+  const organisation = t.context.orgs[4]
+  const newMember = {
+    person: person._id.toString(),
+    organisation: organisation._id.toString(),
+    validation: 'random validation'
+    // status: don't set it should be defaulted to follower
+  }
+
+  const res = await request(server)
+    .post('/api/members')
+    .send(newMember)
+    .set('Accept', 'application/json')
+
+  t.is(res.status, 200)
+  const returnedMember = res.body
+
+  const savedMember = await Member.findOne({
+    person: newMember.person,
+    organisation: newMember.organisation
+  }).exec()
+  t.is(savedMember.person._id.toString(), person._id.toString())
+  t.is(savedMember.organisation._id.toString(), organisation._id.toString())
+  t.is(savedMember.status, MemberStatus.FOLLOWER)
+
+  // update state to member
+  returnedMember.status = MemberStatus.MEMBER
+  const res2 = await request(server)
+    .put(`/api/members/${returnedMember._id}`)
+    .send(returnedMember)
+    .set('Accept', 'application/json')
+  t.is(res.status, 200)
+  const updatedMember = res2.body
+  t.is(updatedMember.status, MemberStatus.MEMBER)
+
+  await request(server)
+    .delete(`/api/members/${returnedMember._id}`)
+    .set('Accept', 'application/json')
+
+  t.is(res.status, 200)
+
+  const queriedMember = await Member.findOne({
+    _id: returnedMember._id
+  }).exec()
+  t.is(null, queriedMember)
+})

--- a/server/api/member/member.constants.js
+++ b/server/api/member/member.constants.js
@@ -1,0 +1,21 @@
+const MemberFields = {
+  ID: '_id',
+  STATUS: 'status',
+  DATE_ADDED: 'dateAdded',
+  PERSON: 'person',
+  ORGANISATION: 'organisation',
+  VALIDATION: 'validation'
+}
+
+const MemberStatus = {
+  FOLLOWER: 'follower',
+  JOINER: 'joiner',
+  MEMBER: 'member',
+  EXMEMBER: 'exmember'
+}
+
+module.exports = {
+  SchemaName: 'Member',
+  MemberFields,
+  MemberStatus
+}

--- a/server/api/member/member.controller.js
+++ b/server/api/member/member.controller.js
@@ -1,0 +1,125 @@
+const Member = require('./member')
+// const Person = require('../person/person')
+const Organisation = require('../organisation/organisation')
+// const { config } = require('../../../config/config')
+// const { emailPerson } = require('../person/email/emailperson')
+// const { MemberStatus } = require('./member.constants')
+
+/**
+  api/members -> list all members
+  api/members?org='orgid' -> lists all members associated with orgid.
+  api/members?org='orgid'&me='personid' -> lists all members (hopefully only 0 or 1) associated with opid and personid.
+  api/members?me='personid' -> list all the orgs i'm membered in and populate the org out.
+ */
+const listMembers = async (req, res) => {
+  let sort = 'dateAdded' // todo sort by date.
+  let got
+  try {
+    if (req.query.org) {
+      // an org is asking for a list of members/followers
+      const query = { organisation: req.query.org }
+      if (req.query.me) {
+        // a person is asking for their relationship with an org
+        query.person = req.query.me
+      }
+      // Return enough info for a personCard
+      got = await Member.find(query).populate({ path: 'person', select: 'nickname name avatar' }).sort(sort).exec()
+    } else if (req.query.me) {
+      // a person is asking for the orgs they follow or are members of
+      const query = { person: req.query.me }
+      // return info for an orgCard
+      got = await Member.find(query).populate({ path: 'organisation', select: 'name imgURL' }).sort(sort).exec()
+    } else {
+      // list all relationships
+      got = await Member.find().sort(sort).exec()
+    }
+    res.json(got)
+  } catch (err) {
+    res.status(404).send(err)
+  }
+}
+
+const updateMember = async (req, res) => {
+  try {
+    await Member.updateOne({ _id: req.body._id }, { $set: { status: req.body.status } }).exec()
+    const { organisation } = req.body // person in here is the volunteer-- quite not good naming here
+    Organisation.findById(organisation, (err, organisationFound) => {
+      if (err) console.log(err, organisationFound)
+      else {
+        // const { organisation, status, person } = req.body // person in here is the volunteer-- quite not good naming here
+        // notify the person of their status change in the organisation
+        // processStatusToSendEmail(status, organisationFound, person)
+      }
+    })
+    res.json(req.body)
+  } catch (err) {
+    res.status(404).send(err)
+  }
+}
+
+const createMember = async (req, res) => {
+  const newMember = new Member(req.body)
+  newMember.save(async (err, saved) => {
+    if (err) {
+      return res.status(500).send(err)
+    }
+
+    // TODO: [VP-424] email new members or followers of an organisation
+    // const volunteerID = req.body.person
+    // const { organisation } = req.body
+    // const { title } = organisation
+    // const { requestor } = req.body.organisation
+    // const orgId = organisation._id
+    // const { validation } = req.body
+    // requestor.volunteerComment = validation
+    // // sendEmailBaseOn('acknowledgeMember', volunteerID, title, opId)
+    // // sendEmailBaseOn('RequestorNotificationEmail', requestor._id, title, opId, comment)
+
+    // return the member record with the org name filled in.
+    const got = await Member.findOne({ _id: saved._id }).populate({ path: 'organisation', select: 'name' }).exec()
+    res.json(got)
+  })
+}
+
+// const processStatusToSendEmail = (memberStatus, organisation, volunteer) => {
+//   const { _id } = volunteer
+//   const { requestor, title } = organisation
+//   const opID = organisation._id
+//   if (memberStatus === MemberStatus.INVITED || memberStatus === MemberStatus.DECLINED) {
+//     // send email to volunteer only
+//     sendEmailBaseOn(memberStatus, _id, title, opID) // The _id in here is the volunteer id
+//   } else if (memberStatus === MemberStatus.COMMITTED) {
+//     // send email to requestor only
+//     sendEmailBaseOn(memberStatus, requestor, title, opID)
+//   }
+// }
+
+/**
+ * This will be easier to add more status without having too much if. All we need is add another folder in email template folder and the status will reference to that folder
+ * @param {string} status status will be used to indicate which email template to use
+ * @param {string} personID so we can find the email of that person
+ * @param {string} organisationTitle Just making the email content clearer
+ * @param {string} opId To construct url that link to the organisation
+ * @param {string} volunteerCommment (optional) This is only for requestor notification email only,default is empty string
+ */
+// const sendEmailBaseOn = async (status, personID, organisationTitle, opId, volunteerComment = '') => {
+//   let opUrl = `${config.appUrl + '/ops/' + opId}`
+//   await Person.findById(personID, (err, person) => {
+//     if (err) console.log(err)
+//     else {
+//       const emailProps = {
+//         send: true
+//       }
+//       person.opUrl = opUrl
+//       person.volunteerEvent = organisationTitle
+//       person.volunteerComment = volunteerComment
+//       emailPerson(person, status, emailProps)
+//     }
+//   })
+// }
+
+module.exports = {
+  listMembers,
+  updateMember,
+  createMember
+}

--- a/server/api/member/member.js
+++ b/server/api/member/member.js
@@ -1,0 +1,44 @@
+const mongoose = require('mongoose')
+const Schema = mongoose.Schema
+const idvalidator = require('mongoose-id-validator')
+const { MemberStatus } = require('./member.constants')
+
+const memberSchema = new Schema({
+  person: { type: Schema.Types.ObjectId, ref: 'Person', required: true },
+  organisation: { type: Schema.Types.ObjectId, ref: 'Organisation', required: true },
+  validation: String,
+  status: {
+    type: 'String',
+    default: MemberStatus.FOLLOWER,
+    required: true,
+    enum: [
+      MemberStatus.FOLLOWER,
+      MemberStatus.JOINER,
+      MemberStatus.MEMBER,
+      MemberStatus.EXMEMBER
+    ]
+  },
+  dateAdded: { type: 'Date', default: Date.now, required: true }
+})
+
+/*
+    State flows
+
+    0 person clicks Follow, record is created - anyone can follow an organisation
+        -> follower.
+    1 person clicks join - asserts they are a member of the organisation somehow.
+        fills in validation field.
+        -> joiner
+    2. orgadmin or system validates
+        -> workflow validates - keycode or email verification, or human
+        -> member  (success)
+        -> follower ( failure )
+    5 person leaves the group, admin removes the person
+        -> exmember
+    6 person unfollows the group
+        -> exmember, or record removed
+
+*/
+
+memberSchema.plugin(idvalidator)
+module.exports = mongoose.model('Member', memberSchema)

--- a/server/api/member/member.routes.js
+++ b/server/api/member/member.routes.js
@@ -1,0 +1,28 @@
+const mongooseCrudify = require('mongoose-crudify')
+const helpers = require('../../services/helpers')
+const Member = require('./member')
+const { listMembers, updateMember, createMember } = require('./member.controller')
+
+module.exports = server => {
+  // Docs: https://github.com/ryo718/mongoose-crudify
+  server.use(
+    '/api/members',
+    mongooseCrudify({
+      Model: Member,
+      selectFields: '-__v', // Hide '__v' property
+      endResponseInAction: false,
+
+      // beforeActions: [],
+      // actions: {}, // list (GET), create (POST), read (GET), update (PUT), delete (DELETE)
+      actions: {
+        list: listMembers,
+        update: updateMember,
+        create: createMember
+      },
+      afterActions: [
+        // this is the place to require user be authed.
+        { middlewares: [helpers.formatResponse] }
+      ]
+    })
+  )
+}


### PR DESCRIPTION
added member entity holding a join between a person and an organisation.  Members can have state of follower, member as well as the intermediate state of requesting to join and exmember.

Patterned on the interest entity. 
Full set of tests, 100% coverage. 

TODO includes adding email notification for membership state changes.