### PR TITLE
VP-422 Rich text information pages for members, joiners and followers

### DIFF
--- a/components/Form/Input/RichTextEditor.js
+++ b/components/Form/Input/RichTextEditor.js
@@ -25,12 +25,13 @@ class RichTextEditor extends React.Component {
       toolbar: toolbarOptions
     }
     const Quill = this.quill
+    // TODO: [VP-450] set initial height of the text edit box to be about 3 lines.
     if (Quill && !isTest) {
       return (
         <div>
           <Quill
             style={{ lineHeight: '21px' }}
-            placeholder='Communicate'
+            // placeholder='Communicate'
             modules={modules}
             defaultValue={this.props.value} onChange={this.props.onChange}
           />

--- a/components/Member/MemberSection.js
+++ b/components/Member/MemberSection.js
@@ -12,6 +12,7 @@ import { MemberStatus } from '../../server/api/member/member.constants'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import Markdown from 'markdown-to-jsx'
 
 const SubSection = styled.section`
   margin-bottom: 2.0rem;
@@ -20,7 +21,7 @@ const SubSection = styled.section`
 class MemberSection extends Component {
   componentDidMount () {
     // Get all members and followers of the organisation
-    const orgid = this.props.orgid
+    const orgid = this.props.org._id
     this.props.dispatch(reduxApi.actions.members.get({ orgid: orgid }))
   }
 
@@ -49,6 +50,7 @@ class MemberSection extends Component {
     if (!this.props.members.sync) {
       return <Loading />
     }
+    const org = this.props.org
     const meid = this.props.me._id
     // check if I am in the members list
     // TODO: [VP-440] members ability I am orgadmin then I get all members list, else I get just my own membership status
@@ -125,11 +127,7 @@ class MemberSection extends Component {
             defaultMessage='Information for new members'
             description='label for follower table on org detail page'
           /></h2>
-          <p>
-            {/* // TODO: [VP-442] org info for joiners in data record and in MemberSection */}
-            Placeholder - information for people joining this organisation.
-            should come from the organisation record.
-          </p>
+          <Markdown children={(org.info && org.info.joiners) || ''} />
         </section>
     }
 
@@ -143,11 +141,7 @@ class MemberSection extends Component {
             defaultMessage='Information for members'
             description='label for org info for members detail page'
           /></h2>
-          <p>
-            {/* // TODO: [VP-443] org info for members in data record and in MemberSection */}
-            Placeholder - information for people belonging to this organisation.
-            should come from the organisation record.
-          </p>
+          <Markdown children={(org.info && org.info.members) || ''} />
         </section>
     }
 
@@ -161,11 +155,7 @@ class MemberSection extends Component {
             defaultMessage='Information for followers'
             description='label for org info for followers detail page'
           /></h2>
-          <p>
-            {/* // TODO: [VP-443] org info for members in data record and in MemberSection */}
-            Placeholder - information for people belonging to this organisation.
-            should come from the organisation record.
-          </p>
+          <Markdown children={(org.info && org.info.followers) || ''} />
         </section>
     }
 
@@ -178,12 +168,7 @@ class MemberSection extends Component {
             defaultMessage='About Joining'
             description='message to non members on the org members tab'
           /></h2>
-
-          <p>
-            {/* // TODO: [VP-444] org info for non members in data record and in MemberSection */}
-            Placeholder - information for people not members of this organisation.
-            should come from the organisation record.
-          </p>
+          <Markdown children={(org.info && org.info.outsiders) || ''} />
         </section>
     }
     return (

--- a/components/Member/MemberSection.js
+++ b/components/Member/MemberSection.js
@@ -52,6 +52,7 @@ class MemberSection extends Component {
     }
     const org = this.props.org
     const meid = this.props.me._id
+    if (!org.info) { org.info = {} }
     // check if I am in the members list
     // TODO: [VP-440] members ability I am orgadmin then I get all members list, else I get just my own membership status
     let myMembership = this.props.members.data.find(m => m.person._id === meid)
@@ -127,7 +128,7 @@ class MemberSection extends Component {
             defaultMessage='Information for new members'
             description='label for follower table on org detail page'
           /></h2>
-          <Markdown children={(org.info && org.info.joiners) || ''} />
+          <Markdown children={org.info.joiners || ''} />
         </section>
     }
 
@@ -141,7 +142,7 @@ class MemberSection extends Component {
             defaultMessage='Information for members'
             description='label for org info for members detail page'
           /></h2>
-          <Markdown children={(org.info && org.info.members) || ''} />
+          <Markdown children={org.info.members || ''} />
         </section>
     }
 
@@ -155,7 +156,7 @@ class MemberSection extends Component {
             defaultMessage='Information for followers'
             description='label for org info for followers detail page'
           /></h2>
-          <Markdown children={(org.info && org.info.followers) || ''} />
+          <Markdown children={org.info.followers || ''} />
         </section>
     }
 
@@ -168,7 +169,7 @@ class MemberSection extends Component {
             defaultMessage='About Joining'
             description='message to non members on the org members tab'
           /></h2>
-          <Markdown children={(org.info && org.info.outsiders) || ''} />
+          <Markdown children={org.info.outsiders || ''} />
         </section>
     }
     return (

--- a/components/Member/__tests__/MemberSection.spec.js
+++ b/components/Member/__tests__/MemberSection.spec.js
@@ -42,14 +42,15 @@ function sleep (ms) {
 
 test.serial('followers can become members and then be removed', async t => {
   const members = t.context.members
-  const orgid = t.context.orgs[4]._id
+  const org = t.context.orgs[4]
+  const orgid = org._id
   const orgMembers = members.filter(member => member.organisation._id === orgid)
 
   t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${orgid}`, orgMembers)
 
   const wrapper = await mountWithIntl(
     <Provider store={t.context.store}>
-      <MemberSection orgid={orgid} />
+      <MemberSection org={org} />
     </Provider>
   )
   await sleep(1) // allow asynch fetch to complete
@@ -121,14 +122,15 @@ test.serial('followers can become members and then be removed', async t => {
 
 test.serial('joiners can become members ', async t => {
   const members = t.context.members
-  const orgid = t.context.orgs[5]._id
+  const org = t.context.orgs[5]
+  const orgid = org._id
   const orgMembers = members.filter(member => member.organisation._id === orgid)
 
   t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${orgid}`, orgMembers)
 
   const wrapper = await mountWithIntl(
     <Provider store={t.context.store}>
-      <MemberSection orgid={orgid} />
+      <MemberSection org={org} />
     </Provider>
   )
   await sleep(1) // allow asynch fetch to complete
@@ -201,14 +203,15 @@ test.serial('joiners can become members ', async t => {
 
 test.serial('members can become admins ', async t => {
   const members = t.context.members
-  const orgid = t.context.orgs[5]._id
+  const org = t.context.orgs[5]
+  const orgid = org._id
   const orgMembers = members.filter(member => member.organisation._id === orgid)
   let trueMembers = orgMembers.filter(member => [MemberStatus.MEMBER].includes(member.status))
   t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${orgid}`, orgMembers)
 
   const wrapper = await mountWithIntl(
     <Provider store={t.context.store}>
-      <MemberSection orgid={orgid} />
+      <MemberSection org={org} />
     </Provider>
   )
   await sleep(1) // allow asynch fetch to complete

--- a/components/Member/__tests__/MemberSectionInfo.spec.js
+++ b/components/Member/__tests__/MemberSectionInfo.spec.js
@@ -1,0 +1,193 @@
+/*
+  Additional tests for MemberSection that validate the page for different types of member
+*/
+import React from 'react'
+import test from 'ava'
+import { mountWithIntl } from '../../../lib/react-intl-test-helper'
+import MemberSection from '../MemberSection'
+import { Provider } from 'react-redux'
+import reduxApi, { makeStore } from '../../../lib/redux/reduxApi'
+import adapterFetch from 'redux-api/lib/adapters/fetch'
+import { API_URL } from '../../../lib/apiCaller'
+import fixture from './member.fixture.js'
+import { MemberStatus } from '../../../server/api/member/member.constants'
+import objectid from 'objectid'
+
+const { fetchMock } = require('fetch-mock')
+
+test.before('Setup fixtures', t => {
+  fixture(t)
+  const initStore = {
+    members: {
+      loading: false,
+      data: [ ]
+    },
+    session: {
+      me: t.context.people[1]
+    }
+  }
+  t.context.store = makeStore(initStore)
+  t.context.fetchMock = fetchMock.sandbox()
+  t.context.fetchMock.config.overwriteRoutes = false
+  reduxApi.use('fetch', adapterFetch(t.context.fetchMock))
+
+  t.context.orgMembers = (status, who) => [
+    {
+      _id: objectid().toString(),
+      person: t.context.people[who],
+      organisation: t.context.orgs[0],
+      status
+    }
+  ]
+})
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+test.serial('What instructions non members see', async t => {
+  const org = t.context.orgs[0]
+  const orgid = org._id
+  // this org has no members
+  t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${orgid}`, [])
+
+  const wrapper = await mountWithIntl(
+    <Provider store={t.context.store}>
+      <MemberSection org={org} />
+    </Provider>
+  )
+  await sleep(1) // allow asynch fetch to complete
+  wrapper.update()
+  let membersSection = wrapper.find('section').first()
+  t.regex(membersSection.find('h2').first().text(), /About Joining/)
+  t.is(membersSection.find('span').at(1).text(), org.info.outsiders)
+  t.truthy(t.context.fetchMock.done())
+  t.context.fetchMock.restore()
+})
+
+test.serial('What instructions followers see', async t => {
+  const org = t.context.orgs[0]
+  t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${org._id}`, t.context.orgMembers(MemberStatus.FOLLOWER, 1))
+
+  const wrapper = await mountWithIntl(
+    <Provider store={t.context.store}>
+      <MemberSection org={org} />
+    </Provider>
+  )
+  await sleep(1) // allow asynch fetch to complete
+  wrapper.update()
+  let membersSection = wrapper.find('section').first()
+  t.regex(membersSection.find('h2').first().text(), /Information for followers/)
+  t.is(membersSection.find('span').at(1).text(), org.info.followers)
+  t.truthy(t.context.fetchMock.done())
+  t.context.fetchMock.restore()
+})
+
+test.serial('What instructions joiners see', async t => {
+  const org = t.context.orgs[0]
+  t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${org._id}`, t.context.orgMembers(MemberStatus.JOINER, 1))
+
+  const wrapper = await mountWithIntl(
+    <Provider store={t.context.store}>
+      <MemberSection org={org} />
+    </Provider>
+  )
+  await sleep(1) // allow asynch fetch to complete
+  wrapper.update()
+  let membersSection = wrapper.find('section').first()
+  t.regex(membersSection.find('h2').first().text(), /Information for new members/)
+  t.is(membersSection.find('span').at(1).text(), org.info.joiners)
+  t.truthy(t.context.fetchMock.done())
+  t.context.fetchMock.restore()
+})
+
+test.serial('What instructions validators see', async t => {
+  const org = t.context.orgs[0]
+  t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${org._id}`, t.context.orgMembers(MemberStatus.VALIDATOR, 1))
+
+  const wrapper = await mountWithIntl(
+    <Provider store={t.context.store}>
+      <MemberSection org={org} />
+    </Provider>
+  )
+  await sleep(1) // allow asynch fetch to complete
+  wrapper.update()
+  let membersSection = wrapper.find('section').first()
+  t.regex(membersSection.find('h2').first().text(), /Information for new members/)
+  t.is(membersSection.find('span').at(1).text(), org.info.joiners)
+  t.truthy(t.context.fetchMock.done())
+  t.context.fetchMock.restore()
+})
+
+test.serial('What instructions members see', async t => {
+  const org = t.context.orgs[0]
+  t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${org._id}`, t.context.orgMembers(MemberStatus.MEMBER, 1))
+
+  const wrapper = await mountWithIntl(
+    <Provider store={t.context.store}>
+      <MemberSection org={org} />
+    </Provider>
+  )
+  await sleep(1) // allow asynch fetch to complete
+  wrapper.update()
+  let membersSection = wrapper.find('section').first()
+  t.regex(membersSection.find('h2').first().text(), /Information for members/)
+  t.is(membersSection.find('span').at(1).text(), org.info.members)
+  t.truthy(t.context.fetchMock.done())
+  t.context.fetchMock.restore()
+})
+
+test.serial('What instructions non members see when no info', async t => {
+  const org = t.context.orgs[0]
+  const orgid = org._id
+  delete (org.info)
+
+  // this org has no members
+  t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${orgid}`, [])
+
+  const wrapper = await mountWithIntl(
+    <Provider store={t.context.store}>
+      <MemberSection org={org} />
+    </Provider>
+  )
+  await sleep(1) // allow asynch fetch to complete
+  wrapper.update()
+  let membersSection = wrapper.find('section').first()
+  t.regex(membersSection.find('h2').first().text(), /About Joining/)
+  t.is(membersSection.find('span').at(1).text(), '')
+  t.truthy(t.context.fetchMock.done())
+  t.context.fetchMock.restore()
+})
+const testNoInfo = async (t, status) => {
+  const org = t.context.orgs[0]
+  delete (org.info)
+  t.context.fetchMock.getOnce(`${API_URL}/members/?orgid=${org._id}`, t.context.orgMembers(status, 1))
+
+  const wrapper = await mountWithIntl(
+    <Provider store={t.context.store}>
+      <MemberSection org={org} />
+    </Provider>
+  )
+  await sleep(1) // allow asynch fetch to complete
+  wrapper.update()
+  t.truthy(t.context.fetchMock.done())
+  t.context.fetchMock.restore()
+  return wrapper
+}
+
+test.serial('When info is not set Follower', async t => {
+  const wrapper = await testNoInfo(t, MemberStatus.FOLLOWER)
+  t.is(wrapper.find('section').first().find('span').at(1).text(), '')
+})
+test.serial('When info is not set Joiner', async t => {
+  const wrapper = await testNoInfo(t, MemberStatus.JOINER)
+  t.is(wrapper.find('section').first().find('span').at(1).text(), '')
+})
+test.serial('When info is not set Member', async t => {
+  const wrapper = await testNoInfo(t, MemberStatus.MEMBER)
+  t.is(wrapper.find('section').first().find('span').at(1).text(), '')
+})
+test.serial('When info is not set Outsider', async t => {
+  const wrapper = await testNoInfo(t, MemberStatus.MEMBER)
+  t.is(wrapper.find('section').first().find('span').at(1).text(), '')
+})

--- a/components/Org/OrgCard.js
+++ b/components/Org/OrgCard.js
@@ -12,8 +12,6 @@ const OrgCard = ({ org, ...props }) => (
           <img className='requestImg' src={org.imgUrl} />
           <p className='requestTitle'>{org.name}</p>
           <OrgCategory orgCategory={org.category} />
-          {/* <p className='requestDateTime'>{org.category}</p> */}
-          {/* <p className='requestDescription'>{org.about}</p> */}
         </div>
       </a>
     </Link>
@@ -94,7 +92,6 @@ const OrgCard = ({ org, ...props }) => (
 OrgCard.propTypes = {
   org: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    about: PropTypes.string.isRequired,
     imgUrl: PropTypes.string.isRequired,
     category: PropTypes.arrayOf(
       PropTypes.oneOf(['admin', 'op', 'vp', 'ap', 'other'])

--- a/components/Org/OrgDetail.js
+++ b/components/Org/OrgDetail.js
@@ -111,12 +111,12 @@ const OrgDetail = ({ org, ...props }) => (
         <Tabs style={shadowStyle} defaultActiveKey='1' onChange={callback}>
           <TabPane tab={orgTab} key='1'>
             <SpacerSmall />
-            <Markdown children={org.about || ''} />
+            <Markdown children={(org.info && org.info.about) || ''} />
           </TabPane>
           {/* <TabPane tab={orgResourcesTab} key='2' /> */}
           {/* <TabPane tab={orgInstructionTab} key='3' /> */}
           <TabPane tab={orgMemberTab} key='4'>
-            <MemberSection orgid={org._id} />
+            <MemberSection org={org} />
           </TabPane>
 
         </Tabs>
@@ -129,7 +129,13 @@ OrgDetail.propTypes = {
   meid: PropTypes.string.isRequired,
   org: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    about: PropTypes.string.isRequired,
+    info: PropTypes.shape({
+      about: PropTypes.string.isRequired,
+      followers: PropTypes.string,
+      joiners: PropTypes.string,
+      members: PropTypes.string,
+      outsiders: PropTypes.string
+    }),
     category: PropTypes.arrayOf(
       PropTypes.oneOf(['admin', 'op', 'vp', 'ap', 'other'])
     ).isRequired,

--- a/components/Org/OrgDetailForm.js
+++ b/components/Org/OrgDetailForm.js
@@ -44,7 +44,11 @@ class OrgDetailForm extends Component {
         // update the rest from the form values.
         org.name = values.name
         org.slug = slug(values.name)
-        org.about = values.about
+        org.info.about = values.about
+        org.info.followers = values.followers
+        org.info.joiners = values.joiners
+        org.info.members = values.members
+        org.info.outsiders = values.outsiders
         org.imgUrl = values.imgUrl
         org.website = values.website
         org.contactEmail = values.contactEmail
@@ -57,11 +61,16 @@ class OrgDetailForm extends Component {
   render () {
     // get translated labels
     const orgName = <FormattedMessage id='orgName' defaultMessage='Title' about='organisation Title label in OrgDetails Form' />
-    const orgAbout = <FormattedMessage id='orgAbout' defaultMessage='About' about='organisation Description label in OrgDetails Form' />
     const orgImgUrl = <FormattedMessage id='orgImgUrl' defaultMessage='Image Link' about='organisation Image URL label in OrgDetails Form' />
     const orgWebsite = <FormattedMessage id='orgWebsite' defaultMessage='Website' about='website label in OrgDetails Form' />
     const orgContactEmail = <FormattedMessage id='orgContactEmail' defaultMessage='Contact Email' about='contact Email label in OrgDetails Form' />
     const orgCategory = <FormattedMessage id='orgCategory' defaultMessage='Category' about='school, business or activity provider' />
+
+    const orgAbout = <FormattedMessage id='orgAbout' defaultMessage='About' about='organisation Description label in OrgDetails Form' />
+    const orgInfoFollowers = <FormattedMessage id='orgInfoFollowers' defaultMessage='Followers' about='organisation Description label in OrgDetails Form' />
+    const orgInfoJoiners = <FormattedMessage id='orgInfoJoiners' defaultMessage='Joiners' about='organisation Description label in OrgDetails Form' />
+    const orgInfoMembers = <FormattedMessage id='orgInfoMembers' defaultMessage='Members' about='organisation Description label in OrgDetails Form' />
+    const orgInfoOutsiders = <FormattedMessage id='orgInfoOutsiders' defaultMessage='Outsiders' about='organisation Description label in OrgDetails Form' />
 
     // TODO translate
     const categoryOptions = [
@@ -162,6 +171,46 @@ class OrgDetailForm extends Component {
               />
             )}
           </Form.Item>
+          <Form.Item label={orgInfoFollowers}>
+            {getFieldDecorator('followers', {
+              rules: [
+
+              ]
+            })(
+              // <TextArea rows={20} placeholder='Tell us about your organisation. You can use markdown here. and include links' />
+              <RichTextEditor onChange={this.setInfoFollowers} />
+            )}
+          </Form.Item>
+          <Form.Item label={orgInfoJoiners}>
+            {getFieldDecorator('joiners', {
+              rules: [
+
+              ]
+            })(
+              // <TextArea rows={20} placeholder='Tell us about your organisation. You can use markdown here. and include links' />
+              <RichTextEditor onChange={this.setInfoJoiners} />
+            )}
+          </Form.Item>
+          <Form.Item label={orgInfoMembers}>
+            {getFieldDecorator('members', {
+              rules: [
+
+              ]
+            })(
+              // <TextArea rows={20} placeholder='Tell us about your organisation. You can use markdown here. and include links' />
+              <RichTextEditor onChange={this.setInfoMembers} />
+            )}
+          </Form.Item>
+          <Form.Item label={orgInfoOutsiders}>
+            {getFieldDecorator('outsiders', {
+              rules: [
+
+              ]
+            })(
+              // <TextArea rows={20} placeholder='Tell us about your organisation. You can use markdown here. and include links' />
+              <RichTextEditor onChange={this.setInfoOutsiders} />
+            )}
+          </Form.Item>
           <Button
             type='secondary'
             htmlType='button'
@@ -197,7 +246,13 @@ class OrgDetailForm extends Component {
 OrgDetailForm.propTypes = {
   org: PropTypes.shape({
     name: PropTypes.string,
-    about: PropTypes.string,
+    info: PropTypes.shape({
+      about: PropTypes.string.isRequired,
+      followers: PropTypes.string,
+      joiners: PropTypes.string,
+      members: PropTypes.string,
+      outsiders: PropTypes.string
+    }),
     category: PropTypes.arrayOf(PropTypes.oneOf(['admin', 'op', 'vp', 'ap', 'other'])),
     imgUrl: PropTypes.string,
     website: PropTypes.string,
@@ -222,15 +277,21 @@ export default Form.create({
     // props.onChange(changedFields);
   },
   mapPropsToFields (props) {
+    const org = props.org
+    if (!org.info) { org.info = {} }
     return {
-      name: Form.createFormField({ ...props.org.name, value: props.org.name }),
-      about: Form.createFormField({ ...props.org.about, value: props.org.about }),
-      imgUrl: Form.createFormField({ ...props.org.imgUrl, value: props.org.imgUrl }),
-      website: Form.createFormField({ ...props.org.website, value: props.org.website }),
-      contactEmail: Form.createFormField({ ...props.org.contactEmail, value: props.org.contactEmail }),
-      facebook: Form.createFormField({ ...props.org.facebook, value: props.org.facebook }),
-      twitter: Form.createFormField({ ...props.org.twitter, value: props.org.twitter }),
-      category: Form.createFormField({ ...props.org.category, value: props.org.category })
+      name: Form.createFormField({ ...org.name, value: org.name }),
+      about: Form.createFormField({ ...org.info.about, value: org.info.about }),
+      followers: Form.createFormField({ ...org.info.followers, value: org.info.followers }),
+      joiners: Form.createFormField({ ...org.info.joiners, value: org.info.joiners }),
+      members: Form.createFormField({ ...org.info.members, value: org.info.members }),
+      outsiders: Form.createFormField({ ...org.info.outsiders, value: org.info.outsiders }),
+      imgUrl: Form.createFormField({ ...org.imgUrl, value: org.imgUrl }),
+      website: Form.createFormField({ ...org.website, value: org.website }),
+      contactEmail: Form.createFormField({ ...org.contactEmail, value: org.contactEmail }),
+      facebook: Form.createFormField({ ...org.facebook, value: org.facebook }),
+      twitter: Form.createFormField({ ...org.twitter, value: org.twitter }),
+      category: Form.createFormField({ ...org.category, value: org.category })
     }
   },
   onValuesChange (_, values) {

--- a/pages/org/orglistpage.js
+++ b/pages/org/orglistpage.js
@@ -11,6 +11,7 @@ class OrgListPage extends Component {
   static async getInitialProps ({ store, query }) {
     // Get all OrgListPage
     try {
+      // TODO: [VP-451] Minimise org list download by only getting OrgCard required information using select.
       await store.dispatch(reduxApi.actions.organisations.get())
     } catch (err) {
       console.log('error in getting orgs', err)

--- a/server/api/organisation/__tests__/organisation.fixture.js
+++ b/server/api/organisation/__tests__/organisation.fixture.js
@@ -1,14 +1,14 @@
 const orgList = [
   {
-    name: 'Voluntari.ly Administrators',
+    name: 'Voluntarily Administrators',
     slug: 'vly-admin',
     category: ['admin'],
     info: {
-      about: '<h1><strong>Industry in the classroom.</strong></h1><p>We are building a platform that connects corporate volunteer time with classrooms to teach science, technology, engineering, entrepreneurship, arts and design with the help of engaging content supplied by New Zealand’s leading innovators in educational content.</p><p><br></p><p>Super</p>',
-      members: '<h1><strong>You are a member of Voluntarily. </strong></h1>',
-      followers: '<h1><strong>You are a follower of Voluntarily. </strong></h1><p><br></p>',
-      joiners: '<h1><strong>You are a nearly a member of Voluntarily. </strong></h1><p><br></p>',
-      outsiders: '<h1><strong>You could be a member of Voluntarily. </strong></h1><p><br></p>'
+      about: 'Industry in the classroom.',
+      members: 'You are a member of Voluntarily.',
+      followers: 'You are a follower of Voluntarily.',
+      joiners: 'You are a nearly a member of Voluntarily.',
+      outsiders: 'You could be a member of Voluntarily.'
     }
   },
   {

--- a/server/api/organisation/__tests__/organisation.fixture.js
+++ b/server/api/organisation/__tests__/organisation.fixture.js
@@ -3,38 +3,45 @@ const orgList = [
     name: 'Voluntari.ly Administrators',
     slug: 'vly-admin',
     category: ['admin'],
-    about: "Voluntari.ly Administrators have special powers. Contact us to get things done that can't be done any other way"
-
+    info: {
+      about: '<h1><strong>Industry in the classroom.</strong></h1><p>We are building a platform that connects corporate volunteer time with classrooms to teach science, technology, engineering, entrepreneurship, arts and design with the help of engaging content supplied by New Zealand’s leading innovators in educational content.</p><p><br></p><p>Super</p>',
+      members: '<h1><strong>You are a member of Voluntarily. </strong></h1>',
+      followers: '<h1><strong>You are a follower of Voluntarily. </strong></h1><p><br></p>',
+      joiners: '<h1><strong>You are a nearly a member of Voluntarily. </strong></h1><p><br></p>',
+      outsiders: '<h1><strong>You could be a member of Voluntarily. </strong></h1><p><br></p>'
+    }
   },
   {
     name: 'OMGTech',
     slug: 'omgtech',
     category: ['ap', 'vp'],
-    about: 'Awesome content providers'
+    info: {
+      about: 'Awesome content providers'
+    }
   },
   {
     name: 'Datacom',
     slug: 'datacom',
     category: ['vp'],
-    about: 'some of our most loyal helpers'
+    info: { about: 'some of our most loyal helpers' }
   },
   {
     name: 'Spark Ltd',
     slug: 'spark',
     category: ['vp'],
-    about: 'more of our most loyal helpers'
+    info: { about: 'more of our most loyal helpers' }
   },
   {
     name: 'Westpac Ltd',
     slug: 'westpac',
     category: ['vp'],
-    about: 'even more of our most loyal helpers'
+    info: { about: 'even more of our most loyal helpers' }
   },
   {
     name: 'Albany High School',
     slug: 'albany-high',
     category: ['op'],
-    about: 'A great place to learn'
+    info: { about: 'A great place to learn' }
   }
 ]
 

--- a/server/api/organisation/organisation.js
+++ b/server/api/organisation/organisation.js
@@ -18,6 +18,13 @@ const organisationSchema = new Schema({
     default: ['vp'],
     enum: ['admin', 'vp', 'op', 'ap', 'other']
   },
+  info: {
+    about: String,
+    followers: String,
+    joiners: String,
+    members: String,
+    outsiders: String
+  },
   dateAdded: { type: 'Date', default: Date.now, required: true }
 })
 


### PR DESCRIPTION
## Proposed changes
When viewing an organisation page the person sees two tabs. An About tab containing general information for the public and a members tab containing information for followers and members.

Depending on the state of membership the person sees different information pages.  These fields are added to the organisation object in the info object.  

OpDetails display and OpDetailsForm updated to collect and show the content.  Most work done by MemberSection

## Test coverage
Extensive tests required so that each membership relationship sees the right content. 

## Addition Notes
The original about field has been moved to an object 'info' that contains fields for about, joiners, followers etc.  This means that existing database records will need to be updated and the old about field deleted. (easiest at this point to recreate the organisation).

