### PR TITLE
Fix server crash when click on opportunity for not logged in user

### DIFF
--- a/pages/op/opdetailpage.js
+++ b/pages/op/opdetailpage.js
@@ -135,7 +135,7 @@ export class OpDetailPage extends Component {
   }
 
   retrieveOpportunity () {
-    if (this.props.members.sync && this.props.members.data.length > 0) {
+    if (this.props.members.sync && this.props.members.data.length > 0 && this.props.me) {
       this.props.me.orgMembership = this.props.members.data.filter(m => [MemberStatus.MEMBER, MemberStatus.ORGADMIN].includes(m.status))
     }
 


### PR DESCRIPTION
# Proposed Changes? 🤔
1.  Added another condition in the if statement in opdetailPage.js  line 138

## Additional Info.🧐

The problem was in line 138 the if statement doesn't check for me field. In public page, if user is not logged in me field will have value false instead of object.

## Screenshots 📷
 
### Updated
![fixed](https://user-images.githubusercontent.com/29682322/64139830-5f20b880-ce56-11e9-9a17-82735e8eeff4.JPG)

