### PR TITLE
VP-904 Fix broken production build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,6 +38,21 @@ systemtest_task:
     - apt-get install -y firefox-esr
     - npm run end-to-end-test
 
+buildtest_task:
+  only_if: $CIRRUS_BRANCH != 'master'
+  env:
+    NEXT_TELEMETRY_DISABLED: 1
+    NODE_ENV: production
+    MONGOMS_DISABLE_POSTINSTALL: 1
+    MONGOMS_DOWNLOAD_MIRROR: "http://downloads.mongodb.org"
+    MONGOMS_VERSION: "4.0.5"
+  node_modules_cache:
+    folder: node_modules
+    fingerprint_script: cat package-lock.json
+    populate_script: npm ci --production
+  test_script:
+    - npm run prod-build
+
 prod_docker_docker_builder:
   only_if: $CIRRUS_BRANCH == 'master'
   depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,6 +50,8 @@ buildtest_task:
     folder: node_modules
     fingerprint_script: cat package-lock.json
     populate_script: npm ci --production
+  next_cache:
+    folder: .next/cache
   test_script:
     - npm run prod-build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28878,7 +28878,6 @@
       "version": "4.41.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
       "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -28909,7 +28908,6 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
           "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
-          "dev": true,
           "requires": {
             "chokidar": "^2.0.2",
             "graceful-fs": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "sanitize-html": "^1.20.1",
     "slug": "^1.1.0",
     "storybook": "^5.1.11",
-    "styled-components": "^4.4.1"
+    "styled-components": "^4.4.1",
+    "webpack": "^4.41.2"
   },
   "devDependencies": {
     "@babel/register": "^7.6.2",


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Install `webpack` as a dependency so prod-docker build works

## Additional Info.🧐

I've tested this locally by mimicking what happens during the prod-docker build (specifically, setting `NODE_ENV` to "production" and passing the `--production` flag to `npm ci` and then running `npm run prod-build`).
