### PR TITLE
Fixed Styling on error 500 page. Changed from h1 to h2, for error tex…

### DIFF
--- a/__tests__/404.spec.js
+++ b/__tests__/404.spec.js
@@ -20,5 +20,5 @@ test('render 200', t => {
 
 test('render 500', t => {
   const wrapper = mountWithIntl(<ErrorPageTest router={router} url='/404' errorCode={E500} />)
-  t.regex(wrapper.find('h1').first().text(), /Sorry, there was a problem/)
+  t.regex(wrapper.find('h2').first().text(), /Sorry, there was a problem/)
 })

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -34,12 +34,12 @@ const BugContainer = styled.div`
 `
 
 class ErrorPage extends React.Component {
-  static getInitialProps ({ res, xhr }) {
+  static getInitialProps({ res, xhr }) {
     const errorCode = res ? res.statusCode : xhr ? xhr.status : null
     return { errorCode }
   }
 
-  render () {
+  render() {
     var response
 
     switch (this.props.errorCode) {
@@ -109,10 +109,10 @@ class ErrorPage extends React.Component {
                 id='error.servererror.description'
                 description='A server error'
                 defaultMessage='Sorry, there was a problem and we can not complete this task. We have let our team know so they can take a look and fix it. For now try to refresh the page, or go back to the previous page'
-                tagName='h1'
+                tagName='h2'
               />
               <Container className='pt-5 text-center'>
-                <h1 className='display-4'>HTTP {this.props.errorCode} Error</h1>
+                <h4 className='display-4'>HTTP {this.props.errorCode} Error</h4>
                 <p>
                   An <strong>HTTP {this.props.errorCode}</strong> error occurred
                   while trying to access{' '}

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -34,12 +34,12 @@ const BugContainer = styled.div`
 `
 
 class ErrorPage extends React.Component {
-  static getInitialProps({ res, xhr }) {
+  static getInitialProps ({ res, xhr }) {
     const errorCode = res ? res.statusCode : xhr ? xhr.status : null
     return { errorCode }
   }
 
-  render() {
+  render () {
     var response
 
     switch (this.props.errorCode) {


### PR DESCRIPTION
…t, and h1-h4 for error code

# Pull Request Template (VP-123)

Please check that your ticket number and ticket description is included in the PR title 😀


## Proposed Changes? 🤔
1. Fixed text styling on error 500 page. Changed from h1 > h2 for main body text, and h1 > h4 for error code
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
