### PR TITLE
VP-883 Add test-all script for CI test runs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ test_task:
     fingerprint_script: cat package-lock.json
     populate_script: MONGOMS_DOWNLOAD_MIRROR="http://downloads.mongodb.org" MONGOMS_VERSION="4.0.5" MONGOMS_DISABLE_POSTINSTALL=1 npm ci
   test_script:
-    - npm test -- --tap --verbose --serial --fail-fast
+    - npm test-all -- --tap --verbose --serial --fail-fast
     - unset CIRRUS_CI
     - ./node_modules/codecov/bin/codecov --disable=gcov
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ test_task:
     fingerprint_script: cat package-lock.json
     populate_script: MONGOMS_DOWNLOAD_MIRROR="http://downloads.mongodb.org" MONGOMS_VERSION="4.0.5" MONGOMS_DISABLE_POSTINSTALL=1 npm ci
   test_script:
-    - npm test-all -- --tap --verbose --serial --fail-fast
+    - npm run test-all -- --tap --verbose --serial --fail-fast
     - unset CIRRUS_CI
     - ./node_modules/codecov/bin/codecov --disable=gcov
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server/server.js",
   "scripts": {
     "test": "cross-env NODE_ENV=test PORT=8080 node_modules/.bin/nyc node --no-deprecation node_modules/ava/cli.js --serial --fail-fast",
+    "test-all": "cross-env NODE_ENV=test PORT=8080 node_modules/.bin/nyc --all node --no-deprecation node_modules/ava/cli.js --serial --fail-fast",
     "watch:test": "npm run test -- --watch",
     "end-to-end-test": "run-p -r dev testcafe-tests",
     "testcafe-tests": "wait-on -t 60000 -w 2000 -l http://localhost:3122 && node node_modules/testcafe/bin/testcafe.js firefox:headless systemtest/landing.test.js",
@@ -172,7 +173,6 @@
     ]
   },
   "nyc": {
-    "all": true,
     "include": [
       "pages/**/*.js",
       "components/**/*.js",


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Turn off nyc "all" config by default and add a script that turns it on for continuous integration test runs.
