### PR TITLE
VP-386 add gamma and delta deployments

### DIFF
--- a/x/aws/cloudformation/fargate.yml
+++ b/x/aws/cloudformation/fargate.yml
@@ -108,7 +108,7 @@ Resources:
   ECSCluster:
     Type: AWS::ECS::Cluster
     Properties:
-      ClusterName: !Join ['-', [!Ref 'StackName', 'ECSCluster']]
+      ClusterName: !Join ['-', [!Ref 'ServiceName', 'ECSCluster']]
 
   # Setup networking resources for the public subnets. Containers
   # in the public subnets have public IP addresses and the routing table
@@ -178,7 +178,7 @@ Resources:
     Properties:
       ServiceName: !Ref 'ServiceName'
       Cluster:
-          !Join ['-', [!Ref 'StackName', 'ECSCluster']]
+          !Join ['-', [!Ref 'ServiceName', 'ECSCluster']]
       LaunchType: FARGATE
       DeploymentConfiguration:
         MaximumPercent: 200

--- a/x/aws/cloudformation/make-delta
+++ b/x/aws/cloudformation/make-delta
@@ -1,0 +1,5 @@
+aws cloudformation deploy \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --template-file fargate.yml \
+  --stack-name vly-delta \
+  --parameter-overrides ServiceName=vly-delta AppUrl=https://delta.voluntarily.nz

--- a/x/aws/cloudformation/make-gamma
+++ b/x/aws/cloudformation/make-gamma
@@ -1,0 +1,5 @@
+aws cloudformation deploy \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --template-file fargate.yml \
+  --stack-name vly-gamma2 \
+  --parameter-overrides ServiceName=vly-gamma AppUrl=https://gamma.voluntarily.nz

--- a/x/aws/cloudformation/readme.md
+++ b/x/aws/cloudformation/readme.md
@@ -9,3 +9,16 @@ You will probably want to also set
 ServiceName
 DbUriBase
 AppUrl
+
+Note the following other changes will be required for a new deployment
+## Deploy an image 
+use deploy-{target} to copy from alpha to {target} or use a common image
+
+
+## Domain:  
+101Domain.com nameserver records 
+create a CNAME record for the site subdomain e.g gamma.voluntarily.nz and point this at the load balancer created. 
+beta CNAME voluntarily-beta-load-balancer-587146228.ap-southeast-2.elb.amazonaws.com.
+
+## Auth0
+add the new service to the whitelist of authentication endpoints.

--- a/x/aws/deploy-delta
+++ b/x/aws/deploy-delta
@@ -1,0 +1,20 @@
+#!/bin/bash
+MY_DIR=$( dirname "${BASH_SOURCE[0]}" )
+
+# Get a docker login and run it
+source ${MY_DIR}/login-singapore
+
+# pull latest alpha image
+docker pull 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly2-alpha:master
+
+# retag
+docker image tag 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly2-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-delta:master
+
+# login to signapore
+source ${MY_DIR}/login-sydney
+
+# push the new image
+docker push 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-delta:master
+
+# restart
+aws ecs update-service --service vly-delta --cluster vly-delta-ECSCluster --desired-count 3 --deployment-configuration maximumPercent=100,minimumHealthyPercent=50 --force-new-deployment 

--- a/x/aws/deploy-gamma
+++ b/x/aws/deploy-gamma
@@ -1,0 +1,20 @@
+#!/bin/bash
+MY_DIR=$( dirname "${BASH_SOURCE[0]}" )
+
+# Get a docker login and run it
+source ${MY_DIR}/login-singapore
+
+# pull latest alpha image
+docker pull 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly2-alpha:master
+
+# retag
+docker image tag 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly2-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-gamma:master
+
+# login to signapore
+source ${MY_DIR}/login-sydney
+
+# push the new image
+docker push 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-gamma:master
+
+# restart
+aws ecs update-service --service vly-gamma --cluster vly-gamma-ECSCluster --desired-count 3 --deployment-configuration maximum  


### PR DESCRIPTION
## Proposed Changes? 🤔
1.  Updated the Fargate Cloudformation script so that it creates deployments with a consistent naming
2. Added deploy scripts to copy the master release to the different deployments e.g. make-gamma
3. Deployed two new installations for testing - https://gamma.voluntarily.nz https://delta.voluntarily.nz.   

We will be using Gamma for performance testing.  The other is just for practice in deployments and we may destroy it from time to time.

Note each deployment creates a new database on the same Atlas collection. 
Auth0 and DNS setup to point to the resulting load balancers.
