### PR TITLE
VP-904 Switch task to docker builder

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,22 +38,10 @@ systemtest_task:
     - apt-get install -y firefox-esr
     - npm run end-to-end-test
 
-buildtest_task:
+build_test_docker_builder:
   only_if: $CIRRUS_BRANCH != 'master'
-  env:
-    NEXT_TELEMETRY_DISABLED: 1
-    NODE_ENV: production
-    MONGOMS_DISABLE_POSTINSTALL: 1
-    MONGOMS_DOWNLOAD_MIRROR: "http://downloads.mongodb.org"
-    MONGOMS_VERSION: "4.0.5"
-  node_modules_cache:
-    folder: node_modules
-    fingerprint_script: cat package-lock.json
-    populate_script: npm ci --production
-  next_cache:
-    folder: .next/cache
   test_script:
-    - npm run prod-build
+    - docker build --target production_build .
 
 prod_docker_docker_builder:
   only_if: $CIRRUS_BRANCH == 'master'

--- a/server/api/personalGoal/__tests__/personalGoal.subscribe.spec.js
+++ b/server/api/personalGoal/__tests__/personalGoal.subscribe.spec.js
@@ -41,10 +41,22 @@ test.serial('Trigger PubSub', async t => {
   t.is(pgs.length, 0)
 
   t.true(PubSub.publishSync(TOPIC_PERSON__CREATE, newPerson))
+
   // validate that the goal cards have been allocated.
-  while (pgs.length === 0) {
-    await sleep(1)
+  let attempt = 0
+  const maxAttempts = 10
+
+  while (pgs.length !== 2) {
+    await sleep(10)
     pgs = await PersonalGoal.find()
+
+    if (attempt >= maxAttempts) {
+      t.fail(`Goals not created after ${attempt} checks`)
+      break
+    }
+
+    attempt += 1
   }
+
   t.is(pgs.length, 2)
 })


### PR DESCRIPTION
The task was consistently being killed on Cirrus due to running out of
memory. Given this doesn't seem to happen to our prod docker task I've
switched our the build test task to be a docker builder instead.

## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Switch "build test" Cirrus task to be a docker builder instead (hopefully to avoid the task being killed by Cirrus due to running out of memory)