### PR TITLE
Vp 369 big search can t search for nothing

### DIFF
--- a/components/LandingPageComponents/Hero.js
+++ b/components/LandingPageComponents/Hero.js
@@ -226,9 +226,10 @@ const SearchBox = styled.div`
 // end right hand copy and CTA side
 
 const handleSearch = search => {
-  if (!search) {
-    return false
-  }
+  console.log('The search value is ', search)
+  // if (!search) {
+  //   return false
+  // }
   Router.push({
     pathname: '/search',
     query: {

--- a/components/LandingPageComponents/Hero.js
+++ b/components/LandingPageComponents/Hero.js
@@ -226,10 +226,6 @@ const SearchBox = styled.div`
 // end right hand copy and CTA side
 
 const handleSearch = search => {
-  console.log('The search value is ', search)
-  // if (!search) {
-  //   return false
-  // }
   Router.push({
     pathname: '/search',
     query: {

--- a/server/api/location/location.controller.js
+++ b/server/api/location/location.controller.js
@@ -5,7 +5,9 @@ const getLocations = function (req, res) {
     const regionsAndLocations = { regions: regions, locations: sortedLocations }
     res.json(regionsAndLocations)
   } else {
-    res.json(sortedLocations)
+    let returnLocation = sortedLocations.filter(element => element !== 'Online')
+    returnLocation.unshift('Online')
+    res.json(returnLocation)
   }
 }
 


### PR DESCRIPTION
VP 369 : Big search in landing page can not search for empty 
 *  Proposed Changes

- Remove if condition when search button clicked

<h2> Additionan Info. </h2>
<p>1. Also fix location options in op detail form</p>
<p>2. The Online option will be shown first then the rest will be ordered by alphabetical order</p>

This is the first time I follow the template so it takes me longer than usual

