### PR TITLE
VP-582 revert git-describe usage.

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -66,9 +66,10 @@ const appReady = app.prepare().then(() => {
     req.localeDataScript = getLocaleDataScript(req.locale)
     // req.messages = dev ? {} : getMessages(req.locale)
     req.messages = getMessages(req.locale)
-    const { gitDescribeSync } = require('git-describe')
-    const gitInfo = gitDescribeSync()
-    req.messages.revision = process.env.REVISION || gitInfo.raw
+    // const { gitDescribeSync } = require('git-describe')
+    // const gitInfo = gitDescribeSync()
+    // req.messages.revision = process.env.REVISION || gitInfo.raw
+    req.messages.revision = process.env.REVISION
     next()
   })
 

--- a/x/aws/deploy-beta
+++ b/x/aws/deploy-beta
@@ -10,7 +10,7 @@ docker pull 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly2-alpha:master
 # retag
 docker image tag 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly2-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-beta:master
 
-# login to signapore
+# login to sydney
 source ${MY_DIR}/login-sydney
 
 # push the new image


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1.  remove usage of git-describe in startup server.js as this appears not to work on the fargate servers. 
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
