### PR TITLE
Fix security api health config expose AWS key

### DIFF
--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -102,10 +102,14 @@ class PersonHomePage extends Component {
     if (!person) return
     // Actual data request
     let res = {}
+
+    const role = this.sortRoleByPower(person)
+    const personData = { ...person, role }
+    console.log(personData)
     res = await this.props.dispatch(
       reduxApi.actions.people.put(
-        { id: person._id },
-        { body: JSON.stringify(person) }
+        { id: personData._id },
+        { body: JSON.stringify(personData) }
       )
     )
 
@@ -115,6 +119,13 @@ class PersonHomePage extends Component {
     this.setState({ editProfile: false })
   }
 
+  sortRoleByPower = ({ role }) => {
+    if (role.includes('admin')) {
+      role = role.filter(element => { return element !== 'admin' })
+      role.push('admin')
+    }
+    return role
+  }
   render () {
     var shadowStyle = { overflow: 'visible' }
     if (this.props.members.sync && this.props.members.data.length > 0) {

--- a/server/api/health/health.controller.js
+++ b/server/api/health/health.controller.js
@@ -17,14 +17,26 @@ const getHealth = (req, res) => {
   if (req.params.param1 === 'log') {
     console.log(req.query.msg)
   }
-  const result = {
-    message: `${config.appName} (${process.env.REVISION || 'local_build'}) running on ${config.appUrl}/ Be Awesome`,
-    health: 'OK',
-    params: req.params,
-    query: req.query,
-    app_url: process.env.APP_URL,
-    config: req.params.param1 === 'config' && config
+  let result
+  if (req.params.param1 === 'config' && req.ability.can('manage', 'Person')) {
+    result = {
+      message: `${config.appName} (${process.env.REVISION || 'local_build'}) running on ${config.appUrl}/ Be Awesome`,
+      health: 'OK',
+      params: req.params,
+      query: req.query,
+      app_url: process.env.APP_URL,
+      config: req.params.param1 === 'config' && config
+    }
+  } else {
+    result = {
+      message: `${config.appName} (${process.env.REVISION || 'local_build'}) running on ${config.appUrl}/ Be Awesome`,
+      health: 'OK',
+      params: req.params,
+      query: req.query,
+      app_url: process.env.APP_URL
+    }
   }
+
   return res.status(200).json(result)
 }
 


### PR DESCRIPTION
Fix api security backdoor to get information about the config file in api health check😀

## Proposed Changes? 🤔
1. Casl check for the api request if the request has the right to manage person then the request can return config file otherwise it will return normal message

### Original


### Updated
