### PR TITLE
VP-321 add skills to profiles

### DIFF
--- a/components/Person/PersonDetail.js
+++ b/components/Person/PersonDetail.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import PersonRoles from './PersonRole'
+import TagDisplay from '../Tags/TagDisplay'
 import { FormattedMessage } from 'react-intl'
 import MemberUl from '../Member/MemberUl'
 import {
@@ -120,6 +121,12 @@ const PersonDetail = ({ person }, ...props) => (
             <Icon type='compass' /> {person.location}
           </a>
         </TextPBold>
+        <TextPBold>
+          <a>
+            <Icon type='tags' />
+          </a>
+        </TextPBold>
+        <TagDisplay tags={person.tags} />
       </ListItem>
       <DetailItemMobile>
         <p>        <Icon type='history' /> 312 ops completed</p>
@@ -164,7 +171,13 @@ PersonDetail.propTypes = {
         'tester'
       ])
     ),
-    status: PropTypes.oneOf(['active', 'inactive', 'hold'])
+    status: PropTypes.oneOf(['active', 'inactive', 'hold']),
+    tags: PropTypes.arrayOf(
+      PropTypes.shape({
+        tag: PropTypes.string.isRequired,
+        _id: PropTypes.string
+      })
+    )
   }).isRequired
 }
 

--- a/components/Person/PersonDetailForm.js
+++ b/components/Person/PersonDetailForm.js
@@ -14,6 +14,7 @@ import {
 } from '../VTheme/FormStyles'
 import PageTitle from '../../components/LandingPageComponents/PageTitle.js'
 import LocationSelector from '../Form/Input/LocationSelector'
+import TagInput from '../Form/Input/TagInput'
 
 const { TextArea } = Input
 
@@ -52,6 +53,7 @@ class PersonDetailForm extends Component {
         person.pronoun = values.pronoun
         person.about = values.about
         person.location = values.location
+        person.tags = values.tags
         person.avatar = values.avatar
         person.role = values.role
         person.status = values.status
@@ -142,6 +144,14 @@ class PersonDetailForm extends Component {
       </span>
     )
 
+    const personTags = (
+      <FormattedMessage
+        id='personTags'
+        defaultMessage='Tags'
+        description='Descriptions of general areas the person has skills in'
+      />
+    )
+
     const {
       getFieldDecorator,
       getFieldsError,
@@ -223,6 +233,34 @@ class PersonDetailForm extends Component {
                 })(
                   <LocationSelector
                     existingLocations={this.props.locations}
+                  />
+                )}
+              </Form.Item>
+            </InputContainer>
+          </FormGrid>
+          <Divider />
+
+          <FormGrid>
+            <DescriptionContainer>
+              <TitleContainer>
+                <TextHeadingBold>
+                  Do you have any specific skills? (optional)
+                </TextHeadingBold>
+              </TitleContainer>
+              <TextP>
+                Do you have skills in any specific categories
+                like programming, electronics, or robots? Enter them here to
+                make it easier for us to recommend suitable opportunities for you.
+              </TextP>
+            </DescriptionContainer>
+            <InputContainer>
+              <Form.Item label={personTags}>
+                {getFieldDecorator('tags', {
+                  initialValue: [],
+                  rules: []
+                })(
+                  <TagInput
+                    existingTags={this.props.existingTags}
                   />
                 )}
               </Form.Item>
@@ -369,7 +407,11 @@ PersonDetailForm.propTypes = {
   }),
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  locations: PropTypes.arrayOf(PropTypes.string)
+  locations: PropTypes.arrayOf(PropTypes.string),
+  existingTags: PropTypes.arrayOf(PropTypes.shape({
+    tag: PropTypes.string.isRequired,
+    _id: PropTypes.string
+  })).isRequired
   // dispatch: PropTypes.func.isRequired,
 }
 
@@ -420,6 +462,10 @@ export default Form.create({
       status: Form.createFormField({
         ...props.person.status,
         value: props.person.status
+      }),
+      tags: Form.createFormField({
+        ...props.person.tags,
+        value: props.person.tags
       })
     }
   },

