### PR TITLE
VP-566 Add New Activity button in dashboard for people with activity …

### DIFF
--- a/components/Act/ActAdd.js
+++ b/components/Act/ActAdd.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux'
 
 // todo if image is not present then use a fallback.
 const ActAdd = ({ roles, ...props }) => {
-  if (roles && roles.includes('activity-provider')) {
+  if (roles && roles.includes('activityProvider')) {
     return (
       <Link href={'/act/new'}>
         <Button type='primary' shape='round' size='large'>

--- a/components/Act/ActAdd.js
+++ b/components/Act/ActAdd.js
@@ -7,10 +7,10 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { connect } from 'react-redux'
-
+import { Role } from '../../server/services/authorize/role.js'
 // todo if image is not present then use a fallback.
 const ActAdd = ({ roles, ...props }) => {
-  if (roles && roles.includes('activityProvider')) {
+  if (roles && roles.includes(Role.ACTIVITY_PROVIDER)) {
     return (
       <Link href={'/act/new'}>
         <Button type='primary' shape='round' size='large'>

--- a/components/Act/__tests__/ActAdd.spec.js
+++ b/components/Act/__tests__/ActAdd.spec.js
@@ -25,8 +25,8 @@ test('render the opadd as null if not activity-provider role', t => {
   t.falsy(wrapper.find('button').exists())
 })
 
-test('render the opadd correctly if activity-provider role', t => {
-  mockStore.getState().session.me.role = ['activity-provider']
+test('render the opadd correctly if  activityProvider role', t => {
+  mockStore.getState().session.me.role = ['activityProvider']
   const wrapper = mountWithIntl(
     <Provider store={mockStore}>
       <ActAdd store={mockStore} />

--- a/components/Act/__tests__/ActAdd.spec.js
+++ b/components/Act/__tests__/ActAdd.spec.js
@@ -4,6 +4,7 @@ import ActAdd from '../ActAdd'
 import { mountWithIntl } from '../../../lib/react-intl-test-helper'
 import configureStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
+import { Role } from '../../server/services/authorize/role.js'
 
 const mockStore = configureStore()(
   {
@@ -26,7 +27,7 @@ test('render the opadd as null if not activity-provider role', t => {
 })
 
 test('render the opadd correctly if  activityProvider role', t => {
-  mockStore.getState().session.me.role = ['activityProvider']
+  mockStore.getState().session.me.role = [Role.ACTIVITY_PROVIDER]
   const wrapper = mountWithIntl(
     <Provider store={mockStore}>
       <ActAdd store={mockStore} />

--- a/components/Act/__tests__/ActAdd.spec.js
+++ b/components/Act/__tests__/ActAdd.spec.js
@@ -4,7 +4,7 @@ import ActAdd from '../ActAdd'
 import { mountWithIntl } from '../../../lib/react-intl-test-helper'
 import configureStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
-import { Role } from '../../server/services/authorize/role.js'
+import { Role } from '../../../server/services/authorize/role.js'
 
 const mockStore = configureStore()(
   {

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet'
 import { FormattedMessage } from 'react-intl'
 import styled from 'styled-components'
 import NextActionBlock from '../../components/Action/NextActionBlock'
+import ActAdd from '../../components/Act/ActAdd'
 import OpAdd from '../../components/Op/OpAdd'
 import OpList from '../../components/Op/OpList'
 import OpRecommendations from '../../components/Op/OpRecommendations'
@@ -176,6 +177,7 @@ class PersonHomePage extends Component {
           </TitleContainer>
           <RequestButtonContainer>
             <OpAdd {...this.props} />
+            <ActAdd {...this.props} />
           </RequestButtonContainer>
           <p>See the requests you have signed up for here</p>
         </PageHeaderContainer>


### PR DESCRIPTION
…provider role

VP-566 Add New Activity button in dashboard for people with activity provider role

Please check that your ticket number and ticket description is included in the PR title 😀


## Proposed Changes? 🤔
1.  Add ActAdd component in home page
2.  Update ActAdd component to display button if user has activityProvider role
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
