### PR TITLE
VP-310 Enable SSL on Beta 

### DIFF
--- a/server/api/health/health.controller.js
+++ b/server/api/health/health.controller.js
@@ -14,7 +14,6 @@ const config = require('../../../config/config').config
   /api/health/config - prints the current config file and env vars.
 */
 const getHealth = (req, res) => {
-
   if (req.param1 === 'log') {
     console.log(req.query.msg)
   }

--- a/server/api/health/health.controller.js
+++ b/server/api/health/health.controller.js
@@ -3,9 +3,21 @@
  */
 const config = require('../../../config/config').config
 
-// check a bunch of things here like whether the db is connected and responding.
-// any depended upon api services
+/* The /api/health endpoint returns information about the health of the system
+  it is the endpoint to call in docker or AWS container health monitoring
+  if it returns 200 the server is operating
+
+  There are also some other useful features
+  /api/health/<p1>/<p2>?query - prints the current params and query parameters
+  /api/health/log?msg="message" - allows you to push a message into the logfile.
+    This is useful when you want to see which instance you are talking to
+  /api/health/config - prints the current config file and env vars.
+*/
 const getHealth = (req, res) => {
+
+  if (req.param1 === 'log') {
+    console.log(req.query.msg)
+  }
   const result = {
     message: `${config.appName} (${process.env.REVISION || 'local_build'}) running on ${config.appUrl}/ Be Awesome`,
     health: 'OK',


### PR DESCRIPTION
## Enable SSL (https) on beta test site

created new

* ssl certificate in sydney
* service voluntarily-beta-service
* target group voluntarily-beta-target-group
* application load balancer voluntarily-beta-load-balancer
* security group sg-0741c857d0cd48946, voluntarily-beta-security-group - limiting access to 80 and 443 http.

Add a listener to load balancer for HTTPS with local SSL certificate
Edit listener for HTTP 80 to redirect 301 to Https 

All the above are AWS configuration changes.
add health/log to output message to logfile.
update the name of the voluntarily-beta-service in the x/aws/deploy-beta script