--- a/components/Person/__tests__/PersonDetailForm.spec.js
+++ b/components/Person/__tests__/PersonDetailForm.spec.js
@@ -3,6 +3,7 @@ import test from 'ava'
 // import { JSDOM } from 'jsdom'
 import { mountWithIntl, shallowWithIntl } from '../../../lib/react-intl-test-helper'
 import objectid from 'objectid'
+import tagList from '../../../server/api/tag/__tests__/tag.fixture'
 
 import PersonDetailForm from '../PersonDetailForm'
 import sinon from 'sinon'
@@ -37,7 +38,7 @@ test.after.always(() => {
 
 test('shallow the detail with person', t => {
   const wrapper = shallowWithIntl(
-    <PersonDetailForm person={t.context.me} locations={sortedLocations} onSubmit={() => {}} onCancel={() => {}} />
+    <PersonDetailForm person={t.context.me} existingTags={tagList} locations={sortedLocations} onSubmit={() => {}} onCancel={() => {}} />
   )
   t.is(wrapper.find('PersonDetailForm').length, 1)
 })
@@ -47,7 +48,7 @@ test('render the detail with op', t => {
   const cancelOp = sinon.spy()
 
   const wrapper = mountWithIntl(
-    <PersonDetailForm person={t.context.me} locations={sortedLocations} onSubmit={submitOp} onCancel={cancelOp} />
+    <PersonDetailForm person={t.context.me} existingTags={tagList} locations={sortedLocations} onSubmit={submitOp} onCancel={cancelOp} />
   )
   t.log(wrapper)
   // console.log(wrapper.html())
@@ -55,6 +56,7 @@ test('render the detail with op', t => {
   locationInput.props().onChange('Auckland')
 
   t.is(wrapper.find('PersonDetailForm').length, 1)
+  t.is(wrapper.find('TagInput').length, 1)
   t.is(wrapper.find('button').length, 2)
   wrapper.find('button').first().simulate('click')
   t.truthy(cancelOp.calledOnce)

--- a/lib/redux/reduxApi.js
+++ b/lib/redux/reduxApi.js
@@ -144,7 +144,7 @@ export const withOrgs = PageComponent => withReduxEndpoints(PageComponent, ['org
 export const withActs = PageComponent => withReduxEndpoints(PageComponent, ['activities', 'tags'])
 export const withOps = PageComponent => withReduxEndpoints(PageComponent, ['opportunities', 'tags', 'locations'])
 export const withLocations = PageComponent => withReduxEndpoints(PageComponent, ['locations'])
-export const withPeople = PageComponent => withReduxEndpoints(PageComponent, ['people'])
+export const withPeople = PageComponent => withReduxEndpoints(PageComponent, ['people', 'tags'])
 export const withInterests = PageComponent => withReduxEndpoints(PageComponent, ['interests'])
 export const withMembers = PageComponent => withReduxEndpoints(PageComponent, ['members'])
 export const withArchivedOpportunities = PageComponent => withReduxEndpoints(PageComponent, ['archivedOpportunities', 'tags', 'locations'])

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -90,6 +90,8 @@ class PersonHomePage extends Component {
         // s: date
       }
 
+      await store.dispatch(reduxApi.actions.tags.get())
+
       await Promise.all([
         store.dispatch(reduxApi.actions.opportunities.get(filters)),
         store.dispatch(reduxApi.actions.locations.get({ withRelationships: true })),
@@ -259,6 +261,7 @@ class PersonHomePage extends Component {
               {this.state.editProfile ? (
                 <PersonDetailForm
                   person={this.props.me}
+                  existingTags={this.props.tags.data}
                   locations={this.props.locations.data[0].locations}
                   onSubmit={this.handleUpdate.bind(this, this.props.me)}
                   onCancel={this.handleCancel}

--- a/server/api/person/__tests__/person.fixture.js
+++ b/server/api/person/__tests__/person.fixture.js
@@ -12,7 +12,8 @@ const people = [
     ],
     'status': 'active',
     'avatar': 'https://avatars2.githubusercontent.com/u/1596437?v=4',
-    'phone': '+64 027 7031007'
+    'phone': '+64 027 7031007',
+    'tags': []
   },
   {
     'nickname': 'Dali',
@@ -28,7 +29,8 @@ const people = [
     'name': 'Salvador Domingo Felipe Jacinto Dalí i Domènech, 1st Marquis of Dalí de Púbol ',
     'email': 'salvador@voluntari.ly',
     'phone': '000 000 0000',
-    'avatar': 'https://uploads5.wikiart.org/images/salvador-dali.jpg!Portrait.jpg'
+    'avatar': 'https://uploads5.wikiart.org/images/salvador-dali.jpg!Portrait.jpg',
+    'tags': []
   },
   {
     'name': 'Testy A McTestface',
@@ -40,7 +42,8 @@ const people = [
     'gender': 'male',
     'avatar': 'https://blogcdn1.secureserver.net/wp-content/uploads/2014/06/create-a-gravatar-beard.png',
     'role': ['tester', 'volunteer'],
-    'status': 'active'
+    'status': 'active',
+    'tags': []
   },
   {
     'name': 'Testy B McTestface',
@@ -52,7 +55,8 @@ const people = [
     'gender': 'female',
     'avatar': 'https://blogcdn1.secureserver.net/wp-content/uploads/2014/06/create-a-gravatar-beard.png',
     'role': ['tester', 'volunteer'],
-    'status': 'active'
+    'status': 'active',
+    'tags': []
   },
   {
     'name': 'Testy C McTestface',
@@ -64,7 +68,8 @@ const people = [
     'gender': 'non binary',
     'avatar': 'https://blogcdn1.secureserver.net/wp-content/uploads/2014/06/create-a-gravatar-beard.png',
     'role': ['tester', 'volunteer'],
-    'status': 'active'
+    'status': 'active',
+    'tags': []
   },
   {
     'name': 'Testy D McTestface',
@@ -76,7 +81,8 @@ const people = [
     'gender': 'robot',
     'avatar': 'https://blogcdn1.secureserver.net/wp-content/uploads/2014/06/create-a-gravatar-beard.png',
     'role': ['tester', 'volunteer'],
-    'status': 'active'
+    'status': 'active',
+    'tags': []
   },
   {
     'name': 'Testy E McTestface',
@@ -88,7 +94,8 @@ const people = [
     'gender': 'tester',
     'avatar': 'https://blogcdn1.secureserver.net/wp-content/uploads/2014/06/create-a-gravatar-beard.png',
     'role': ['tester', 'volunteer'],
-    'status': 'active'
+    'status': 'active',
+    'tags': []
   },
   {
     'name': 'Testy F McTestface',
@@ -100,7 +107,8 @@ const people = [
     'gender': 'Tane',
     'avatar': 'https://blogcdn1.secureserver.net/wp-content/uploads/2014/06/create-a-gravatar-beard.png',
     'role': ['tester', 'volunteer'],
-    'status': 'active'
+    'status': 'active',
+    'tags': []
   }
 ]
 

--- a/server/api/person/__tests__/person.spec.js
+++ b/server/api/person/__tests__/person.spec.js
@@ -56,7 +56,8 @@ test.failing('Should send correct data when queried against an id', async t => {
     nickname: 'Testy',
     phone: '123 456789',
     email: 'query@omgtech.co.nz',
-    role: ['tester']
+    role: ['tester'],
+    tags: []
   }
 
   const person = new Person(p)
@@ -80,7 +81,8 @@ test.serial('Should correctly add a person', async t => {
     phone: '123 456789',
     email: 'addy@omgtech.co.nz',
     gender: 'binary',
-    role: ['tester']
+    role: ['tester'],
+    tags: []
   }
 
   const res = await request(server)
@@ -117,7 +119,8 @@ test.serial('Should correctly add a person and sanitise inputs', async t => {
     phone: "1234<img src=x onerror=alert('img') />ABCD", // should remove img
     email: 'bobby@omgtech.co.nz', // ok
     gender: "console.log('hello world')", // ok
-    role: ['tester']
+    role: ['tester'],
+    tags: []
   }
 
   await request(server)
@@ -138,7 +141,8 @@ test.serial('Should load a person into the db but block access and delete them v
     phone: '123 456789',
     email: 'loady@omgtech.co.nz',
     gender: 'binary',
-    role: ['tester']
+    role: ['tester'],
+    tags: []
   }
   const person = new Person(p)
   await person.save()
@@ -171,7 +175,8 @@ test.serial('Should find a person by email', async t => {
     nickname: 'Testy',
     phone: '123 456789',
     email: 'unique_email@voluntari.ly',
-    role: ['tester']
+    role: ['tester'],
+    tags: []
   }
 
   const person = new Person(p)
@@ -194,7 +199,8 @@ test.serial('Should find a person by nickname', async t => {
     nickname: 'Testy',
     phone: '123 456789',
     email: 'Testy555@voluntari.ly',
-    role: ['tester']
+    role: ['tester'],
+    tags: []
   }
 
   const person = new Person(p)
@@ -223,7 +229,8 @@ test.serial('Should correctly handle missing inputs', async t => {
     nickname: 'Testy',
     phone: '123 456789',
     // email: 'Testy555@voluntari.ly', <- explicity remove email
-    role: ['tester']
+    role: ['tester'],
+    tags: []
   }
   try {
     const res = await request(server)

--- a/server/api/person/person.controller.js
+++ b/server/api/person/person.controller.js
@@ -9,7 +9,7 @@ const Action = require('../../services/abilities/ability.constants')
  */
 function getPersonBy (req, res) {
   const query = { [req.params.by]: req.params.value }
-  Person.findOne(query).exec((_err, got) => {
+  Person.findOne(query).populate('tags').exec((_err, got) => {
     if (!got) { // person does not exist
       return res.status(404).send({ error: 'person not found' })
     }

--- a/server/api/person/person.js
+++ b/server/api/person/person.js
@@ -29,7 +29,12 @@ const personSchema = new Schema({
     default: 'active',
     enum: ['active', 'inactive', 'hold']
   },
-  dateAdded: { type: 'Date', default: Date.now, required: true }
+  dateAdded: { type: 'Date', default: Date.now, required: true },
+  tags: [
+    {
+      type: Schema.Types.ObjectId, ref: 'Tag'
+    }
+  ]
 })
 
 personSchema.plugin(idvalidator)

--- a/server/api/person/person.routes.js
+++ b/server/api/person/person.routes.js
@@ -6,6 +6,7 @@ const { ensureSanitized, getPersonBy, updatePersonDetail } = require('./person.c
 const { SchemaName } = require('./person.constants')
 const removeUnauthorizedFields = require('../../services/authorize/removeUnauthorizedFields')
 const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
+const initializeTags = require('../../util/initTags')
 
 module.exports = function (server) {
   // Docs: https://github.com/ryo718/mongoose-crudify
@@ -15,10 +16,17 @@ module.exports = function (server) {
       Model: Person,
       selectFields: '-__v', // Hide '__v' property
       endResponseInAction: false,
+      beforeActions: [
+        { middlewares: [ authorizeActions(SchemaName), ensureSanitized ]
+        }, {
+          middlewares: [initializeTags],
+          only: ['create', 'update']
+        }],
       actions: {
+        list: getPersonBy,
+        read: getPersonBy,
         update: updatePersonDetail
       },
-      beforeActions: [{ middlewares: [ authorizeActions(SchemaName), ensureSanitized ] }],
       // actions: {}, // list (GET), create (POST), read (GET), update (PUT), delete (DELETE)
       afterActions: [{ middlewares: [ removeUnauthorizedFields(Person), helpers.formatResponse ] }]
     })


### PR DESCRIPTION
## Proposed Changes?
When editing their profile, a user (volunteer) can optionally add skills they think they are particularly great in. 

By going to .../home, and clicking on the profile tab and subsequent edit button, a user should now be able to input and save skills they believe they are proficient in.

This information will be used in the future, to recommend relevant opportunities to them, based on these skills.

<h2>Screenshots</h2>
<img width="1065" alt="Screen Shot 2019-08-15 at 11 41 11 AM" src="https://user-images.githubusercontent.com/31422519/63063669-aac7fc80-bf51-11e9-8bfd-32046fef8793.png">
<img width="849" alt="Screen Shot 2019-08-15 at 11 41 59 AM" src="https://user-images.githubusercontent.com/31422519/63063686-ba474580-bf51-11e9-9f79-55f98b41f17d.png">

## Test Coverage
Edits have been made to tests around Person/PersonDetailForm/PersonDetail etc., to factor in new attribute. Most of the testing of the component itself (TagInput/TagDisplay) has already been done in previous PRs.

## Cute gif
![](https://media.giphy.com/media/3oKIPnAiaMCws8nOsE/giphy.gif)
