### PR TITLE
bug/VP-825/signin_icon_misaligned: removed margin right on icon so it…

### DIFF
--- a/components/Navigation/Navigation.js
+++ b/components/Navigation/Navigation.js
@@ -11,6 +11,10 @@ const StyledMenu = styled(Menu)`
 const StyledAvatar = styled(Avatar)`
   background-color: #fff;
 
+  .anticon-user {
+    margin-right: 0px;
+  }
+
   .ant-imgUrl > i {
     margin-right: 0px;
   }


### PR DESCRIPTION
… is now centered

## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. When signed out, the icon avatar is not aligned in the center
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original
![image](https://user-images.githubusercontent.com/32690491/70007865-d5a89000-15d6-11ea-8cc5-bb7356f9a0b8.png)


### Updated

![image](https://user-images.githubusercontent.com/32690491/70007876-de996180-15d6-11ea-8b90-9696311465cd.png)

