### PR TITLE
VP-516 rewrite the op card to use v theme card and simplify all the styling

### DIFF
--- a/__tests__/landing.spec.js
+++ b/__tests__/landing.spec.js
@@ -85,7 +85,8 @@ test('render landing page ', t => {
       <LandingTest {...props} />
     </Provider>)
   t.is(wrapper.find('h1').first().text(), 'volunteer yo—self.')
-
-  // there should be a list of ops
-  t.is(wrapper.find('.requestTitle').length, ops.length)
+  // there should be a list of ops each with a link pointing to detailed op page
+  for (const op of ops) {
+    t.is(wrapper.find(`a[href='/ops/${op._id}']`).length, 1)
+  }
 })

--- a/components/Op/OpCard.js
+++ b/components/Op/OpCard.js
@@ -5,6 +5,7 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import moment from 'moment'
+import { Card } from '../VTheme/VTheme'
 
 const getOpPageURL = (isArchived, opid) => {
   if (isArchived) {
@@ -14,7 +15,7 @@ const getOpPageURL = (isArchived, opid) => {
   }
 }
 // todo if image is not present then use a fallback.
-const OpCard = ({ size, op }) => {
+const OpCard = ({ op }) => {
   const cardImage = op.imgUrl ? op.imgUrl : '../../static/missingimage.svg'
   const draft = op.status === 'draft' ? 'DRAFT: ' : ''
   const isArchived = op.status === 'completed' || op.status === 'cancelled'
@@ -23,226 +24,30 @@ const OpCard = ({ size, op }) => {
   const startLocation = op.location ? `🏫 ${op.location}` : ''
   const startDuration = op.duration ? `⏱ ${op.duration}` : ''
   return (
-    <div>
-      <div className={`requestContainer${size}`}>
-        <Link href={getOpPageURL(isArchived, op._id)}>
-          <a>
-            <img className={`requestImg${size}`} src={cardImage} />
-            <p className={`requestTitle requestTitle${size}`}>
+    <Card>
+      <Link href={getOpPageURL(isArchived, op._id)}>
+        <a>
+          <img src={cardImage} />
+          <figcaption>
+            <h1>
               {draft}
               {op.name}
-            </p>
-            <p className={`requestDateTime${size}`}> {startLocation}</p>
-            <p className={`requestDateTime${size}`}> {startTime} </p>
-            <p className={`requestDateTime${size}`}> {startDuration}</p>
-            <p className={`requestDescription${size}`}>
+            </h1>
+            <p> {startLocation}</p>
+            <p> {startTime} </p>
+            <p> {startDuration}</p>
+            <p>
               {op.subtitle}
               <strong>{interestState}</strong>
             </p>
-          </a>
-        </Link>
-      </div>
-
-      <style jsx>{`
-        a {
-          text-decoration: none;
-        }
-
-        .requestContainerSmall {
-          -webkit-transition: all 0.2s;
-          width: 18.5rem;
-          letter-spacing: -0.3px;
-          line-height: 24px;
-          padding-bottom: 1rem;
-        }
-
-        .requestContainerSmall:hover {
-          -webkit-transition: all 0.2s;
-          transition: all 0.3s;
-          box-shadow: 1px 1px 12px 2px rgba(10,10,10,0.1);
-          transform: scale(1.1);
-          border-radius: 8px;
-        }
-
-        .requestContainerSmall:hover .requestTitleSmall {
-          -webkit-transition: all 0.2s;
-          transform: scale(0.9091);
-
-
-        }
-
-
-        .requestContainerSmall:hover .requestDateTimeSmall {
-          -webkit-transition: all 0.2s;
-          transform: scale(0.9091);
-          font-weight: bold;
-
-        }
-
-
-        .requestContainerSmall:hover .requestDescriptionSmall {
-          -webkit-transition: all 0.2s;
-          transform: scale(0.9091);
-
-        }
-        .requestContainerSmall:hover .requestImgSmall {
-          -webkit-transition: all 0.2s;
-          border-radius: 8px 8px 0 0;
-      
-        }
-
-        .requestContainerBig {
-
-          letter-spacing: -0.3px;
-          line-height: 24px;
-          margin-bottom: 4rem;
-        }
-
-        .requestImgSmall {
-          -webkit-transition: all 0.2s;
-          width: 100%;
-          height: 10rem;
-          background-color: rgba(0, 0, 0, 0);
-          object-fit: cover;
-          overflow: hidden;
-          object-position: center;
-        }
-
-        .requestImgBig {
-          width: 38rem;
-          height: 21rem;
-          background-color: rgba(0, 0, 0, 0);
-          object-fit: cover;
-          object-position: center;
-        }
-
-        .requestTitle {
-          margin-top: 0.5rem;
-          margin-bottom: 0.5rem;
-          vertical-align: middle;
-          color: #000;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          -webkit-box-orient: vertical;
-
-        }
-
-        .requestTitleSmall {
-          -webkit-transition: all 0.28s;
-          font-weight: 700;
-          font-size: 20px;
-          line-height: 1.4;
-          -webkit-line-clamp: 3;
-          overflow: hidden;
-        }
-
-        .requestTitleBig {
-          font-weight: 600;
-          font-size: 1.2rem;
-          letter-spacing: -0.8px;
-          line-height: 40px;
-        }
-
-        .requestDateTimeSmall {
-          vertical-align: middle;
-          margin-bottom: 0px;
-          font-weight: 500;
-          font-size: 16px;
-          color: #585858;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          display: -webkit-box;
-          -webkit-line-clamp: 1;
-          -webkit-box-orient: vertical;
-          margin-block-start: 0;
-          -webkit-transition: all 0.28s;
-        }
-
-        .requestDateTimeBig {
-          vertical-align: middle;
-          margin-bottom: 0px;
-          font-weight: 400;
-          font-size: 1rem;
-          color: #585858;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          display: -webkit-box;
-          -webkit-line-clamp: 1;
-          -webkit-box-orient: vertical;
-          line-height: 24px;
-          letter-spacing: -0.5px;
-        }
-
-        .requestDescriptionSmall {
-          -webkit-transition: all 0.28s;
-          vertical-align: top;
-          font-weight: 400;
-          font-size: 16px;
-          line-height: 24px;
-          color: #585858;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          -webkit-box-orient: vertical;
-          margin-block-start: 0;
-          margin-top: 8px;
-    
-        }
-
-        .requestDescriptionBig {
-          vertical-align: top;
-          font-weight: 400;
-          font-size: 1rem;
-          line-height: 24px;
-          color: #000;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          -webkit-box-orient: vertical;
-          letter-spacing: -0.3px;
-        }
-
-        .requestTitle :hover {
-          color: #6549aa;
-        }
-
-        @media screen and (max-width: 768px) {
-          .requestContainerSmall {
-            width: calc(100vw - 2rem);
-            margin-bottom: 1.5rem;
-          }
-          .requestContainerBig {
-            width: calc(100vw - 4rem);
-          }
-          .requestImgSmall {
-            height: 12rem;
-          }
-          .requestImgBig {
-            width: calc(100vw - 4rem);
-          }
-        }
-
-        @media screen and (min-width: 768px) and (max-width: 1281px) {
-          .requestContainerBig {
-            width: calc(50vw - 4rem);
-            margin-bottom: 2rem;
-          }
-          .requestImgBig {
-            height: 12rem;
-            width: calc(50vw - 5rem);
-          }
-        }
-      `}</style>
-    </div>
+          </figcaption>
+        </a>
+      </Link>
+    </Card>
   )
 }
 
 OpCard.propTypes = {
-  size: PropTypes.string.isRequired,
   op: PropTypes.shape({
     name: PropTypes.string.isRequired,
     subtitle: PropTypes.string,

--- a/components/Op/__tests__/OpCard.spec.js
+++ b/components/Op/__tests__/OpCard.spec.js
@@ -3,6 +3,7 @@ import test from 'ava'
 import { shallowWithIntl, mountWithIntl } from '../../../lib/react-intl-test-helper'
 import OpCard from '../OpCard'
 import ops from './Op.fixture'
+import moment from 'moment'
 
 test.before('Setup fixtures', (t) => {
   // Initial opportunities
@@ -75,7 +76,7 @@ test('ops with start and end date should be display start date', t => {
     <OpCard op={op} />
   )
   t.is(wrapper.find('figcaption').find('h1').text(), op.name)
-  t.is(wrapper.find('figcaption').find('p').at(1).text(), ' 🗓 12:26AM - Fri 24/05/19 ')
+  t.is(wrapper.find('figcaption').find('p').at(1).text(), moment(op.date[0]).format(' 🗓 h:mmA - ddd DD/MM/YY '))
 })
 
 test('op with an interested should append interested inside strong tag for subtitle', t => {
@@ -97,7 +98,7 @@ test('ops without location and duration should display P tags with blank', t => 
     <OpCard op={op} />
   )
   t.is(wrapper.find('figcaption').find('h1').text(), op.name)
-  t.is(wrapper.find('figcaption').find('p').at(1).text(), ' 🗓 12:26AM - Fri 24/05/19 ')
+  t.is(wrapper.find('figcaption').find('p').at(1).text(), moment(op.date[0]).format(' 🗓 h:mmA - ddd DD/MM/YY '))
   t.is(wrapper.find('figcaption').find('p').at(0).text().trim().length, 0)
   t.is(wrapper.find('figcaption').find('p').at(2).text().trim().length, 0)
 })

--- a/components/Op/__tests__/OpCard.spec.js
+++ b/components/Op/__tests__/OpCard.spec.js
@@ -40,7 +40,7 @@ test('op without an image should be displayed with default image', t => {
   t.is(wrapper.find('img').prop('src'), '../../static/missingimage.svg')
 })
 
-test.only('draft ops should display name with prefix DRAFT: ', t => {
+test('draft ops should display name with prefix DRAFT: ', t => {
   t.plan(1)
   const op = t.context.op
   op.status = 'draft'
@@ -49,6 +49,16 @@ test.only('draft ops should display name with prefix DRAFT: ', t => {
     <OpCard op={op} onPress={() => {}} />
   )
   t.is(wrapper.find('figcaption').find('h1').text(), `DRAFT: ${op.name}`)
+})
+
+
+test('Link on card should point to ops/<opportunity_id>', t => {
+  const op = t.context.op
+  const wrapper = mountWithIntl(
+    <OpCard op={op} />
+  )
+  let archivedOpLink = wrapper.find('Link').first().props().href
+  t.is((archivedOpLink), '/ops/' + op._id)
 })
 
 test('Link on cards in history tab, points to archived Opportunities.', t => {
@@ -67,8 +77,6 @@ test('ops with start and end date should be display start date', t => {
   )
   t.is(wrapper.find('figcaption').find('h1').text(), op.name)
   t.is(wrapper.find('figcaption').find('p').at(1).text(), ' 🗓 12:26AM - Fri 24/05/19 ')
-  // should have a real location
-  t.is(wrapper.find('figcaption').find('p').first().text(), ` 🏫 ${op.location}`)
 })
 
 test('op with an interested should append interested inside strong tag for subtitle', t => {
@@ -76,7 +84,23 @@ test('op with an interested should append interested inside strong tag for subti
   const wrapper = mountWithIntl(
     <OpCard op={op} />
   )
-  // should find interested status
+  // should find interested status inside a strong tag
   t.is(wrapper.find('strong').last().text(), ' - interested')
+  //should fin the op name suffix with - interested inside last p tag
   t.is(wrapper.find('figcaption').find('p').last().text(), `${op.subtitle} - interested`)
+})
+
+
+
+test('ops without location and duration should display P tags with blank', t => {
+  const op = t.context.ops[4]
+  op.location=undefined
+  op.duration=undefined
+  const wrapper = mountWithIntl(
+    <OpCard op={op} />
+  )
+  t.is(wrapper.find('figcaption').find('h1').text(), op.name)
+  t.is(wrapper.find('figcaption').find('p').at(1).text(), ' 🗓 12:26AM - Fri 24/05/19 ')
+  t.is(wrapper.find('figcaption').find('p').at(0).text().trim().length, 0)
+  t.is(wrapper.find('figcaption').find('p').at(2).text().trim().length, 0)
 })

--- a/components/Op/__tests__/OpCard.spec.js
+++ b/components/Op/__tests__/OpCard.spec.js
@@ -51,7 +51,6 @@ test('draft ops should display name with prefix DRAFT: ', t => {
   t.is(wrapper.find('figcaption').find('h1').text(), `DRAFT: ${op.name}`)
 })
 
-
 test('Link on card should point to ops/<opportunity_id>', t => {
   const op = t.context.op
   const wrapper = mountWithIntl(
@@ -86,16 +85,14 @@ test('op with an interested should append interested inside strong tag for subti
   )
   // should find interested status inside a strong tag
   t.is(wrapper.find('strong').last().text(), ' - interested')
-  //should fin the op name suffix with - interested inside last p tag
+  // should find the op name suffix with - interested inside last p tag
   t.is(wrapper.find('figcaption').find('p').last().text(), `${op.subtitle} - interested`)
 })
 
-
-
 test('ops without location and duration should display P tags with blank', t => {
   const op = t.context.ops[4]
-  op.location=undefined
-  op.duration=undefined
+  op.location = undefined
+  op.duration = undefined
   const wrapper = mountWithIntl(
     <OpCard op={op} />
   )

--- a/components/Op/__tests__/OpCard.spec.js
+++ b/components/Op/__tests__/OpCard.spec.js
@@ -14,85 +14,69 @@ test.before('Setup fixtures', (t) => {
   }
 })
 
-test('shallow the card with op', t => {
+test('Card include name imgUrl location duration and subtitle', t => {
   const op = t.context.op
   const wrapper = shallowWithIntl(
-    <OpCard size='Small' op={op} onPress={() => {}} />
+    <OpCard op={op} onPress={() => {}} />
   )
-  t.is(wrapper.find('.requestContainerSmall').length, 1)
-  t.is(wrapper.find('.requestTitleSmall').text(), op.name)
-  t.is(wrapper.find('.requestImgSmall').prop('src'), op.imgUrl)
-  t.is(wrapper.find('.requestDateTimeSmall').first().text(), ` 🏫 ${op.location}`)
-
-  t.truthy(wrapper.find('.requestContainerSmall').first().html().includes(op.location))
+  t.is(wrapper.find('a').length, 1)
+  t.is(wrapper.find('figcaption').find('h1').text(), op.name)
+  t.is(wrapper.find('img').prop('src'), op.imgUrl)
+  // four p tags for location time duration subtitle+interest
+  t.is(wrapper.find('figcaption').find('p').length, 4)
+  t.is(wrapper.find('figcaption').find('p').first().text(), ` 🏫 ${op.location}`)
+  // second p for time and should be blank as time is not set
+  t.is(wrapper.find('figcaption').find('p').at(1).text().trim().length, 0)
+  t.is(wrapper.find('figcaption').find('p').at(2).text(), ` ⏱ ${op.duration}`)
+  t.is(wrapper.find('figcaption').find('p').last().text(), `${op.subtitle}`)
 })
 
-test('op card with default image', t => {
-  const op = t.context.op
-
-  const wrapper = shallowWithIntl(
-    <OpCard size='Small' op={{ ...op, imgUrl: undefined }} onPress={() => {}} />
-  )
-  t.is(wrapper.find('.requestContainerSmall').length, 1)
-  t.is(wrapper.find('.requestTitleSmall').text(), op.name)
-  t.is(wrapper.find('.requestImgSmall').prop('src'), '../../static/missingimage.svg')
-})
-
-test('shallow the big card with op', t => {
+test('op without an image should be displayed with default image', t => {
   const op = t.context.op
 
   const wrapper = shallowWithIntl(
-    <OpCard size='Big' op={op} onPress={() => {}} />
+    <OpCard op={{ ...op, imgUrl: undefined }} onPress={() => {}} />
   )
-  t.is(wrapper.find('.requestContainerBig').length, 1)
-  t.is(wrapper.find('.requestTitleBig').text(), op.name)
+  t.is(wrapper.find('img').prop('src'), '../../static/missingimage.svg')
 })
 
-test('mount the small card with op', t => {
-  const op = t.context.op
-
-  const wrapper = mountWithIntl(
-    <OpCard size='Small' op={op} onPress={() => {}} />
-  )
-  t.is(wrapper.find('.requestContainerSmall').length, 1)
-  t.is(wrapper.find('.requestTitleSmall').text(), op.name)
-})
-
-test('show card for a draft op', t => {
+test.only('draft ops should display name with prefix DRAFT: ', t => {
+  t.plan(1)
   const op = t.context.op
   op.status = 'draft'
 
-  const wrapper = mountWithIntl(
-    <OpCard size='Big' op={op} onPress={() => {}} />
+  const wrapper = shallowWithIntl(
+    <OpCard op={op} onPress={() => {}} />
   )
-  t.is(wrapper.find('.requestContainerBig').length, 1)
-  t.regex(wrapper.find('.requestTitleBig').text(), /DRAFT.*/)
+  t.is(wrapper.find('figcaption').find('h1').text(), `DRAFT: ${op.name}`)
 })
 
 test('Link on cards in history tab, points to archived Opportunities.', t => {
   const archivedOp = t.context.archivedOp
   const wrapper = mountWithIntl(
-    <OpCard op={archivedOp} size='Small' />
+    <OpCard op={archivedOp} />
   )
   let archivedOpLink = wrapper.find('Link').first().props().href
   t.is((archivedOpLink), '/archivedops/' + archivedOp._id)
 })
 
-test('should have a date', t => {
+test('ops with start and end date should be display start date', t => {
   const op = t.context.ops[4]
   const wrapper = mountWithIntl(
-    <OpCard op={op} size='Small' />
+    <OpCard op={op} />
   )
-
+  t.is(wrapper.find('figcaption').find('h1').text(), op.name)
+  t.is(wrapper.find('figcaption').find('p').at(1).text(), ' 🗓 12:26AM - Fri 24/05/19 ')
   // should have a real location
-  t.is(wrapper.find('.requestDateTimeSmall').first().text(), ` 🏫 ${op.location}`)
+  t.is(wrapper.find('figcaption').find('p').first().text(), ` 🏫 ${op.location}`)
 })
 
-test('something interested in', t => {
+test('op with an interested should append interested inside strong tag for subtitle', t => {
   const op = t.context.ops[2]
   const wrapper = mountWithIntl(
-    <OpCard op={op} size='Small' />
+    <OpCard op={op} />
   )
   // should find interested status
   t.is(wrapper.find('strong').last().text(), ' - interested')
+  t.is(wrapper.find('figcaption').find('p').last().text(), `${op.subtitle} - interested`)
 })


### PR DESCRIPTION
## I do solemnly swear that I have:
- 
- [ ✔] Run `npm test` and all the tests pass.
- [✔ ] Run `npm run lint` and there are no warnings.
- [ ✔] Not decreased the overall test coverage?
- [✔ ] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Update OpCard to use VTheme to render Ops and remove inline styles
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
