### PR TITLE
VP-468 remove isMe modifying of membership

### DIFF
--- a/components/Member/MemberSection.js
+++ b/components/Member/MemberSection.js
@@ -56,11 +56,8 @@ class MemberSection extends Component {
     // check if I am in the members list
     // TODO: [VP-440] members ability I am orgadmin then I get all members list, else I get just my own membership status
     let myMembership = this.props.members.data.find(m => m.person._id === meid)
-    if (myMembership) {
-      myMembership.isMe = true
-    } else {
+    if (!myMembership) {
       myMembership = {
-        isMe: false,
         status: MemberStatus.NONE
       }
     }
@@ -69,7 +66,7 @@ class MemberSection extends Component {
     const memberOrOrgAdmin = m => [MemberStatus.MEMBER, MemberStatus.ORGADMIN].includes(m.status)
     const joinerOrValidator = m => [MemberStatus.VALIDATOR, MemberStatus.JOINER].includes(m.status)
     const follower = m => [MemberStatus.FOLLOWER].includes(m.status)
-    const nonMember = m => !myMembership.isMe || [MemberStatus.NONE, MemberStatus.EXMEMBER].includes(m.status)
+    const nonMember = m => [MemberStatus.NONE, MemberStatus.EXMEMBER].includes(m.status)
 
     // OrgAdmins see Member Table
     let orgAdminSection = ''
@@ -89,6 +86,7 @@ class MemberSection extends Component {
             <MemberTable
               members={joiners}
               onMembershipChange={this.handleMembershipChange.bind(this)}
+              meid={meid}
             />
           </SubSection>
           <SubSection>
@@ -101,6 +99,7 @@ class MemberSection extends Component {
             <MemberTable
               members={members}
               onMembershipChange={this.handleMembershipChange.bind(this)}
+              meid={meid}
             />
           </SubSection>
 
@@ -114,6 +113,7 @@ class MemberSection extends Component {
             <MemberTable
               members={followers}
               onMembershipChange={this.handleMembershipChange.bind(this)}
+              meid={meid}
             />
           </SubSection>
         </div>

--- a/components/Member/MemberTable.js
+++ b/components/Member/MemberTable.js
@@ -59,7 +59,7 @@ class MemberTable extends Component {
       title: 'Action',
       key: 'action',
       render: (text, record) => {
-        const options = buttonStates(record)
+        const options = buttonStates(record, this.props.meid)
         return (
           <div>
             {options.map(btn => {
@@ -97,7 +97,8 @@ class MemberTable extends Component {
 
 MemberTable.propTypes = {
   onMembershipChange: PropTypes.func.isRequired,
-  members: PropTypes.array
+  members: PropTypes.array,
+  meid: PropTypes.string
 }
 
 /* Button State options
@@ -107,7 +108,7 @@ MemberTable.propTypes = {
   EXMEMBER: OrgAdmin can confirm or reject membership
   ORGADMIN: OrgAdmin can make normal member again
 */
-const buttonStates = member => {
+const buttonStates = (member, meid) => {
   return [
     {
       buttonEnabled: [MemberStatus.FOLLOWER, MemberStatus.JOINER, MemberStatus.VALIDATOR, MemberStatus.EXMEMBER].includes(member.status),
@@ -130,7 +131,7 @@ const buttonStates = member => {
       action: 'makeadmin'
     },
     {
-      buttonEnabled: (member.status === MemberStatus.ORGADMIN) && !member.isMe,
+      buttonEnabled: (member.status === MemberStatus.ORGADMIN) && (member.person._id !== meid),
       label: <FormattedMessage id='member.unadmin' defaultMessage='Cancel Admin' description='Button allowing orgAdmin to return an admin back to normal member' />,
       action: 'add'
     }


### PR DESCRIPTION
## Proposed Changes
on the members page of organisation the value isMe is used to pass in a flag showing which membership record belongs to the signed in person. This is used on the MemberTable to hide action buttons the membership entry line for the orgAdmin to prevent them removing themselves and locking them out of the admin role.

However updating the redux object seems to cause it to be removed in some circumstances and this results in an exception.  

Instead we now pass in the me id of the person and check the match explicitly. 
