### PR TITLE
VP-274 enable edit button for orgAdmins

### DIFF
--- a/lib/redux/reduxApi.js
+++ b/lib/redux/reduxApi.js
@@ -140,7 +140,7 @@ const mapStateToProps = (endpointNames, reduxState) => {
 
 export const withReduxEndpoints = (PageComponent, endpointNames) => connect(mapStateToProps.bind(undefined, endpointNames))(PageComponent)
 // Define custom endpoints/providers here:
-export const withOrgs = PageComponent => withReduxEndpoints(PageComponent, ['organisations'])
+export const withOrgs = PageComponent => withReduxEndpoints(PageComponent, ['organisations', 'members'])
 export const withActs = PageComponent => withReduxEndpoints(PageComponent, ['activities', 'tags'])
 export const withOps = PageComponent => withReduxEndpoints(PageComponent, ['opportunities', 'tags', 'locations'])
 export const withLocations = PageComponent => withReduxEndpoints(PageComponent, ['locations'])


### PR DESCRIPTION
## Proposed changes
When OrgDetails page loads obtain the membership status of the currently signed in person. on Render set the isOrgAdmin flag true if the the current person is in the org membership list as an OrgAdmin.  

Edit Org button is enabled for OrgAdmins and System Admins. 
