### PR TITLE
Fix activity db validation handler (VP-763)

### DIFF
--- a/components/Act/ActDetailForm.js
+++ b/components/Act/ActDetailForm.js
@@ -106,7 +106,7 @@ class ActDetailForm extends Component {
         act.equipment = values.equipment
         act.description = values.description
         act.offerOrg = values.offerOrg && values.offerOrg.key
-        act.imgUrl = values.imgUrl
+        act.imgUrl = values.imgUrl === '' ? undefined : values.imgUrl
         act.tags = values.tags
         act.status = e.target.name === 'publish' ? 'active' : 'draft'
         // act.owner = (this.props.act.owner && this.props.op.owner._id) || this.props.me._id

--- a/package-lock.json
+++ b/package-lock.json
@@ -9741,15 +9741,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "git-describe": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/git-describe/-/git-describe-4.0.4.tgz",
-      "integrity": "sha512-L1X9OO1e4MusB4PzG9LXeXCQifRvyuoHTpuuZ521Qyxn/B0kWHWEOtsT4LsSfSNacZz0h4ZdYDsDG7f+SrA3hg==",
-      "requires": {
-        "lodash": "^4.17.11",
-        "semver": "^5.6.0"
-      }
-    },
     "glob": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "enzyme-adapter-react-16": "^1.15.1",
     "eslint-plugin-html": "^6.0.0",
     "express": "^4.16.4",
-    "git-describe": "^4.0.4",
     "glob": "^7.1.5",
     "hoist-non-react-statics": "^3.3.0",
     "ical-generator": "^1.8.2",

--- a/server/api/activity/__tests__/activity.spec.js
+++ b/server/api/activity/__tests__/activity.spec.js
@@ -343,7 +343,7 @@ test.serial('Mongoose validation should failed for empty string', async (t) => {
     .set('Cookie', [`idToken=${jwtData.idToken}`])
   t.is(res.status, 500)
   t.assert(res.body.errors != null, 'Assert there is an error in the request')
-  t.is(res.body.message,'Activity validation failed: imgUrl: Path `imgUrl` is required.')
+  t.is(res.body.message, 'Activity validation failed: imgUrl: Path `imgUrl` is required.')
   t.is(res.body.name, 'ValidationError')
 })
 

--- a/server/api/activity/__tests__/activity.spec.js
+++ b/server/api/activity/__tests__/activity.spec.js
@@ -324,6 +324,29 @@ test.serial('Should correctly add an activity with tags all having id properties
   t.is(t.context.tags.length, savedAct.tags.length)
 })
 
