### PR TITLE
VP-888 demonstrate functional component page with GetInitialProps

### DIFF
--- a/__tests__/oplistpage.spec.js
+++ b/__tests__/oplistpage.spec.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import test from 'ava'
+import { OpListPage } from '../pages/op/oplistpage'
+import { shallowWithIntl } from '../lib/react-intl-test-helper'
+import ops from '../server/api/opportunity/__tests__/opportunity.fixture'
+import objectid from 'objectid'
+
+test.before('Setup fixtures', (t) => {
+  // not using mongo or server here so faking ids
+  ops.map(p => { p._id = objectid().toString() })
+})
+
+test('render OpList', async t => {
+  // first test GetInitialProps
+  const store = {
+    dispatch: (ACTION) => {
+      console.log('dispatch', ACTION)
+      return Promise.resolve(ops)
+    }
+  }
+  const props = await OpListPage.getInitialProps({ store })
+
+  const wrapper = shallowWithIntl(<OpListPage {...props} />)
+  console.log(wrapper.debug())
+  t.is(wrapper.find('h1 FormattedMessage').first().props().id, 'opportunities')
+  t.truthy(wrapper.find('Button'))
+  t.truthy(wrapper.find('OpList'))
+})
+
+test('render OpList with dispatch error', async t => {
+  // first test GetInitialProps
+  const store = {
+    dispatch: (ACTION) => {
+      console.log('dispatch', ACTION)
+      throw Error('Catch This!')
+    }
+  }
+  const props = await OpListPage.getInitialProps({ store })
+
+  const wrapper = shallowWithIntl(<OpListPage {...props} />)
+  console.log(wrapper.debug())
+  t.is(wrapper.find('h1 FormattedMessage').first().props().id, 'opportunities')
+  t.truthy(wrapper.find('Button'))
+  t.truthy(wrapper.find('OpList'))
+})

--- a/pages/op/oplistpage.js
+++ b/pages/op/oplistpage.js
@@ -1,53 +1,57 @@
 import { Button } from 'antd'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
 import { Helmet } from 'react-helmet'
 import { FormattedMessage } from 'react-intl'
 import OpList from '../../components/Op/OpList'
 import { FullPage } from '../../components/VTheme/VTheme'
-import publicPage from '../../hocs/publicPage'
+import securePage from '../../hocs/securePage'
 import reduxApi, { withOps } from '../../lib/redux/reduxApi.js'
 
-class Ops extends Component {
-  static async getInitialProps ({ store, query }) {
-    // Get all Ops
-    try {
-      const ops = await store.dispatch(reduxApi.actions.opportunities.get())
-      return { ops, query }
-    } catch (err) {
-      console.error('error in getting ops', err)
-    }
-  }
-
-  render () {
-    return (
-      <FullPage>
-        <Helmet>
-          <title>Voluntarily - Opportunities List</title>
-        </Helmet>
-        <h1>
+/*
+  This is a basic crud listings page with no filters or anything
+  as such its not really used in Voluntarily except as an admin check.
+*/
+export const OpListPage = ({ ops }) =>
+  <FullPage>
+    <Helmet>
+      <title>Voluntarily - Opportunities List</title>
+    </Helmet>
+    <h1>
+      <FormattedMessage
+        id='opportunities'
+        defaultMessage='Opportunities'
+        description='Title of page listing opportunities'
+      />
+    </h1>
+    <Button shape='round'>
+      <Link href='/op/new'>
+        <a>
           <FormattedMessage
-            id='opportunities'
-            defaultMessage='Opportunities'
-            description='Title of page listing opportunities'
+            id='op.new'
+            defaultMessage='New Opportunity'
+            description='Button to create a new opportunity'
           />
-        </h1>
-        <Button shape='round'>
-          <Link href='/op/new'>
-            <a>
-              <FormattedMessage id='op.new' defaultMessage='New Opportunity' description='Button to create a new opportunity' />
-            </a>
-          </Link>
-        </Button>
-        <br /><br />
-        <OpList ops={this.props.ops} />
-      </FullPage>
-    )
+        </a>
+      </Link>
+    </Button>
+    <br /><br />
+    <OpList ops={ops} />
+  </FullPage>
+
+OpListPage.getInitialProps = async ({ store }) => {
+  // Get all OpListPage
+  try {
+    // warning: not a good example, don't return the got data in props,
+    // let it be store in redux and you have the loading data too.
+    const ops = await store.dispatch(reduxApi.actions.opportunities.get())
+    return { ops }
+  } catch (err) {
+    console.error('error in getting ops', err)
   }
 }
 
-Ops.propTypes = {
+OpListPage.propTypes = {
   ops: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string.isRequired,
     subtitle: PropTypes.string,
@@ -57,12 +61,6 @@ Ops.propTypes = {
     status: PropTypes.string,
     _id: PropTypes.string.isRequired
   })).isRequired
-  //  showAddOp: PropTypes.bool.isRequired,
-  // dispatch: PropTypes.func.isRequired
 }
 
-Ops.contextTypes = {
-  router: PropTypes.object
-}
-
-export default publicPage(withOps(Ops))
+export default securePage(withOps(OpListPage))


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1.  We don't have to use classes for top level pages, you can use functional components and still have a getInitialProps call as illustrated here.
2. Also the test files for top level pages don't have to be complex and load everything. This example mocks dispatch and provides the resulting props to the component.
3. using shallow rendering means the test is fast and only needs to check the high level component positioning, given that the individual components should have their own unit tests.


## Additional Info.🧐
This page is available on the route /op  and /ops  the first as it is the index page for the /pages/op folder and the second due to a specific path listed in routes.js

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
