### PR TITLE
VP-879 Add /my/org/op call to redirect to my school

### DIFF
--- a/server/api/goal/__init__/goal.init.js
+++ b/server/api/goal/__init__/goal.init.js
@@ -20,7 +20,7 @@ export default [
       activities you should volunteer for and helps teachers select 
       the range of helpers they need for an activity`,
     preconditions: [],
-    startLink: '/home', // should be /profile#edit
+    startLink: '/my/person',
     language: 'en',
     category: 'Getting Started',
     rank: 1,
@@ -51,7 +51,7 @@ Don't worry if you have started the process but don't think it will be
 completed in time - there are ways we can handle that.
 `,
     preconditions: [],
-    startLink: '/home', // should be /profile#edit
+    startLink: '/todo',
     language: 'en',
     category: 'Getting Started',
     rank: 2,
@@ -95,7 +95,7 @@ Once you have done that return to this page by clicking the
 This card will disappear when the profile is complete
 `,
     imgUrl: '/static/img/actions/teacherSetup.png',
-    startLink: '/orgs/5d9fe6804eb179218c8d1d32',
+    startLink: '/my/org/op',
     category: 'Get Started for Teachers',
     rank: 1,
     evaluation: () => { console.log('Tell us about your school'); return false }
@@ -114,7 +114,7 @@ This creates a new Activity page where you can setup the time and place details
 Once Published we will start finding volunteers
 `,
     imgurl: '/static/img/actions/itf.png',
-    startLink: '/acts/5dbb7c0550ebca11d9866859',
+    startLink: '/acts',
     category: 'Get Started for Teachers',
     rank: 2,
     evaluation: () => { console.log('does person have first-volunteer-activity badge'); return false }

--- a/server/api/member/__tests__/findMy.spec.js
+++ b/server/api/member/__tests__/findMy.spec.js
@@ -1,0 +1,107 @@
+import test from 'ava'
+import request from 'supertest'
+import Member from '../../../../server/api/member/member'
+import { MemberStatus } from '../../../../server/api/member/member.constants'
+import Organisation from '../../../../server/api/organisation/organisation'
+import orgs from '../../../../server/api/organisation/__tests__/organisation.fixture'
+import Person from '../../../../server/api/person/person'
+import people from '../../../../server/api/person/__tests__/person.fixture'
+import { jwtData, jwtDataDali } from '../../../../server/middleware/session/__tests__/setSession.fixture'
+import { appReady, server } from '../../../../server/server'
+import MemoryMongo from '../../../../server/util/test-memory-mongo'
+
+test.before('before connect to database', async (t) => {
+  try {
+    t.context.memMongo = new MemoryMongo()
+    await t.context.memMongo.start()
+    t.context.orgs = await Organisation.create(orgs).catch(() => 'Unable to create orgs')
+    t.context.org = t.context.orgs[0]
+
+    t.context.people = await Person.create(people).catch((err) => `Unable to create people: ${err}`)
+    t.context.andrew = t.context.people[0]
+    t.context.dali = t.context.people[1]
+    t.context.alice = t.context.people[2]
+
+    const members = [
+      {
+        person: t.context.andrew._id,
+        organisation: t.context.orgs[0]._id,
+        validation: 'orgAdmin',
+        status: MemberStatus.ORGADMIN
+      },
+      {
+        person: t.context.dali._id,
+        organisation: t.context.orgs[2]._id,
+        validation: 'member',
+        status: MemberStatus.MEMBER
+      }
+    ]
+    t.context.members = await Member.create(members).catch((err) => `Unable to create members: ${err}`)
+    const orgid = t.context.org._id
+    t.context.url = `/api/notify/org/${orgid}?memberStatus=member&memberValidation=%27test%20invitation%27`
+    await appReady
+  } catch (e) { console.error('notify.spec.js before error:', e) }
+})
+
+test.afterEach(t => {
+  // Reset the mock back to the defaults after each test
+})
+
+test.serial('find my org - member of admin', async t => {
+  const res = await request(server)
+    .get('/my/org/admin')
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+  t.is(res.status, 307)
+  t.is(res.headers.location, `/orgs/${t.context.orgs[0]._id}`)
+})
+
+test.serial('find my org - no category', async t => {
+  const res = await request(server)
+    .get('/my/org')
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+  t.is(res.status, 307)
+  t.is(res.headers.location, `/orgs/${t.context.orgs[0]._id}`)
+})
+
+test.serial('find my org - not a vp member', async t => {
+  const res = await request(server)
+    .get('/my/org/vp')
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+  t.is(res.status, 404)
+})
+
+test.serial('find my org - member of vp', async t => {
+  const res = await request(server)
+    .get('/my/org/vp')
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+  t.is(res.status, 307)
+  t.is(res.headers.location, `/orgs/${t.context.orgs[2]._id}`)
+})
+
+test.serial('find my org - not signed in ', async t => {
+  const res = await request(server)
+    .get('/my/org/vp')
+    .set('Accept', 'application/json')
+  t.is(res.status, 403)
+})
+
+test.serial('find my person - not signed in ', async t => {
+  const res = await request(server)
+    .get('/my/person')
+    .set('Accept', 'application/json')
+  t.is(res.status, 403)
+})
+
+test.serial('find my person - signed in ', async t => {
+  const res = await request(server)
+    .get('/my/person')
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+
+  t.is(res.status, 307)
+  t.is(res.headers.location, `/people/${t.context.dali._id}`)
+})

--- a/server/api/member/findMy.js
+++ b/server/api/member/findMy.js
@@ -1,0 +1,39 @@
+const Member = require('./member')
+
+const findMyOrg = async (req, res) => {
+  if (!req.session || !req.session.isAuthenticated || !req.session.me) {
+    return res.status(403).send('Must be signed in')
+  }
+  // search membership table for org matching category and person id
+  const query = { person: req.session.me._id }
+  let myorgs = await Member.find(query).populate({ path: 'organisation', select: 'name category' }).exec()
+
+  // filter by category if present  e.g /my/org/vp
+  const category = req.params.category
+  if (category) {
+    myorgs = myorgs.filter(
+      o => o.organisation.category.includes(category))
+  }
+  if (!myorgs.length) { // failed to find matching org
+    return res.status(404).send('No matching organisation')
+  }
+  // get id of Organisation
+  const orgid = myorgs[0].organisation._id
+  // forward to the /orgs/id page
+  res.redirect(307, `/orgs/${orgid}`)
+  // res.json({ status: 'OK', category, org: myorgs[0] })
+}
+
+// redirect to the current persons profile
+const findMyPerson = async (req, res) => {
+  if (!req.session || !req.session.isAuthenticated || !req.session.me) {
+    return res.status(403).send('Must be signed in')
+  }
+  // forward to the /people/id page
+  res.redirect(307, `/people/${req.session.me._id}`)
+}
+
+module.exports = {
+  findMyOrg,
+  findMyPerson
+}

--- a/server/api/member/member.controller.js
+++ b/server/api/member/member.controller.js
@@ -70,22 +70,17 @@ const updateMember = async (req, res) => {
 
 // creates a new member or updates status of existing member
 const addMember = async (member) => {
-  try {
-    const found = await Member.findOneAndUpdate(
-      { // check for a match
-        person: member.person,
-        organisation: member.organisation
-      },
-      member, // create or upsert
-      { new: true, upsert: true }
-    )
-    // get populated out member record
-    const got = await getMemberbyId(found._id)
-    return got
-  } catch (e) {
-    console.error(e)
-    return false
-  }
+  const found = await Member.findOneAndUpdate(
+    { // check for a match
+      person: member.person,
+      organisation: member.organisation
+    },
+    member, // create or upsert
+    { new: true, upsert: true }
+  )
+  // get populated out member record
+  const got = await getMemberbyId(found._id)
+  return got
 }
 
 const createMember = async (req, res) => {

--- a/server/api/member/member.routes.js
+++ b/server/api/member/member.routes.js
@@ -2,8 +2,13 @@ const mongooseCrudify = require('mongoose-crudify')
 const helpers = require('../../services/helpers')
 const Member = require('./member')
 const { listMembers, updateMember, createMember } = require('./member.controller')
+const { findMyOrg, findMyPerson } = require('./findMy')
 
 module.exports = server => {
+  server.use('/my/org/:category', findMyOrg)
+  server.use('/my/org', findMyOrg)
+  server.use('/my/person', findMyPerson)
+
   // Docs: https://github.com/ryo718/mongoose-crudify
   server.use(
     '/api/members',


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
These changes support Goal Card links to key places 
1. Adds a new pseudo page URL /my where 
   /my/org  goes to the first org of which I am a member
   /my/org/:category goes to the first org I belong to that is of that type e.g /my/org/op goes to my school
   /my/person goes to my profile page. 
2. new routes added to members.routes as this is closest to what we are checking but new functions added to findMe.js. 

These all check the person is signed in, get their membership records and find the relevant organisation, then redirect to the correct url for that page e.g /orgs/1231232131
