### PR TITLE
restore props to OpDetail so router is found

### DIFF
--- a/pages/op/opdetailpage.js
+++ b/pages/op/opdetailpage.js
@@ -219,7 +219,7 @@ export class OpDetailPage extends Component {
             >
               <FormattedMessage id='op.edit' defaultMessage='Edit' description='Button to edit an opportunity' />
             </Button>}
-          <OpDetail op={op} router={this.props.router} />
+          <OpDetail op={op} {...this.props} />
           <Divider />
           <OpVolunteerInterestSection
             isAuthenticated={this.props.isAuthenticated}


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. OpDetail requires a router in the props to be passed down to the social buttons  - at run time this doesn't require any special handling but in the functional test for opdetailpage we appear to have to pass in the router through the props due to the mock router we are using.
2. recommend in the future we find a better way to pass in the router 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
