### PR TITLE
Configure ava to retain lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "timeout": "2m",
     "babel": {
       "testOptions": {
+        "retainLines": true,
         "plugins": [
           "@babel/plugin-syntax-jsx"
         ],


### PR DESCRIPTION
When tests fail this will ensure ava displays the correct line of the
error in the unit test.

## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Set the "retainLines" config value in the ava config so that unit test errors are accurate

## Additional Info.🧐

When running ava tests that fail they were showing the wrong line, e.g. (line 28 is highlighted below)

```
  /home/node/app/server/api/school-lookup/__tests__/school-lookup.spec.js:28

   27:   const requiredFields = SchoolLookUp.schema.requiredPaths(true)
   28:                                                                 
   29:   const error = await t.throwsAsync(SchoolLookUp.create({}))    

  Test failed via `t.fail()`
```

After this config change the output looks like this:

```
  /home/node/app/server/api/school-lookup/__tests__/school-lookup.spec.js:19

   18:           
   19:   t.fail()
   20:           

  Test failed via `t.fail()`
```

There's a bit more discussion of this issue here: https://github.com/avajs/ava/issues/1980