### PR TITLE
Add recommendations of opportunities based on a user's skills

### DIFF
--- a/components/Op/OpRecommendations.js
+++ b/components/Op/OpRecommendations.js
@@ -6,13 +6,20 @@ import OpList from './OpList'
 class OpRecommendations extends React.Component {
   render () {
     const { recommendedOps } = this.props
-    return (recommendedOps.basedOnLocation.length === 0)
-      ? <div /> : (
-        <div>
-          <TextHeadingSubtitle>Nearby opportunities</TextHeadingSubtitle>
-          <OpList ops={recommendedOps.basedOnLocation} />
-        </div>
-      )
+    return (
+    <>
+      {recommendedOps.basedOnLocation.length !== 0 &&
+      <div>
+        <TextHeadingSubtitle>Nearby opportunities</TextHeadingSubtitle>
+        <OpList ops={recommendedOps.basedOnLocation} />
+      </div>}
+
+      {recommendedOps.basedOnSkills.length !== 0 &&
+      <div>
+        <TextHeadingSubtitle>Based on your skills</TextHeadingSubtitle>
+        <OpList ops={recommendedOps.basedOnSkills} />
+      </div>}
+    </>)
   }
 }
 

--- a/components/Op/__tests__/OpRecommendations.spec.js
+++ b/components/Op/__tests__/OpRecommendations.spec.js
@@ -22,18 +22,48 @@ test.serial('ensure recommendations component renders all locations when provide
     basedOnLocation: ops
   }
   const wrapper = mountWithIntl(<OpRecommendations recommendedOps={recommendations} />)
-
   const numOpCards = wrapper.find('OpCard').length
+
+  t.true(('' + wrapper.html()).includes('Nearby opportunities'))
+  t.false(('' + wrapper.html()).includes('Based on your skills'))
   t.is(numOpCards, ops.length)
 })
 
