### PR TITLE
VP-386 add facebook and twitter links

### DIFF
--- a/components/Org/OrgDetail.js
+++ b/components/Org/OrgDetail.js
@@ -1,9 +1,10 @@
 import React from 'react'
+import { Button, Icon, Tabs } from 'antd'
 import { FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
-import { Icon, Tabs } from 'antd'
 import Markdown from 'markdown-to-jsx'
 import OrgCategory from './OrgCategory'
+import Link from 'next/link'
 import MemberSection from '../Member/MemberSection'
 import Head from 'next/head'
 import styled from 'styled-components'
@@ -14,6 +15,7 @@ import {
   TextH1,
   SpacerSmall
 } from '../VTheme/VTheme'
+const ButtonGroup = Button.Group
 
 function callback (key) {
   // TODO: [VP-300] on tab change update the path so that the page is bookmark and reloadable
@@ -36,8 +38,11 @@ const OrgContainer = styled.div`
 `
 
 const ContactContainer = styled.div`
-margin-top: 0.5rem;
-display: inline-block;
+  margin-top: 0.5rem;
+`
+const SocialButton = styled(Button)`
+  margin-top: 0.5rem;
+  font-size: 2rem !important;
 `
 
 const orgTab = (
@@ -50,26 +55,7 @@ const orgTab = (
     />
   </span>
 )
-// const orgResourcesTab = (
-//   <span>
-//     <Icon type='fire' />
-//     <FormattedMessage
-//       id='orgResources'
-//       defaultMessage='Offers'
-//       description='show opportunities list on volunteer home page'
-//     />
-//   </span>
-// )
-// const orgInstructionTab = (
-//   <span>
-//     <Icon type='usergroup-add' />
-//     <FormattedMessage
-//       id='orgInstruction'
-//       defaultMessage='Getting Started'
-//       description='show opportunities list on volunteer home page'
-//     />
-//   </span>
-// )
+
 const orgMemberTab = (
   <span>
     <Icon type='team' />
@@ -96,11 +82,18 @@ const OrgDetail = ({ org, ...props }) => (
 
         <OrgContainer>
           <TextPBold>Get in touch</TextPBold>
-          {org.website && <ContactContainer><Icon type='global' />&nbsp;&nbsp;{org.website}</ContactContainer>}
+          {org.website &&
+            <ContactContainer>
+              <Icon type='global' />&nbsp;&nbsp;
+              <Link href={org.website}>
+                {org.website}
+              </Link>
+            </ContactContainer>}
           {org.contactEmail && <ContactContainer><Icon type='mail' />&nbsp;&nbsp;{org.contactEmail}</ContactContainer>}
-          {org.facebook && <ContactContainer><Icon type='facebook' />&nbsp;&nbsp;{org.facebook}</ContactContainer>}
-          {org.twitter && <ContactContainer><Icon type='twitter' />&nbsp;{org.twitter}</ContactContainer>}
-
+          <ButtonGroup size='large' >
+            {org.facebook && <SocialButton type='link' href={`https://www.facebook.com/${org.facebook}`} target='_blank' icon='facebook' />}
+            {org.twitter && <SocialButton type='link' href={`https://www.twitter.com/${org.twitter}`} target='_blank' icon='twitter' />}
+          </ButtonGroup>
         </OrgContainer>
       </GridContainer>
 

--- a/components/Org/OrgDetailForm.js
+++ b/components/Org/OrgDetailForm.js
@@ -51,6 +51,8 @@ class OrgDetailForm extends Component {
         org.info.outsiders = values.outsiders
         org.imgUrl = values.imgUrl
         org.website = values.website
+        org.twitter = values.twitter
+        org.facebook = values.facebook
         org.contactEmail = values.contactEmail
         org.category = values.category
         this.props.onSubmit(this.props.org)
@@ -98,7 +100,6 @@ class OrgDetailForm extends Component {
 
     // Only show error after a field is touched.
     const orgNameError = isFieldTouched('name') && getFieldError('name')
-
     return (
       <div className='OrgDetailForm'>
         <Form
@@ -138,6 +139,15 @@ class OrgDetailForm extends Component {
             )}
             <ImageUpload setImgUrl={this.setImgUrl} />
           </Form.Item>
+          <Form.Item label={orgContactEmail}>
+            {getFieldDecorator('contactEmail', {
+              rules: [
+              ]
+            })(
+              // <TextArea rows={20} placeholder='Enter email address for organisations contact person' />
+              <Input placeholder='example@gmail.com' />
+            )}
+          </Form.Item>
           <Form.Item
             label={orgWebsite}
           >
@@ -150,14 +160,18 @@ class OrgDetailForm extends Component {
               <Input placeholder='Organisation Website' />
             )}
           </Form.Item>
-
-          <Form.Item label={orgContactEmail}>
-            {getFieldDecorator('contactEmail', {
+          <Form.Item label='Facebook'>
+            {getFieldDecorator('facebook', {
               rules: [
               ]
             })(
-              // <TextArea rows={20} placeholder='Enter email address for organisations contact person' />
-              <Input placeholder='example@gmail.com' />
+              <Input addonBefore='https://www.facebook.com/' />
+            )}
+          </Form.Item>
+          <Form.Item label='Twitter'>
+            {getFieldDecorator('twitter', {
+            })(
+              <Input addonBefore='@' />
             )}
           </Form.Item>
           <Form.Item label={orgCategory}>


### PR DESCRIPTION
# New changes
Fields to hold facebook and twitter links have been added to the organisation record
OrgDetailForm - updated to allow entry of the links.  We don't ask for the full URL but just the user's name. This prevents them pointing the links away from fb or twitter. 
OrgDetail - social links shown in sidebar as icon buttons.

<img width="277" alt="image" src="https://user-images.githubusercontent.com/1596437/63557950-f5bfc080-c59e-11e9-80e0-f27217c6a26b.png">
