### PR TITLE
Fix issue with recommended ops not showing

### DIFF
--- a/components/Op/OpRecommendations.js
+++ b/components/Op/OpRecommendations.js
@@ -5,50 +5,22 @@ import OpList from './OpList'
 
 class OpRecommendations extends React.Component {
   render () {
-    // const location = this.props.me.location // TODO: verify this works when "me" has location added
-    const location = this.props.me.location || 'No location'
-    const regionToMatch = (location === 'No location') ? '' : this.props.locations.find(loc => {
-      return loc.name === location || loc.containedTerritories.includes(location)
-    })
-
-    const filteredOps = (location === 'No location') ? [] : this.props.ops.filter(o => {
-      return o.location === regionToMatch.name ||
-      regionToMatch.containedTerritories.includes(o.location)
-    })
-
-    // if user has specified a territory, we should show the exact matches first, because we know
-    // they are closest to the user.
-    const userIsInTerritory = regionToMatch.name !== location
-    if (userIsInTerritory) {
-      filteredOps.sort((a, b) => {
-        if (a.location === location && b.location !== location) {
-          return -1
-        } else if (b.location === location && a.location !== location) {
-          return 1
-        } else {
-          return 0 // we don't care about the ordering if the location isn't matching
-        }
-      })
-    }
-
-    return (filteredOps.length === 0)
+    const { recommendedOps } = this.props
+    return (recommendedOps.basedOnLocation.length === 0)
       ? <div /> : (
         <div>
           <TextHeadingSubtitle>Nearby opportunities</TextHeadingSubtitle>
-          <OpList ops={filteredOps} />
+          <OpList ops={recommendedOps.basedOnLocation} />
         </div>
       )
   }
 }
 
 OpRecommendations.propTypes = {
-  me: PropTypes.object.isRequired,
-  // attributes: PropTypes.arrayOf(PropTypes.string).isRequired,
-  ops: PropTypes.array.isRequired,
-  locations: PropTypes.arrayOf(PropTypes.shape({
-    name: PropTypes.string,
-    containedTerritories: PropTypes.arrayOf(PropTypes.string)
-  })).isRequired
+  recommendedOps: PropTypes.shape({
+    basedOnLocation: PropTypes.array,
+    basedOnSkills: PropTypes.array
+  }).isRequired
 }
 
 export default OpRecommendations

--- a/components/Op/__tests__/OpRecommendations.spec.js
+++ b/components/Op/__tests__/OpRecommendations.spec.js
@@ -3,8 +3,6 @@ import test from 'ava'
 import OpRecommendations from '../OpRecommendations'
 import { mountWithIntl } from '../../../lib/react-intl-test-helper'
 const originalWarn = console.warn
