### PR TITLE
VP-569 make activity name mandatory

### DIFF
--- a/components/Act/ActDetailForm.js
+++ b/components/Act/ActDetailForm.js
@@ -255,12 +255,13 @@ class ActDetailForm extends Component {
 
     // Only show error after a field is touched.
     const titleError = isFieldTouched('name') && getFieldError('name')
+    const durationError = isFieldTouched('duration') && getFieldError('duration')
     const orgMembership =
     this.props.me.orgMembership &&
     this.props.me.orgMembership.map(member => member.organisation)
     return (
       <div className='ActDetailForm'>
-        <Form hideRequiredMark colon={false}>
+        <Form colon={false}>
           <FormGrid>
             <DescriptionContainer>
               <TitleContainer>
@@ -289,7 +290,7 @@ class ActDetailForm extends Component {
                 >
                   {getFieldDecorator('name', {
                     rules: [{ required: true, message: 'Title is required' }]
-                  })(<Input placeholder='Title' />)}
+                  })(<Input placeholder='Title' required />)}
                 </Form.Item>
 
                 <Form.Item label={actSubtitle}>
@@ -379,7 +380,11 @@ class ActDetailForm extends Component {
             </DescriptionContainer>
             <InputContainer>
               <ShortInputContainer>
-                <Form.Item label={actCommitment}>
+                <Form.Item
+                  label={actCommitment}
+                  validateStatus={durationError ? 'error' : ''}
+                  help={durationError || ''}
+                >
                   {getFieldDecorator('duration', {
                     rules: [
                       {
@@ -519,7 +524,7 @@ class ActDetailForm extends Component {
               <P>
                 <FormattedMessage
                   id='act.SaveInstructions'
-                  defaultMessage='Save as Draft will allow you to preview the activity while Publish will make it available to everyone to view.'
+                  defaultMessage='Save as draft will allow you to preview the activity while Publish will make it available to everyone to view.'
                   description='Instructions for save and publish on activity details form'
                 />
               </P>

--- a/server/api/activity/__tests__/activity.spec.js
+++ b/server/api/activity/__tests__/activity.spec.js
@@ -158,7 +158,7 @@ test.serial('Should correctly add an activity with default image', async t => {
   const res = await request(server)
     .post('/api/activities')
     .send({
-      title: 'The first 400 metres',
+      name: 'The first 400 metres',
       subtitle: 'Launching into space step 3',
       description: 'Project to build a simple rocket that will reach 400m',
       duration: '4 hours'
@@ -167,7 +167,7 @@ test.serial('Should correctly add an activity with default image', async t => {
 
   t.is(res.status, 200)
 
-  const savedActivity = await Activity.findOne({ title: 'The first 400 metres' }).exec()
+  const savedActivity = await Activity.findOne({ name: 'The first 400 metres' }).exec()
   t.is(savedActivity.subtitle, 'Launching into space step 3')
 
   // activity has been given the default image

--- a/server/api/activity/activity.js
+++ b/server/api/activity/activity.js
@@ -4,10 +4,9 @@ const idvalidator = require('mongoose-id-validator')
 const { accessibleRecordsPlugin, accessibleFieldsPlugin } = require('@casl/mongoose')
 
 const ActivitySchema = new Schema({
-  name: String, // "Growing in the garden",
-  title: String, // deprecated - use name instead
+  name: { type: String, required: true }, // "Growing in the garden",
   subtitle: String, // "Growing digitally in the garden",
-  imgUrl: { type: 'String', required: true, default: '../.././static/img/activity/activity.png' },
+  imgUrl: { type: String, required: true, default: '../.././static/img/activity/activity.png' },
   description: String, // "Project to grow something in the garden",
   duration: String, // "15 Minutes",
   offerOrg: { type: Schema.Types.ObjectId, ref: 'Organisation' },


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1.  Made name required in activity.js
2. its already required in the form.
3. stopped hiding the required * indicator on the form
4. made duration not show an error when page first loaded.
5. removed deprecated title field.


## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
