### PR TITLE
VP-517 modify PersonCard to use VTheme Card

### DIFF
--- a/components/Person/PersonCard.js
+++ b/components/Person/PersonCard.js
@@ -1,52 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
+import { Card } from '../VTheme/VTheme'
 
 const PersonCard = ({ person, ...props }) => (
-  <div>
+  <Card>
     <Link href={`/people/${person._id}`} >
       <a>
-        <div className='personContainer'>
-          <img className='personImg' src={person.imgUrl} />
-          <p className='personTitle'>{person.nickname}</p>
+        <img src={person.imgUrl} />
+        <figcaption>
+          <h1>{person.nickname}</h1>
           <p className='personName'>{person.name}</p>
-        </div>
+        </figcaption>
       </a>
-    </Link>
-    <style jsx>{`
-      .personContainer {
-        width: 10rem;
-        letter-spacing: -0.3px;
-        line-height: 24px;
-        margin-bottom: 0px;
-      }
-
-      .personImg {
-        width: 100%;
-        height: 10rem;
-        background-color: rgba(0,0,0,0.0);
-        object-fit: cover;
-        object-position: center;
-        
-      }
-
-      .personTitle {
-        margin-top: 0px;
-        margin-bottom: 0px;
-        vertical-align: middle;
-        font-weight: bold;
-        font-size: 16px;
-        color: #000;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-      }
-     
-      .personTitle :hover {
-        color: #6549aa;
-      }
+    </Link>    <style jsx>{`
       .personName {
         overflow: hidden;
         text-overflow: ellipsis; 
@@ -56,10 +23,8 @@ const PersonCard = ({ person, ...props }) => (
         -webkit-line-clamp: 6;
         -webkit-box-orient: vertical;
       }
-      
-
     `}</style>
-  </div>
+  </Card>
 )
 
 PersonCard.propTypes = {

--- a/components/Person/__tests__/PersonCard.spec.js
+++ b/components/Person/__tests__/PersonCard.spec.js
@@ -12,6 +12,7 @@ const person = {
 
 test('PersonCard renders properly', t => {
   const wrapper = render(<PersonCard person={person} />)
-  t.is(wrapper.find('.personTitle').first().text(), person.nickname)
-  t.is(wrapper.find('.personName').first().text(), person.name)
+  t.is(wrapper.find('h1').first().text(), person.nickname)
+  t.is(wrapper.find('img').first().prop('src'), person.imgUrl)
+  t.is(wrapper.find('p').first().text(), person.name)
 })


### PR DESCRIPTION
VP-517 modify PersonCard to use VTheme Card


## Proposed Changes? 🤔
1. Remove <div> tag in PersonCard and use <Card> from VTheme to display people
2.  Use style tag in PersonCard to wrap overflow text in person's name
3.  Update testcase

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
![peopleList](https://user-images.githubusercontent.com/15199781/65652558-4c209300-e066-11e9-8568-4fdadfb9d896.png)

### Original


### Updated
