### PR TITLE
VP-472 catch 403 forbidden is returned. fix idline

### DIFF
--- a/components/VTheme/IdLine.js
+++ b/components/VTheme/IdLine.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Avatar } from 'antd'
 import Link from 'next/link'
-import styled from 'styled-components'
 /*
   Display any entity that has a name and imgUrl
   Clicks through to the resource + id
@@ -12,38 +11,20 @@ import styled from 'styled-components'
   }
   type = orgaanisation, person, activity
 */
-const IDGrid = styled.a`
-display: grid;
-grid-template-columns: 1.5rem 1fr;
-height: 3rem;
-`
-
-const IDItems = styled.p`
-margin-left: 1rem;
-display: inline;
-
-`
 
 const IdLine = ({ item, path }) =>
-  item
-    ? <Link href={`/${path}/${item._id}`}>
+  item &&
+    <Link href={`/${path}/${item._id}`}>
       <a style={{ display: 'block', margin: '0' }} >
-        <IDGrid>
-          <Avatar
-            style={{ marginTop: '0.5rem' }}
-            size={32}
-            shape='square'
-            src={item.imgUrl}
-            icon='team'
-          />
-          <IDItems>
-            {item.name}<br />
-        Legitimate Organization
-          </IDItems>
-        </IDGrid>
+        <Avatar
+          size={32}
+          shape='square'
+          src={item.imgUrl}
+          icon='team'
+        />
+        <span style={{ marginLeft: '1em' }}>{item.name}</span>
       </a>
     </Link>
-    : null
 
 IdLine.propTypes = {
   item: PropTypes.shape({

--- a/pages/person/persondetailpage.js
+++ b/pages/person/persondetailpage.js
@@ -46,10 +46,15 @@ export class PersonDetailPage extends Component {
       let cookies = req ? req.cookies : Cookie.get()
       const cookiesStr = JSON.stringify(cookies)
       query.session = store.getState().session
-      await store.dispatch(reduxApi.actions.people.get(query, {
-        params: cookiesStr
-      }))
-      await store.dispatch(reduxApi.actions.members.get({ meid }))
+      try {
+        await store.dispatch(reduxApi.actions.people.get(query, {
+          params: cookiesStr
+        }))
+        await store.dispatch(reduxApi.actions.members.get({ meid }))
+      } catch (err) {
+        // this can return a 403 forbidden if not signed in
+        console.log('Error in persondetailpage:', err)
+      }
 
       return {
         isNew: false,
@@ -98,7 +103,7 @@ export class PersonDetailPage extends Component {
   handleDeleteCancel = () => { message.error('Delete Cancelled') }
 
   render () {
-    const isOrgAdmin = false // TODO: is this person an admin for the org that person belongs to.
+    const isOrgAdmin = false // TODO: [VP-473] is this person an admin for the org that person belongs to.
     const isAdmin = (this.props.me && this.props.me.role.includes('admin'))
     const canEdit = (isOrgAdmin || isAdmin)
     const canRemove = isAdmin


### PR DESCRIPTION
## Proposed Changes? 🤔
1. add try/catch block around data getters in persondetailpage get initial props as this was throwing an exception when 403 forbidden was returned for non signed in users.  

## Additional Info.🧐
Page later forces authorisation but getinitialprops runs early server side when we have not checked we are signed in.

Also reverted IdLine back to the way it was as we were getting DOM warnings a in a and p in p. Also the control contained static text - Legitimate Organisation.  
