### PR TITLE
VP-871 Add API end point to send school invitation emails

### DIFF
--- a/emails/inviteSchool/html.pug
+++ b/emails/inviteSchool/html.pug
@@ -1,0 +1,18 @@
+//- expects locals of {
+//-   inviteeName: person receiving email
+//-   schoolName: school to be activated
+//-   adminMsg: custom additional message from administrator to invitee
+//-   inviteButtonLink: link to invite person to sign up and activate school
+//- }
+extends ../theme/layout.pug
+
+block copy
+  p Hi #{inviteeName},
+  p #{schoolName} has been selected to be one of the first schools to take part in our Inspiring the Future New Zealand trials.
+  p By now you should know all about Inspiring the Future and how the program can benefit you and your school.
+  p Before we start finding you volunteers for your Inspiring the Future activity, #{schoolName} needs to be set up on our online platform.
+  p Click the button below to sign up, activate #{schoolName} on the platform and create an Inspiring the Future activity to run.
+  p #{adminMsg}
+
+block copybutton
+  a(href=inviteButtonLink class='mobile-button') Sign up and activate your school

--- a/emails/inviteSchool/subject.pug
+++ b/emails/inviteSchool/subject.pug
@@ -1,0 +1,1 @@
+| Your school has been invited to Voluntarily

--- a/emails/theme/footer.pug
+++ b/emails/theme/footer.pug
@@ -7,10 +7,11 @@ table(width="100%")
             table(width="500" border="0" cellspacing="0" cellpadding="0" align="center" class="responsive-table")
               tr
                 td(align="center" valign="middle" style="font-size: 12px; line-height: 18px; color:#aaaaaa;")
-                  span(class="appleFooter") 
+                  span(class="appleFooter")
                     block footer
-                      p Voluntarily is an initiative run by the 
+                      p Voluntarily is an initiative run by the
                         a( href="http://www.pamfergusson.co.nz/") Pam Fergusson Charitable Trust
-                      span This email was sent to #{to.email}. You're receiving this email because you expressed interest in Voluntarily Opportunities. 
-                      span If you'd rather not see us in your inbox in the future, please set your 
-                        a(href=to.href) profile to inactive.
+                        if (to && to.email && to.href)
+                          span This email was sent to #{to.email}. You're receiving this email because you expressed interest in Voluntarily Opportunities.
+                          span If you'd rather not see us in your inbox in the future, please set your
+                            a(href=to.href) profile to inactive.

--- a/lib/sec/actiontoken.js
+++ b/lib/sec/actiontoken.js
@@ -2,8 +2,8 @@
   and carry out an action
 */
 
-import { privateKey, publicKey } from './keys'
-import jwt from 'jsonwebtoken'
+const { privateKey, publicKey } = require('./keys')
+const jwt = require('jsonwebtoken')
 const { config } = require('../../config/config')
 
 // expecting content to include
@@ -14,7 +14,7 @@ const { config } = require('../../config/config')
 //   action - action to carry out e.g. registerOrgMember, must be known
 //   expiresIn: '1h'
 // }
