### PR TITLE
VP-202 api caller triggers onfulfilled callback insetad of onrejected callback when fetch fails

### DIFF
--- a/lib/__test__/apiCaller.spec.js
+++ b/lib/__test__/apiCaller.spec.js
@@ -39,7 +39,6 @@ test('When server throws an error then Promise should be rejected with the same 
   fetchMock.restore()
   fetchMock.getOnce(`${API_URL}/health`, Promise.reject(new Error('foo')))
   await t.throwsAsync(() => callApi('health'), 'foo')
-  
 })
 
 test('Can convert cookie object to cookie KVPs', async t => {

--- a/lib/__test__/apiCaller.spec.js
+++ b/lib/__test__/apiCaller.spec.js
@@ -4,21 +4,6 @@ import callApi, { API_URL, convertCookiesToKvps } from '../apiCaller'
 // import sinon from 'sinon'
 
 const { fetchMock } = require('fetch-mock')
-// test('fetchMock works', async t => {
-// const health = {
-//   message: 'Hello',
-//   health: 'OK'
-// }
-//   fetchMock.getOnce('http://localhost:3122/api/health', health)
-
-//   // eslint-disable-next-line no-use-before-define
-//   const res = await fetch('http://localhost:3122/api/health')
-//   const json = await res.json()
-//   t.is(res.ok, true)
-//   t.is(res.status, 200)
-//   t.is(json.health, 'OK')
-//   fetchMock.restore()
-// })
 
 test('API_URL', async t => {
   t.is(API_URL, `http://localhost:${process.env.PORT}/api`)
@@ -36,47 +21,27 @@ test('getAPI ', async t => {
   fetchMock.restore()
 })
 
-// test.only('getAPI handles data errors', async t => {
-
-//   fetchMock.getOnce(`${API_URL}/nothere`, { status: 404, body: { message: 'These are not the pages you are looking for' } } )
-//   const error = await t.throwsAsync( () => callApi('nothere'), {is: 'These are not the pages you are looking for'})
-//   t.is(error.message, 'These are not the pages you are looking for')
-// })
-
-test('When server returns 500 status code then Promise should be rejected', async t => {
-  try {
-    fetchMock.getOnce(`*`, 500)
-    await t.throwsAsync(() => callApi('health'), 'Internal Server Error')
-  } catch (err) {
-    console.log(err)
-  }
+test('getAPI handles data errors', async t => {
+  fetchMock.getOnce(`${API_URL}/nothere`, { status: 404, body: { message: 'These are not the pages you are looking for' } })
+  const message = '{"status":404,"statusText":"Not Found","message":"{\\"message\\":\\"These are not the pages you are looking for\\"}"}'
+  await t.throwsAsync(() => callApi('nothere'), message)
+  fetchMock.restore()
 })
 
-test('When server throws an error then Promise should be rejected', async t => {
-  try {
-    fetchMock.restore()
-    fetchMock.getOnce(`${API_URL}/health`, Promise.reject(new Error('foo')))
-    await t.throwsAsync(() => callApi('health'), 'foo')
-  } catch (err) {
-    console.log(err)
-  }
+test('When server returns 500 status code then Promise should be rejected with the status', async t => {
+  fetchMock.restore()
+  fetchMock.getOnce(`*`, 500)
+  const message = '{"status":500,"statusText":"Internal Server Error"}'
+  await t.throwsAsync(() => callApi('health'), message)
 })
 
-/*
-test.only('throws an error if empty object', async t => {
-   fetchMock.getOnce(`*`, 500)
-  const onResponse =  sinon.spy()
-  const onError =  sinon.spy()
+test('When server throws an error then Promise should be rejected with the same error', async t => {
+  fetchMock.restore()
+  fetchMock.getOnce(`${API_URL}/health`, Promise.reject(new Error('foo')))
+  await t.throwsAsync(() => callApi('health'), 'foo')
+  
+})
 
-  return  callApi('health')
-    .then(onResponse)
-    .catch(onError)
-    .finally(() => {
-        t.truthy(onResponse.notCalled)
-  t.truthy(onError.calledOnce)
-    });
-});
-*/
 test('Can convert cookie object to cookie KVPs', async t => {
   const expectedCookieKvps = 'foo=bar;up=down;'
   const cookies = {

--- a/lib/__test__/apiCaller.spec.js
+++ b/lib/__test__/apiCaller.spec.js
@@ -1,6 +1,8 @@
 import test from 'ava'
 import 'isomorphic-fetch'
 import callApi, { API_URL, convertCookiesToKvps } from '../apiCaller'
+// import sinon from 'sinon'
+
 const { fetchMock } = require('fetch-mock')
 // test('fetchMock works', async t => {
 // const health = {
@@ -34,14 +36,6 @@ test('getAPI ', async t => {
   fetchMock.restore()
 })
 
-// test.todo('Test failure modes of the API call.')
-// test('getAPI handles server errors', async t => {
-
-//   fetchMock.getOnce(`*`, 500)
-//   const error = await t.throwsAsync( () => callApi('health'))
-//   t.is(error.status, 500)
-// })
-
 // test.only('getAPI handles data errors', async t => {
 
 //   fetchMock.getOnce(`${API_URL}/nothere`, { status: 404, body: { message: 'These are not the pages you are looking for' } } )
@@ -49,6 +43,40 @@ test('getAPI ', async t => {
 //   t.is(error.message, 'These are not the pages you are looking for')
 // })
 
+test('When server returns 500 status code then Promise should be rejected', async t => {
+  try {
+    fetchMock.getOnce(`*`, 500)
+    await t.throwsAsync(() => callApi('health'), 'Internal Server Error')
+  } catch (err) {
+    console.log(err)
+  }
+})
+
+test('When server throws an error then Promise should be rejected', async t => {
+  try {
+    fetchMock.restore()
+    fetchMock.getOnce(`${API_URL}/health`, Promise.reject(new Error('foo')))
+    await t.throwsAsync(() => callApi('health'), 'foo')
+  } catch (err) {
+    console.log(err)
+  }
+})
+
+/*
+test.only('throws an error if empty object', async t => {
+   fetchMock.getOnce(`*`, 500)
+  const onResponse =  sinon.spy()
+  const onError =  sinon.spy()
+
+  return  callApi('health')
+    .then(onResponse)
+    .catch(onError)
+    .finally(() => {
+        t.truthy(onResponse.notCalled)
+  t.truthy(onError.calledOnce)
+    });
+});
+*/
 test('Can convert cookie object to cookie KVPs', async t => {
   const expectedCookieKvps = 'foo=bar;up=down;'
   const cookies = {

--- a/lib/apiCaller.js
+++ b/lib/apiCaller.js
@@ -23,7 +23,6 @@ const callApi = async (endpoint, method = 'get', body, cookies) => {
   let headers = {
     'content-type': 'application/json'
   }
-
   if (cookies) {
     headers.Cookie = convertCookiesToKvps(cookies)
   }
@@ -40,11 +39,10 @@ const callApi = async (endpoint, method = 'get', body, cookies) => {
       method,
       body: JSON.stringify(requestBody)
     })
-
     if (!response.ok) {
       // according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject
       // it is useful to make reason an instanceof Error
-      return Promise.reject(new Error(response.statusText))
+      return Promise.reject(new Error(JSON.stringify({ status: response.status, statusText: response.statusText, message: response.body })))
     }
     const json = await response.json()
     return json

--- a/lib/apiCaller.js
+++ b/lib/apiCaller.js
@@ -42,12 +42,14 @@ const callApi = async (endpoint, method = 'get', body, cookies) => {
     })
 
     if (!response.ok) {
-      return Promise.reject(response)
+      // according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject
+      // it is useful to make reason an instanceof Error
+      return Promise.reject(new Error(response.statusText))
     }
     const json = await response.json()
     return json
   } catch (err) {
-    console.error('callAPI error ', err)
+    return Promise.reject(err)
   }
 }
 


### PR DESCRIPTION
# Pull Request VP-202
VP-202 api caller triggers onfulfilled callback insetad of onrejected callback when fetch fails



## Proposed Changes? 🤔
1.  Updated to return a Promise.reject in catch block.
2.  Update to return a Error in Promise.reject 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
