### PR TITLE
VP-435 remove unnecessary client side sanitization

### DIFF
--- a/components/Op/OpDetail.js
+++ b/components/Op/OpDetail.js
@@ -45,12 +45,7 @@ export function OpDetail ({ op }) {
   // This will make sure that if the description is undefined we will set it to an empty string
   // Otherwise Markdown will throw error
   // BUG: [VP-435] sanitize OpDetail description is filtering out the Rich Text.
-  const description =
-    op.description == null
-      ? ''
-      : sanitize(op.description, {
-        allowedAttributes: { a: ['href', 'style'] }
-      }) // Only href and style attribute is allowed in link tag
+  const description = op.description || ''
   const startDate = op.date[0]
     ? moment(op.date[0]).format('h:mmA · ddd DD/MM/YY')
     : 'Negotiable'


### PR DESCRIPTION
# Changes
rich text field on opportunities was not displaying the full rich text due to an overzealous sanitisation on the client side. This is not required as the server will have already performed the sanitisation. 

