### PR TITLE
VP-795 handler page for action tokens

### DIFF
--- a/assets/voluntarily.less
+++ b/assets/voluntarily.less
@@ -99,3 +99,25 @@ p {
 img {
 object-fit: contain;
 }
+
+
+dl {
+  width: 100%;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+}
+dt {
+  float: left;
+  width: 20%;
+  /* adjust the width; make sure the total of both is 100% */
+  padding: 0;
+  margin: 0;
+}
+dd {
+  float: left;
+  width: 80%;
+  /* adjust the width; make sure the total of both is 100% */
+  padding: 0;
+  margin: 0;
+}

--- a/components/Header/HeaderMenu.js
+++ b/components/Header/HeaderMenu.js
@@ -23,11 +23,11 @@ export default () => [
     text: 'Organisations'
 
   },
-  {
-    key: 'help',
-    text: 'Help',
-    href: 'https://voluntarily.atlassian.net/servicedesk/customer/portals'
-  },
+  // {
+  //   key: 'help',
+  //   text: 'Help',
+  //   href: 'https://voluntarily.atlassian.net/servicedesk/customer/portals'
+  // },
   {
     key: 'hsignin',
     href: '/auth/sign-in',

--- a/components/Navigation/Navigation.js
+++ b/components/Navigation/Navigation.js
@@ -30,6 +30,7 @@ const Navigation = ({ items, defaultItem, router, me, ...props }) => {
       {items.map(item => (
         <Menu.Item key={item.key}>
           {/* don't do prefetch during testing */}
+          {/* // TODO: [VP-800] in menu if link is offset use A instead of Link to avoid Next warning */}
           <Link key={item.href} href={item.href}>
             <a>{item.text}</a>
           </Link>

--- a/components/__tests__/Header.spec.js
+++ b/components/__tests__/Header.spec.js
@@ -25,7 +25,7 @@ test('renders the Header and Navigation for anon user', t => {
   )
 
   t.truthy(wrapper.find('Link').first().containsMatchingElement(<img />))
-  t.is(wrapper.find('a').length, 6)
+  t.is(wrapper.find('a').length, 5)
   t.is(wrapper.find('a').last().text(), 'Sign up')
   t.snapshot()
 
@@ -53,7 +53,7 @@ test('renders the Header and Navigation for authenticated user', t => {
   )
 
   t.truthy(wrapper.find('Link').first().containsMatchingElement(<img />))
-  t.is(wrapper.find('a').length, 6)
+  t.is(wrapper.find('a').length, 5)
   t.is(wrapper.find('a').last().text(), 'Sign Out')
   t.snapshot()
 })

--- a/lib/sec/__test__/actiontoken.spec.js
+++ b/lib/sec/__test__/actiontoken.spec.js
@@ -42,6 +42,7 @@ test('test missing action', async t => {
 test('test bad token', async t => {
   t.plan(1)
   const payload = {
+    landingUrl: '/random',
     data: {
       foo: 'bar'
     },

--- a/lib/sec/actiontoken.js
+++ b/lib/sec/actiontoken.js
@@ -22,7 +22,7 @@ export const makeURLToken = (content) => {
   }
   var token = jwt.sign(content, privateKey(), options)
 
-  return `${config.appUrl}/${content.landingUrl}?token=${token}`
+  return `${config.appUrl}${content.landingUrl}?token=${token}`
 }
 
 // will throw if jwt verify fails, caller must work out what to do next)
@@ -33,7 +33,8 @@ export const handleURLToken = (token, actions) => {
   const content = jwt.verify(token, publicKey(), options)
   // check the action
   if (Object.prototype.hasOwnProperty.call(actions, content.action)) {
-    return actions[content.action](content.data)
+    actions[content.action](content.data)
+    return content
   }
   return false
 }

--- a/lib/sec/keys.js
+++ b/lib/sec/keys.js
@@ -3,17 +3,17 @@ const path = require('path')
 
 const keys = {
   development: {
-    VLY_PRIVATE_KEY: fs.readFileSync(path.resolve(__dirname, './dev.priv.pem')).toString(),
-    VLY_PUBLIC_KEY: fs.readFileSync(path.resolve(__dirname, './dev.pub.pem')).toString()
+    VLY_PRIVATE_KEY: fs.readFileSync(path.resolve(process.cwd(), 'lib/sec/dev.priv.pem')).toString(),
+    VLY_PUBLIC_KEY: fs.readFileSync(path.resolve(process.cwd(), 'lib/sec/dev.pub.pem')).toString()
   },
 
   test: {
-    VLY_PRIVATE_KEY: fs.readFileSync(path.resolve(__dirname, './test.priv.pem')).toString(),
-    VLY_PUBLIC_KEY: fs.readFileSync(path.resolve(__dirname, './test.pub.pem')).toString()
+    VLY_PRIVATE_KEY: fs.readFileSync(path.resolve(process.cwd(), 'lib/sec/test.priv.pem')).toString(),
+    VLY_PUBLIC_KEY: fs.readFileSync(path.resolve(process.cwd(), 'lib/sec/test.pub.pem')).toString()
   },
 
   production: {
-    VLY_PUBLIC_KEY: process.env.VLY_PUBLIC_KEY || fs.readFileSync(path.resolve(__dirname, './prod.pub.pem')).toString(),
+    VLY_PUBLIC_KEY: process.env.VLY_PUBLIC_KEY || fs.readFileSync(path.resolve(process.cwd(), 'lib/sec/prod.pub.pem')).toString(),
     VLY_PRIVATE_KEY: process.env.VLY_PUBLIC_KEY || 'Please set the private key'
   }
 }

--- a/pages/api/token/[cmd].js
+++ b/pages/api/token/[cmd].js
@@ -1,0 +1,20 @@
+import { makeURLToken } from '../../../lib/sec/actiontoken'
+
+/* the api/doToken/getToken endpoint returns a valid token
+  required to carry out the desired action.
+e.g https://localhost:3122/api/token/mintToken?action=log&data="hello world"
+*/
+
+export default async (req, res) => {
+  if (!req.session.isAuthenticated) res.status(403).end()
+
+  try {
+    const { cmd } = req.query
+    const payload = req.query
+    payload.token = makeURLToken(payload)
+    return res.json(payload)
+  } catch (e) {
+    console.log('doToken:', e)
+    res.status(500).end()
+  }
+}

--- a/pages/api/token/[cmd].js
+++ b/pages/api/token/[cmd].js
@@ -9,7 +9,6 @@ export default async (req, res) => {
   if (!req.session.isAuthenticated) res.status(403).end()
 
   try {
-    const { cmd } = req.query
     const payload = req.query
     payload.token = makeURLToken(payload)
     return res.json(payload)

--- a/pages/api/token/index.js
+++ b/pages/api/token/index.js
@@ -1,0 +1,3 @@
+import doToken from './token'
+
+export default doToken

--- a/pages/api/token/token.js
+++ b/pages/api/token/token.js
@@ -1,0 +1,30 @@
+import { handleURLToken } from '../../../lib/sec/actiontoken'
+
+/* the doToken endpoint handles a URL token request
+  and then forwards to the requested page.
+
+*/
+const actionTable = {
+  log: props => console.log('log', props)
+}
+
+export default async (req, res) => {
+  console.log('token', req.query)
+  const { token } = req.query
+  // request must have a ?token=
+  if (!token) {
+    return res.status(403).end()
+  }
+  // if user is not authenticated then get them in.
+  if (!req.session.isAuthenticated) {
+    console.log('signing thru to', req.originalUrl)
+    res.redirect(`/auth/sign-thru?redirect=${req.originalUrl}`)
+  }
+  try {
+    const payload = handleURLToken(token, actionTable)
+    res.redirect(payload.redirectUrl)
+  } catch (e) {
+    console.log('doToken:', e)
+    res.status(500).end()
+  }
+}

--- a/pages/auth/sign-thru.js
+++ b/pages/auth/sign-thru.js
@@ -1,0 +1,15 @@
+import { authorize } from '../../lib/auth/auth0'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export const SignThru = () => {
+  const router = useRouter()
+  const redirectUrl = router.query.redirect || '/home'
+  useEffect(() => {
+    authorize({ redirectUrl })
+  }, [])
+
+  return null
+}
+
+export default SignThru

--- a/pages/test/test-token.js
+++ b/pages/test/test-token.js
@@ -1,0 +1,57 @@
+import publicPage from '../../hocs/publicPage'
+import React, { useState, useEffect } from 'react'
+import { FullPage } from '../../components/VTheme/VTheme'
+import callApi from '../../lib/callApi'
+import queryString from 'querystring'
+import { useRouter } from 'next/router'
+
+const Payload = ({ payload }) =>
+  <dl>
+    <dt>landingUrl</dt><dd>{payload.landingUrl}</dd>
+    <dt>redirectUrl</dt><dd>{payload.redirectUrl}</dd>
+    <dt>data</dt><dd>{JSON.stringify(payload.data)}</dd>
+    <dt>action</dt><dd>{payload.action}</dd>
+    <dt>expiresIn</dt><dd>{payload.expiresIn}</dd>
+    <dt>link</dt><dd><a href={payload.token}>Follow Link</a></dd>
+    <dt>token</dt><dd>{payload.token}</dd>
+
+  </dl>
+
+export const TestToken = () => {
+  const [link, setLink] = useState('')
+  const [refresh, setRefresh] = useState(0)
+  const router = useRouter()
+  console.log(router.pathname, router.query)
+  const payload = {
+    landingUrl: '/api/token',
+    redirectUrl: '/test/test-token',
+    data: JSON.stringify({
+      msg: 'came here to do this',
+      count: refresh
+    }),
+    action: 'log',
+    expiresIn: '2h'
+  }
+  useEffect(() => {
+    async function fetchData () {
+      try {
+        const data = await callApi(`token/log?${queryString.stringify(payload)}`)
+        console.log(data)
+        setLink(data)
+      } catch (e) {
+        console.error('getToken:', e)
+      }
+    }
+    fetchData()
+  }, [refresh])
+
+  const handleClick = () => {
+    setRefresh(refresh + 1)
+  }
+  return (
+    <FullPage>
+      <Payload payload={link}>{link}</Payload>
+      <button onClick={handleClick}>Refresh Token URL</button>
+    </FullPage>)
+}
+export default publicPage(TestToken)


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. test/test-token page asks api for an action token. clicking the token link hits a page that validates the token link, carries out the requested action and then forwards the to the redirected page.
2. if person using link is not signed in they go through a sign in process
3. add sign-thru.js a neater way to carry a destination through the sign in process.

## Additional Info.🧐
This function will be used to generate emails containing self-registration links.

## Screenshots 📷
 /test/test-token
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/1596437/68997845-d3c0aa80-090f-11ea-91cf-7c86d7fa5cf9.png">