-test.serial('ensure recommendations renders correctly with no matching locations', t => {
+test.serial('ensure recommendations component renders all recommendations on skills when provided', t => {
+  const recommendations = {
+    basedOnSkills: ops,
+    basedOnLocation: []
+  }
+  const wrapper = mountWithIntl(<OpRecommendations recommendedOps={recommendations} />)
+  const numOpCards = wrapper.find('OpCard').length
+
+  t.false(('' + wrapper.html()).includes('Nearby opportunities'))
+  t.true(('' + wrapper.html()).includes('Based on your skills'))
+  t.is(numOpCards, ops.length)
+})
+
+test.serial('ensure recommendations component renders all recommendations on skills and locations when provided', t => {
+  const recommendations = {
+    basedOnLocation: ops.slice(0, 3),
+    basedOnSkills: ops.slice(3, 5)
+  }
+  const wrapper = mountWithIntl(<OpRecommendations recommendedOps={recommendations} />)
+  const numOpCards = wrapper.find('OpCard').length
+
+  t.true(wrapper.html().includes('Nearby opportunities'))
+  t.true(wrapper.html().includes('Based on your skills'))
+  t.is(numOpCards, ops.length)
+})
+
+test.serial('ensure recommendations renders correctly with no matching locations or skills', t => {
   const recommendations = {
     basedOnSkills: [],
     basedOnLocation: []
   }
   const wrapper = mountWithIntl(<OpRecommendations recommendedOps={recommendations} />)
-
   const numOpCards = wrapper.find('OpCard').length
+
+  t.false(('' + wrapper.html()).includes('Nearby opportunities'))
+  t.false(('' + wrapper.html()).includes('Based on your skills'))
   t.is(numOpCards, 0)
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -7063,10 +7063,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -210,18 +210,6 @@ class PersonHomePage extends Component {
                 />
               )}
             </SectionWrapper>
-
-            <SectionWrapper>
-              <SectionTitleWrapper>
-                <TextHeadingBlack>Getting Started</TextHeadingBlack>
-                <TextP>
-                  To start volunteering on Voluntarily, here are a few things we
-                  recommend doing:
-                </TextP>
-              </SectionTitleWrapper>
-              {/* // TODO: [VP-208] list of things volunteers can do on home page */}
-              <NextActionBlock />
-            </SectionWrapper>
             <SectionWrapper>
               <SectionTitleWrapper>
                 <TextHeadingBlack>
@@ -242,6 +230,18 @@ class PersonHomePage extends Component {
               <OpRecommendations
                 recommendedOps={this.props.recommendedOps.data[0]} />
             </SectionWrapper>
+            <SectionWrapper>
+              <SectionTitleWrapper>
+                <TextHeadingBlack>Getting Started</TextHeadingBlack>
+                <TextP>
+                  To start volunteering on Voluntarily, here are a few things we
+                  recommend doing:
+                </TextP>
+              </SectionTitleWrapper>
+              {/* // TODO: [VP-208] list of things volunteers can do on home page */}
+              <NextActionBlock />
+            </SectionWrapper>
+
           </TabPane>
           <TabPane tab={searchTab} key='2'>
             <SectionWrapper>

--- a/server/api/opportunity/opportunity.controller.js
+++ b/server/api/opportunity/opportunity.controller.js
@@ -8,6 +8,7 @@ const InterestArchive = require('./../interest-archive/interestArchive')
 const { OpportunityStatus } = require('./opportunity.constants')
 const { regions } = require('../location/locationData')
 const sanitizeHtml = require('sanitize-html')
+const { getLocationRecommendations, getSkillsRecommendations } = require('./opportunity.util')
 
 /**
  * Get all orgs
@@ -112,36 +113,10 @@ const getOpportunityRecommendations = async (req, res) => {
       return res.status(400).send('Could not find the specified user')
     }
 
-    const regionToMatch = regions.find(loc => {
-      return loc.name === me.location || loc.containedTerritories.includes(me.location)
-    })
+    const locationOps = await getLocationRecommendations(me)
+    const skillsOps = await getSkillsRecommendations(me)
 
-    let locationOps
-    if (regionToMatch) {
-      locationOps = await Opportunity.find({
-        location: { $in: [regionToMatch.name, ...regionToMatch.containedTerritories] },
-        requestor: { $ne: meId }
-      })
-
-      // if user has specified a territory, we should show the exact matches first, because we know
-      // they are closest to the user.
-      const userIsInTerritory = regionToMatch.name !== me.location
-      if (userIsInTerritory) {
-        locationOps.sort((a, b) => {
-          if (a.location === me.location && b.location !== me.location) {
-            return -1
-          } else if (b.location === me.location && a.location !== me.location) {
-            return 1
-          } else {
-            return 0 // we don't care about the ordering if the location isn't matching
-          }
-        })
-      }
-    } else {
-      locationOps = []
-    }
-
-    return res.json({ basedOnLocation: locationOps.slice(0, 10), basedOnSkills: 'todo' })
+    return res.json({ basedOnLocation: locationOps, basedOnSkills: skillsOps })
   } catch (e) {
     return res.status(500).send(e)
   }

--- a/server/api/opportunity/opportunity.util.js
+++ b/server/api/opportunity/opportunity.util.js
@@ -42,7 +42,7 @@ const getSkillsRecommendations = async (me) => {
     const tagIdExpression = {
       $or: tagsToMatch.map(id => ({ 'tags': id }))
     }
-    const opsWithMatchingTags = await Opportunity.find(tagIdExpression)
+    const opsWithMatchingTags = await Opportunity.find({ ...tagIdExpression, requestor: { $ne: me._id } })
     const opsWithCounts = []
 
     opsWithMatchingTags.forEach(op => {
@@ -60,7 +60,7 @@ const getSkillsRecommendations = async (me) => {
       return b.count - a.count
     })
 
-    return opsWithCounts.map(op => op.op)
+    return opsWithCounts.map(op => op.op).slice(0, 10)
   } else {
     return []
   }

--- a/server/api/opportunity/opportunity.util.js
+++ b/server/api/opportunity/opportunity.util.js
@@ -1,0 +1,69 @@
+const Opportunity = require('./opportunity')
+const { regions } = require('../location/locationData')
+
+const getLocationRecommendations = async (me) => {
+  const regionToMatch = regions.find(loc => {
+    return loc.name === me.location || loc.containedTerritories.includes(me.location)
+  })
+
+  let locationOps
+  if (regionToMatch) {
+    locationOps = await Opportunity.find({
+      location: { $in: [regionToMatch.name, ...regionToMatch.containedTerritories] },
+      requestor: { $ne: me._id }
+    })
+
+    // if user has specified a territory, we should show the exact matches first, because we know
+    // they are closest to the user.
+    const userIsInTerritory = regionToMatch.name !== me.location
+    if (userIsInTerritory) {
+      locationOps.sort((a, b) => {
+        if (a.location === me.location && b.location !== me.location) {
+          return -1
+        } else if (b.location === me.location && a.location !== me.location) {
+          return 1
+        } else {
+          return 0 // we don't care about the ordering if the location isn't matching
+        }
+      })
+    }
+  } else {
+    locationOps = []
+  }
+
+  return locationOps.slice(0, 10)
+}
+
+const getSkillsRecommendations = async (me) => {
+  const tagsToMatch = me.tags
+
+  // mongoose isn't happy if we provide an empty array as an expression
+  if (tagsToMatch.length > 0) {
+    const tagIdExpression = {
+      $or: tagsToMatch.map(id => ({ 'tags': id }))
+    }
+    const opsWithMatchingTags = await Opportunity.find(tagIdExpression)
+    const opsWithCounts = []
+
+    opsWithMatchingTags.forEach(op => {
+      let count = 0
+      op.tags.forEach(tag => {
+        if (tagsToMatch.includes(tag)) {
+          count++
+        }
+      })
+
+      opsWithCounts.push({ count, op })
+    })
+
+    opsWithCounts.sort((a, b) => {
+      return b.count - a.count
+    })
+
+    return opsWithCounts.map(op => op.op)
+  } else {
+    return []
+  }
+}
+
+module.exports = { getLocationRecommendations, getSkillsRecommendations }

--- a/server/api/person/person.controller.js
+++ b/server/api/person/person.controller.js
@@ -7,7 +7,7 @@ This is a convenience function usually used to call
 /api/person/by/email/person@example.com  but can be used for other fields
 */
 function getPersonBy (req, res) {
-  console.log('getPersonBy', req.params)
+  // console.log('getPersonBy', req.params)
   let query
   if (req.params.by) {
     query = { [req.params.by]: req.params.value }

--- a/x/db/op-cars.json
+++ b/x/db/op-cars.json
@@ -5,7 +5,7 @@
   "imgUrl": "http://www.plaz-tech.com/wp-content/plugins/wp-easycart-data/products/pics1/Arduino%20Car%202_8ab5dd38f1e3f6f05ad244f1e5e74529.jpg",
   "description": "# NZTA Innovation Centre\n \n We have 6 model cars with sensors for vision, proximity etc, \n controlled by Arduinos teach them to solve \n 4 challenges - move, follow a line, avoid obstacles, \n get to a destination etc. \n \n ## We need:\n * Open space with room for the test tracks - e.g a school hall\n * teams of 5 students\n * on adult helper per team, should be able to follow instructions and understand a little C++\n \n ## Learning outcomes:\n * programming a remote device\n * simple coding\n * algorithmic thinking\n * problem solving.\n \n",
   "duration": "4 hours",
-  "location": "NZTA Innovation Centre, 5 Cook St Auckland",
+  "location": "Auckland",
   "status": "draft",
   "tags": [
     { "_id": "5d00656d9c52c52080187aa6" },

--- a/x/db/op-impact.json
+++ b/x/db/op-impact.json
@@ -6,7 +6,7 @@
   "duration": "12 weeks, 1 hour sessions",
   "date": "20190401",
   "offerOrg": "Albany High School",
-  "location": "Albany High School, Auckland",
+  "location": "Auckland",
   "status": "draft",
   "tags": [
     { "_id": "2d00626d9c22c22080187bb6" }

--- a/x/db/op-litter.json
+++ b/x/db/op-litter.json
@@ -4,7 +4,7 @@
   "imgUrl": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQoFSxdBGAk1E3KCHnsDxc5m_OL1wS2_IZE68N60FXTw7J4kjuc",
   "description": "Our class wants to use a camera and computer to watch the playground and see who is leaving rubbish lying around. We need help to understand how machine vision works and how hard this problem is.",
   "duration": "2 hours",
-  "location": "Ponsonby Primary School, Ponsonby, Auckland",
+  "location": "Auckland",
   "status": "draft",
   "tags": [
     { 

--- a/x/db/op-rocket.json
+++ b/x/db/op-rocket.json
@@ -4,7 +4,7 @@
   "imgUrl": "https://images.sunlive.co.nz/images/170705-st-marys-school-rockets1.jpg",
   "description": "Project to build a simple rocket that will reach 100m",
   "duration": "4 hours",
-  "location": "St Marys Intermediate School",
+  "location": "Auckland",
   "status": "draft",
   "tags": [],
   "requestor": "5ccbe4c26c285b7184bff574"


### PR DESCRIPTION
## Proposed Changes
This PR will introduce new functionality to the component **(OpRecommendations)** into the /home page, to display recommended opportunities from the platform.

These will now either be based on:
* **Location** (e.g opportunities in the exact same region and/or related territories - e.g Kaikoura District and Christchurch City are both territories within the Canterbury region) - _(PREVIOUS FUNCTIONALITY)_
* **Skills** - depending on the number of matching skill tags a given opportunity has with a user, that opportunity gets assigned a value (+1 for each matching tags). These are then ranked based on calculated count, from most to least relevant - _(ADDED FUNCTIONALITY)_

Any questions about this, feel free to ask @darcycox97 or I!!

## Screenshots
![image](https://user-images.githubusercontent.com/31422519/63811729-650d2a00-c97c-11e9-980c-64f45ecafa11.png)

![](https://media.giphy.com/media/6nuiJjOOQBBn2/giphy.gif)