+test.serial('Mongoose validation should failed for empty string', async (t) => {
+  t.plan(4)
+  const tags = t.context.tags
+  const res = await request(server)
+    .post('/api/activities')
+    .send({
+      name: 'The first 400 metres',
+      subtitle: 'Launching into space step 3',
+      imgUrl: '',
+      description: 'Project to build a simple rocket that will reach 400m',
+      duration: '4 hours',
+      resource: '5 rockets and 6 volunteers',
+      tags: tags,
+      owner: t.context.people[0]._id
+    })
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+  t.is(res.status, 500)
+  t.assert(res.body.errors != null, 'Assert there is an error in the request')
+  t.is(res.body.message,'Activity validation failed: imgUrl: Path `imgUrl` is required.')
+  t.is(res.body.name, 'ValidationError')
+})
+
 test.serial('Should not add an activity with invalid tag ids', async t => {
   await request(server)
     .post('/api/activities')

--- a/server/api/activity/__tests__/activity.spec.js
+++ b/server/api/activity/__tests__/activity.spec.js
@@ -152,7 +152,7 @@ test.serial('Should correctly add an activity', async t => {
   t.is(savedActivity.subtitle, 'Launching into space step 3')
 })
 
-test.serial('Should correctly add an activity with default image', async t => {
+test.only('Should correctly add an activity with default image', async t => {
   t.plan(3)
 
   const res = await request(server)
@@ -171,6 +171,7 @@ test.serial('Should correctly add an activity with default image', async t => {
   t.is(savedActivity.subtitle, 'Launching into space step 3')
 
   // activity has been given the default image
+  console.log(savedActivity)
   t.is(savedActivity.imgUrl, '/static/img/activity/activity.png')
 })
 

--- a/server/api/activity/__tests__/activity.spec.js
+++ b/server/api/activity/__tests__/activity.spec.js
@@ -171,7 +171,7 @@ test.serial('Should correctly add an activity with default image', async t => {
   t.is(savedActivity.subtitle, 'Launching into space step 3')
 
   // activity has been given the default image
-  t.is(savedActivity.imgUrl, '../.././static/img/activity/activity.png')
+  t.is(savedActivity.imgUrl, '/static/img/activity/activity.png')
 })
 
 test.serial('Should correctly delete an activity', async t => {

--- a/server/api/activity/__tests__/activity.spec.js
+++ b/server/api/activity/__tests__/activity.spec.js
@@ -152,7 +152,7 @@ test.serial('Should correctly add an activity', async t => {
   t.is(savedActivity.subtitle, 'Launching into space step 3')
 })
 
-test.only('Should correctly add an activity with default image', async t => {
+test.serial('Should correctly add an activity with default image', async t => {
   t.plan(3)
 
   const res = await request(server)
@@ -171,7 +171,6 @@ test.only('Should correctly add an activity with default image', async t => {
   t.is(savedActivity.subtitle, 'Launching into space step 3')
 
   // activity has been given the default image
-  console.log(savedActivity)
   t.is(savedActivity.imgUrl, '/static/img/activity/activity.png')
 })
 

--- a/server/api/activity/activity.js
+++ b/server/api/activity/activity.js
@@ -6,7 +6,7 @@ const { accessibleRecordsPlugin, accessibleFieldsPlugin } = require('@casl/mongo
 const ActivitySchema = new Schema({
   name: { type: String, required: true }, // "Growing in the garden",
   subtitle: String, // "Growing digitally in the garden",
-  imgUrl: { type: String, required: true, default: '../.././static/img/activity/activity.png' },
+  imgUrl: { type: String, required: true, default: '/static/img/activity/activity.png' },
   description: String, // "Project to grow something in the garden",
   duration: String, // "15 Minutes",
   offerOrg: { type: Schema.Types.ObjectId, ref: 'Organisation' },

--- a/server/api/activity/activity.js
+++ b/server/api/activity/activity.js
@@ -36,12 +36,12 @@ const ActivitySchema = new Schema({
     default: []
   },
   status: {
-    type: 'String',
+    type: String,
     required: true,
     default: 'draft',
     enum: ['draft', 'active', 'retired']
   },
-  dateAdded: { type: 'Date', default: Date.now, required: true }
+  dateAdded: { type: Date, default: Date.now, required: true }
 })
 
 ActivitySchema.plugin(idvalidator)

--- a/server/api/person/__tests__/person.spec.js
+++ b/server/api/person/__tests__/person.spec.js
@@ -139,7 +139,6 @@ test.serial('add a person', async t => {
       .set('Accept', 'application/json')
       .set('Cookie', [`idToken=${jwtData.idToken}`])
       .expect(200)
-    console.log(resPerson.body)
     t.is(resPerson.body.name, p.name)
     t.is(resPerson.body.email, p.email)
 
@@ -151,7 +150,7 @@ test.serial('add a person', async t => {
 })
 
 test.serial('Update people', async t => {
-// update the person
+  // update the person
   const p = t.context.people[0]
   const id = p._id
   p.phone = '000 0000 000'
@@ -275,15 +274,11 @@ test.serial('Should correctly handle missing inputs', async t => {
     role: ['tester'],
     tags: []
   }
-  try {
-    const res = await request(server)
-      .post('/api/people')
-      .send(p)
-      .set('Accept', 'application/json')
-      .expect(200)
-    t.is(res.body.message, 'Person validation failed: email: Path `email` is required.')
-    t.is(res.body.name, 'ValidationError')
-  } catch (err) {
-    console.error('api/people', err)
-  }
+  const res = await request(server)
+    .post('/api/people')
+    .send(p)
+    .set('Accept', 'application/json')
+    .expect(500)
+  t.is(res.body.message, 'Person validation failed: email: Path `email` is required.')
+  t.is(res.body.name, 'ValidationError')
 })

--- a/server/services/helpers.js
+++ b/server/services/helpers.js
@@ -10,6 +10,9 @@ const _ = require('lodash')
 
 // Since DELETE doesn't return the _id of deleted item by default
 module.exports.formatResponse = function (req, res, next) {
-  if (req.crudify.err) console.error('formatResponse:', _.get(req, 'crudify.err.message'))
+  if (req.crudify.err) {
+    console.error('formatResponse:', _.get(req, 'crudify.err.message'))
+    res.status(500).send(req.crudify.err)
+  }
   return res.json(req.crudify.err || (req.method === 'DELETE' ? req.params : req.crudify.result))
 }


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title 
## Proposed Changes? 🤔
1.  Throw 500 error for any mongoose validation error instead of 200 error
2. Change default image url path for activity schema 
3. Remove git-describe package since we are not using it

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