-export const makeURLToken = (content) => {
+const makeURLToken = (content) => {
   // create token
   const options = {
     algorithm: 'RS256',
@@ -26,7 +26,7 @@ export const makeURLToken = (content) => {
 }
 
 // will throw if jwt verify fails, caller must work out what to do next)
-export const handleURLToken = (token, actions) => {
+const handleURLToken = (token, actions) => {
   const options = {
     algorithm: 'RS256'
   }
@@ -37,4 +37,9 @@ export const handleURLToken = (token, actions) => {
     return content
   }
   return false
+}
+
+module.exports = {
+  makeURLToken,
+  handleURLToken
 }

--- a/lib/sec/keys.js
+++ b/lib/sec/keys.js
@@ -18,5 +18,10 @@ const keys = {
   }
 }
 
-export const privateKey = () => keys[process.env.NODE_ENV].VLY_PRIVATE_KEY
-export const publicKey = () => keys[process.env.NODE_ENV].VLY_PUBLIC_KEY
+const privateKey = () => keys[process.env.NODE_ENV].VLY_PRIVATE_KEY
+const publicKey = () => keys[process.env.NODE_ENV].VLY_PUBLIC_KEY
+
+module.exports = {
+  privateKey,
+  publicKey
+}

--- a/server/api/school-invite/__tests__/school-invite.controller.spec.js
+++ b/server/api/school-invite/__tests__/school-invite.controller.spec.js
@@ -1,0 +1,136 @@
+import test from 'ava'
+import MockExpressRequest from 'mock-express-request'
+import MockExpressResponse from 'mock-express-response'
+import { SchoolInvite } from '../school-invite.controller'
+import { Role } from '../../../services/authorize/role'
+import MemoryMongo from '../../../util/test-memory-mongo'
+import schoolLookUpFixtures from '../../school-lookup/__tests__/school-lookup.fixture'
+import SchoolLookUp from '../../school-lookup/school-lookup'
+import nodemailerMock from 'nodemailer-mock'
+
+test.before('before connect to database', async (t) => {
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
+  await SchoolLookUp.create(schoolLookUpFixtures)
+})
+
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
+})
+
+test('Invalid HTTP methods', async (t) => {
+  for (const method of ['GET', 'PUT', 'DELETE']) {
+    const request = new MockExpressRequest({ method })
+    const response = new MockExpressResponse()
+
+    await SchoolInvite.send(request, response)
+
+    t.is(404, response.statusCode, `${method} requests should result in 404`)
+  }
+})
+
+test('Not logged in', async (t) => {
+  const request = new MockExpressRequest({ method: 'POST' })
+  const response = new MockExpressResponse()
+
+  await SchoolInvite.send(request, response)
+
+  t.is(403, response.statusCode, `Received ${response.statusCode} instead of 403`)
+})
+
+test('Valid login, missing body', async (t) => {
+  const request = new MockExpressRequest({
+    method: 'POST',
+    session: {
+      isAuthenticated: true,
+      me: {
+        role: [Role.ADMIN]
+      }
+    }
+  })
+  const response = new MockExpressResponse()
+
+  await SchoolInvite.send(request, response)
+
+  t.is(400, response.statusCode, `Received ${response.statusCode} instead of 400`)
+})
+
+test('Valid login, missing required data', async (t) => {
+  const request = new MockExpressRequest({
+    method: 'POST',
+    session: {
+      isAuthenticated: true,
+      me: {
+        role: [Role.ADMIN]
+      }
+    },
+    body: {
+      invalidField: 'test'
+    }
+  })
+  const response = new MockExpressResponse()
+
+  await SchoolInvite.send(request, response)
+
+  t.is(400, response.statusCode, `Received ${response.statusCode} instead of 400`)
+  t.deepEqual({
+    message: 'Missing required fields (schoolId, inviteeName, inviteeEmail, invitationMessage)'
+  }, response._getJSON())
+})
+
+test('Valid login, required data, invalid school id', async (t) => {
+  const request = new MockExpressRequest({
+    method: 'POST',
+    session: {
+      isAuthenticated: true,
+      me: {
+        role: [Role.ADMIN]
+      }
+    },
+    body: {
+      schoolId: 2,
+      inviteeName: 'Test Testington',
+      inviteeEmail: 'test@example.com',
+      invitationMessage: 'Hello there'
+    }
+  })
+  const response = new MockExpressResponse()
+
+  await SchoolInvite.send(request, response)
+
+  t.is(400, response.statusCode, `Received ${response.statusCode} instead of 400`)
+  t.deepEqual(response._getJSON(), { message: 'School not found' })
+})
+
+test('Valid login, required data, valid school id', async (t) => {
+  const request = new MockExpressRequest({
+    method: 'POST',
+    session: {
+      isAuthenticated: true,
+      me: {
+        role: [Role.ADMIN]
+      }
+    },
+    body: {
+      schoolId: 1,
+      inviteeName: 'Test Testington',
+      inviteeEmail: 'test@example.com',
+      invitationMessage: 'Hello there'
+    }
+  })
+  const response = new MockExpressResponse()
+
+  await SchoolInvite.send(request, response)
+
+  t.is(200, response.statusCode, `Received ${response.statusCode} instead of 200`)
+  t.deepEqual(response._getJSON(), { message: 'Invitation email sent successfully' })
+
+  const sentEmail = nodemailerMock.mock.getSentMail()
+  t.is(sentEmail.length, 1)
+
+  const email = sentEmail.pop()
+
+  t.truthy(email.text.includes('Test Testington'), 'Name should be in message')
+  t.truthy(email.text.includes('Hello there'), 'Invitation message should be in message')
+  t.truthy(email.text.includes(schoolLookUpFixtures[0].name), 'School name should be in message')
+})

--- a/server/api/school-invite/school-invite.controller.js
+++ b/server/api/school-invite/school-invite.controller.js
@@ -1,0 +1,127 @@
+const { makeURLToken } = require('../../../lib/sec/actiontoken')
+const { Role } = require('../../services/authorize/role')
+const SchoolLookUp = require('../school-lookup/school-lookup')
+const { getTransport } = require('../../services/email/email')
+const Email = require('email-templates')
+const { config } = require('../../../config/config')
+
+class SchoolInvite {
+  static async send (req, res) {
+    res.setHeader('Content-Type', 'application/json')
+
+    if (!this.isPostRequest(req)) {
+      return res.status(404).end()
+    }
+
+    if (!this.userCanSendInvite(req)) {
+      return res.status(403).end()
+    }
+
+    if (!req.body) {
+      return res.status(400).end()
+    }
+
+    const postData = req.body
+
+    const missingFields = this.getMissingRequiredFields(postData)
+
+    if (missingFields.length > 0) {
+      return res.status(400).send({
+        message: `Missing required fields (${missingFields.join(', ')})`
+      })
+    }
+
+    const school = await SchoolLookUp.findOne({ schoolId: postData.schoolId })
+
+    if (!school) {
+      return res.status(400).send({
+        message: 'School not found'
+      })
+    }
+
+    const payload = {
+      landingUrl: '/not-yet-implemented',
+      redirectUrl: '/not-yet-implemented',
+      data: {},
+      action: 'join',
+      expiresIn: '2d'
+    }
+
+    const tokenUrl = makeURLToken(payload)
+
+    const emailSuccess = await this.sendInviteEmail({
+      inviteeName: postData.inviteeName,
+      inviteeEmail: postData.inviteeEmail,
+      invitationMessage: postData.invitationMessage,
+      schoolName: school.name,
+      tokenUrl: tokenUrl
+    })
+
+    if (emailSuccess) {
+      return res.send({
+        message: 'Invitation email sent successfully'
+      })
+    } else {
+      return res.status(500).send({
+        message: 'Invitation email failed to send'
+      })
+    }
+  }
+
+  static isPostRequest (req) {
+    return (req.method === 'POST')
+  }
+
+  static userCanSendInvite (req) {
+    return (
+      req.session &&
+      req.session.isAuthenticated &&
+      req.session.me.role.includes(Role.ADMIN)
+    )
+  }
+
+  static getMissingRequiredFields (postData) {
+    const missingFields = []
+
+    for (const requiredField of ['schoolId', 'inviteeName', 'inviteeEmail', 'invitationMessage']) {
+      if (!postData[requiredField]) {
+        missingFields.push(requiredField)
+      }
+    }
+
+    return missingFields
+  }
+
+  static async sendInviteEmail (emailData) {
+    const emailTransport = await getTransport()
+
+    const inviteEmail = new Email({
+      message: {
+        from: 'no-reply@voluntarily.nz'
+      },
+      send: true,
+      subjectPrefix: config.env === 'production' ? '' : `[${config.env.toUpperCase()}] `,
+      textOnly: config.onlyEmailText,
+      transport: emailTransport
+    })
+
+    const sentEmailInfo = await inviteEmail.send({
+      template: 'inviteSchool',
+      message: {
+        to: emailData.inviteeEmail
+      },
+      locals: {
+        inviteeName: emailData.inviteeName,
+        schoolName: emailData.schoolName,
+        adminMsg: emailData.invitationMessage,
+        inviteButtonLink: emailData.tokenUrl
+      }
+    })
+
+    return (sentEmailInfo.accepted.length > 0)
+  }
+}
+
+module.exports = {
+  SchoolInvite
+}

--- a/server/api/school-invite/school-invite.routes.js
+++ b/server/api/school-invite/school-invite.routes.js
@@ -1,0 +1,5 @@
+const { SchoolInvite } = require('./school-invite.controller')
+
+module.exports = (server) => {
+  server.post('/api/notify/school-invite', SchoolInvite.send)
+}


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Add API to send school invitation email

## Additional Info.🧐

Still more work to do on handling clicks on the magic button in the email but this is the first step.