-
-const { regions } = require('../../../server/api/location/locationData')
 const ops = require('../../../server/api/opportunity/__tests__/opportunity.fixture')
 
 test.before('before test silence async-validator', () => {
@@ -18,122 +16,24 @@ test.after.always(() => {
   console.warn = originalWarn
 })
 
-const user = {
-  location: 'Auckland'
-}
-
-test('ensure recommendations component renders all matching locations', t => {
-  const wrapper = mountWithIntl(<OpRecommendations locations={regions} me={user} ops={ops} />)
-
-  const matchingRegion = regions.find(r => r.name === user.location)
-  const matchingLocations = [ matchingRegion.name, ...matchingRegion.containedTerritories ]
-  const numberOfMatchingOps = ops.filter(op => matchingLocations.includes(op.location)).length
+test.serial('ensure recommendations component renders all locations when provided', t => {
+  const recommendations = {
+    basedOnSkills: [],
+    basedOnLocation: ops
+  }
+  const wrapper = mountWithIntl(<OpRecommendations recommendedOps={recommendations} />)
 
   const numOpCards = wrapper.find('OpCard').length
-  t.is(numOpCards, numberOfMatchingOps)
+  t.is(numOpCards, ops.length)
 })
 
-test('ensure closest location is shown first', t => {
-  const me = {
-    location: 'North Shore City'
+test.serial('ensure recommendations renders correctly with no matching locations', t => {
+  const recommendations = {
+    basedOnSkills: [],
+    basedOnLocation: []
   }
+  const wrapper = mountWithIntl(<OpRecommendations recommendedOps={recommendations} />)
 
-  const fakeRegions = [
-    {
-      name: 'Auckland',
-      containedTerritories: ['North Shore City', 'Central Auckland', 'West Auckland']
-    }
-  ]
-
-  const fakeOps = [
-    {
-      ...ops[0],
-      location: 'Auckland'
-    },
-    {
-      ...ops[1],
-      location: 'West Auckland'
-    },
-    {
-      ...ops[2],
-      location: 'North Shore City'
-    }
-  ]
-
-  const wrapper = mountWithIntl(<OpRecommendations locations={fakeRegions} me={me} ops={fakeOps} />)
-
-  const opCardProps = wrapper.find('OpCard').first().instance().props
-  // since north shore city is closest to the user, should be shown first
-  t.is(opCardProps.op, fakeOps[2])
-})
-
-test('ensure user without location renders properly', t => {
-  const me = {}
-
-  const fakeRegions = [
-    {
-      name: 'Auckland',
-      containedTerritories: ['North Shore City', 'Central Auckland', 'West Auckland']
-    }
-  ]
-
-  const fakeOps = [
-    {
-      ...ops[0],
-      location: 'Auckland'
-    },
-    {
-      ...ops[1],
-      location: 'West Auckland'
-    },
-    {
-      ...ops[2],
-      location: 'North Shore City'
-    }
-  ]
-
-  const wrapper = mountWithIntl(<OpRecommendations locations={fakeRegions} me={me} ops={fakeOps} />)
-
-  t.is(wrapper.find('OpList').length, 0)
-})
-
-test('ensure user without any matching location renders properly', t => {
-  const me = {
-    location: 'North Shore City'
-  }
-
-  const fakeRegions = [
-    {
-      name: 'Auckland',
-      containedTerritories: ['North Shore City', 'Central Auckland', 'West Auckland']
-    },
-    {
-      name: 'Otago',
-      containedTerritories: [
-        'Central Otago District',
-        'Queenstown-Lakes District',
-        'Dunedin City',
-        'Clutha District'
-      ]
-    }
-  ]
-
-  const fakeOps = [
-    {
-      ...ops[0],
-      location: 'Central Otago District'
-    },
-    {
-      ...ops[1],
-      location: 'Queenstown-Lakes District'
-    },
-    {
-      ...ops[2],
-      location: 'Dunedin City'
-    }
-  ]
-
-  const wrapper = mountWithIntl(<OpRecommendations locations={fakeRegions} me={me} ops={fakeOps} />)
-
-  t.is(wrapper.find('OpList').length, 0)
+  const numOpCards = wrapper.find('OpCard').length
+  t.is(numOpCards, 0)
 })

--- a/lib/redux/reduxApi.js
+++ b/lib/redux/reduxApi.js
@@ -55,6 +55,12 @@ const thisReduxApi = reduxApi({
     options: config.jsonOptions,
     transformer: apiTransformer
   },
+  recommendedOps: {
+    url: '/api/opportunities/recommended',
+    crud: true, // Make CRUD actions: https://github.com/lexich/redux-api/blob/master/docs/DOCS.md#crud
+    options: config.jsonOptions,
+    transformer: apiTransformer
+  },
   activities: {
     url: '/api/activities/:id',
     crud: true, // Make CRUD actions: https://github.com/lexich/redux-api/blob/master/docs/DOCS.md#crud
@@ -146,3 +152,4 @@ export const withPeople = PageComponent => withReduxEndpoints(PageComponent, ['p
 export const withInterests = PageComponent => withReduxEndpoints(PageComponent, ['interests'])
 export const withMembers = PageComponent => withReduxEndpoints(PageComponent, ['members'])
 export const withArchivedOpportunities = PageComponent => withReduxEndpoints(PageComponent, ['archivedOpportunities', 'tags', 'locations'])
+export const withRecommendedOps = PageComponent => withReduxEndpoints(PageComponent, ['recommendedOps'])

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -165,7 +165,6 @@ class PersonHomePage extends Component {
         />
       </span>
     )
-
     return (
       <FullPage>
         <PageHeaderContainer>

--- a/server/api/opportunity/opportunity.routes.js
+++ b/server/api/opportunity/opportunity.routes.js
@@ -2,7 +2,13 @@ const mongooseCrudify = require('mongoose-crudify')
 const helpers = require('../../services/helpers')
 const Opportunity = require('./opportunity')
 const { Action } = require('../../services/abilities/ability.constants')
-const { ensureSanitized, getOpportunities, getOpportunity, putOpportunity } = require('./opportunity.controller')
+const {
+  ensureSanitized,
+  getOpportunities,
+  getOpportunity,
+  putOpportunity,
+  getOpportunityRecommendations
+} = require('./opportunity.controller')
 const { SchemaName, OpportunityRoutes } = require('./opportunity.constants')
 const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
 const initializeTags = require('../../util/initTags')
@@ -24,6 +30,7 @@ const convertRequestToAction = (req) => {
 
 module.exports = (server) => {
   // Docs: https://github.com/ryo718/mongoose-crudify
+  server.get('/api/opportunities/recommended', getOpportunityRecommendations)
   server.use(
     '/api/opportunities',
     mongooseCrudify({


### PR DESCRIPTION
This PR fixes the issue where recommended ops aren't showing when they should. 
The problem was due to the initial redux api call filtering the opportunities to only include those I have requested. So I removed this filter and implemented it in the front-end instead, so that the Recommendations component gets passed all ops