### PR TITLE
VP-461 People list page is empty, Person Get returns first person

### DIFF
--- a/server/api/person/__tests__/person.spec.js
+++ b/server/api/person/__tests__/person.spec.js
@@ -49,6 +49,7 @@ test.serial('Should correctly block GET method for api people for anonymous', as
   t.is(undefined, res.body.length) // Return data response will be undefined for 403 response
 })
 
+// FIXME: must test get and list person calls with signed in user
 test.failing('Should send correct data when queried against an id', async t => {
   t.plan(1)
   const p = {

--- a/server/api/person/person.controller.js
+++ b/server/api/person/person.controller.js
@@ -35,7 +35,7 @@ function listPeople (req, res) {
     sort = req.query.s ? JSON.parse(req.query.s) : sort
     select = req.query.p ? JSON.parse(req.query.p) : {}
 
-    Person.find(query, select).sort(sort)
+    Person.find(query, select).populate('tags').sort(sort)
       .then(got => {
         res.json(got)
       })

--- a/server/api/person/person.controller.js
+++ b/server/api/person/person.controller.js
@@ -1,20 +1,48 @@
 const Person = require('./person')
 const sanitizeHtml = require('sanitize-html')
 const Action = require('../../services/abilities/ability.constants')
-/**
- * Get all orgs
- * @param req
- * @param res
- * @returns void
- */
+
+/* find a single person by searching for a key field.
+This is a convenience function usually used to call
+/api/person/by/email/person@example.com  but can be used for other fields
+*/
 function getPersonBy (req, res) {
-  const query = { [req.params.by]: req.params.value }
+  console.log('getPersonBy', req.params)
+  let query
+  if (req.params.by) {
+    query = { [req.params.by]: req.params.value }
+  } else {
+    query = req.params
+  }
+
   Person.findOne(query).populate('tags').exec((_err, got) => {
     if (!got) { // person does not exist
       return res.status(404).send({ error: 'person not found' })
     }
     res.json(got)
   })
+}
+
+/* return a list of people matching the search criteria
+  if no params given then show all permitted.
+*/
+function listPeople (req, res) {
+  let query = {}
+  let sort = 'nickname'
+  let select = ''
+  try {
+    query = req.query.q ? JSON.parse(req.query.q) : {}
+    sort = req.query.s ? JSON.parse(req.query.s) : sort
+    select = req.query.p ? JSON.parse(req.query.p) : {}
+
+    Person.find(query, select).sort(sort)
+      .then(got => {
+        res.json(got)
+      })
+  } catch (e) {
+    console.log('Bad request', req.query)
+    return res.status(400).send(e)
+  }
 }
 
 async function updatePersonDetail (req, res, next) {
@@ -60,6 +88,7 @@ function ensureSanitized (req, res, next) {
 
 module.exports = {
   ensureSanitized,
+  listPeople,
   getPersonBy,
   updatePersonDetail
 }

--- a/server/api/person/person.routes.js
+++ b/server/api/person/person.routes.js
@@ -2,7 +2,7 @@ const mongooseCrudify = require('mongoose-crudify')
 
 const helpers = require('../../services/helpers')
 const Person = require('./person')
-const { ensureSanitized, getPersonBy, updatePersonDetail } = require('./person.controller')
+const { ensureSanitized, listPeople, getPersonBy, updatePersonDetail } = require('./person.controller')
 const { SchemaName } = require('./person.constants')
 const removeUnauthorizedFields = require('../../services/authorize/removeUnauthorizedFields')
 const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
@@ -23,7 +23,7 @@ module.exports = function (server) {
           only: ['create', 'update']
         }],
       actions: {
-        list: getPersonBy,
+        list: listPeople,
         read: getPersonBy,
         update: updatePersonDetail
       },


### PR DESCRIPTION
# Proposed changes
A bug was introduced last week when the route for people/:id was set to be handled by GetPersonBy in order to add tags to the product.  This was a misunderstanding as this handler only returns one person and if no match is found then returns the first person. 

* Added new listPeople controller along the same pattern as for organisations. This means we can search using mongodb queries and filters. 
* updated controller list

Note this was not picked up as the tests are marked as failing.  This is because listPeople is now covered by an ability and requires the user to be signed in in order to be able to get the list of people. 

