### PR TITLE
VP-898 publish new school orgadmin event and trigger Goal Cards

### DIFF
--- a/components/Goal/GoalCard.js
+++ b/components/Goal/GoalCard.js
@@ -180,7 +180,7 @@ GoalCard.propTypes = {
     imgUrl: PropTypes.string,
     description: PropTypes.string,
     startLink: PropTypes.string,
-    category: PropTypes.string
+    group: PropTypes.string
   })
 }
 

--- a/components/Goal/GoalGroupHeading.js
+++ b/components/Goal/GoalGroupHeading.js
@@ -1,0 +1,92 @@
+/* Display a grid of goal cards from an personal goals
+ */
+import { GoalGroup } from '../../server/api/goal/goalGroup'
+
+export const goalGroupHeading = goalGroup => {
+  switch (goalGroup) {
+    case GoalGroup.VP_NEW: return {
+      title: {
+        id: 'GoalSection.VP_NEW.title', defaultMessage: 'Getting Started as a Volunteer'
+      },
+      subtitle: {
+        id: 'GoalSection.VP_NEW.subtitle', defaultMessage: 'Here are a few things we recommend doing:'
+      }
+    }
+    case GoalGroup.OP_NEW: return {
+      title: {
+        id: 'GoalSection.OP_NEW.title', defaultMessage: 'Getting Started as a Teacher'
+      },
+      subtitle: {
+        id: 'GoalSection.OP_NEW.subtitle', defaultMessage: 'Get up and running with your first activites:'
+      }
+    }
+    case GoalGroup.AP_NEW: return {
+      title: {
+        id: 'GoalSection.AP_NEW.title', defaultMessage: 'Getting Started as an Activity Provider'
+      },
+      subtitle: {
+        id: 'GoalSection.AP_NEW.subtitle', defaultMessage: 'Setup your organisation and first activities:'
+      }
+    }
+    case GoalGroup.ORG_OP_NEW: return {
+      title: {
+        id: 'GoalSection.ORG_OP_NEW.title', defaultMessage: 'First steps for a new school'
+      },
+      subtitle: {
+        id: 'GoalSection.ORG_OP_NEW.subtitle', defaultMessage: 'Setup your organisation and first activity:'
+      }
+    }
+    case GoalGroup.ORG_VP_NEW: return {
+      title: {
+        id: 'GoalSection.ORG_OP_NEW.title', defaultMessage: 'First steps for a new business'
+      },
+      subtitle: {
+        id: 'GoalSection.ORG_OP_NEW.subtitle', defaultMessage: 'Setup your organisation and bring in your volunteers'
+      }
+    }
+    case GoalGroup.ORG_AP_NEW: return {
+      title: {
+        id: 'GoalSection.ORG_OP_NEW.title', defaultMessage: 'First steps for a new Activity Provider organisation'
+      },
+      subtitle: {
+        id: 'GoalSection.ORG_OP_NEW.subtitle', defaultMessage: 'Setup your organisation and design your activities'
+      }
+    }
+    case GoalGroup.OP_REGISTER: return {
+      title: {
+        id: 'GoalSection.OP_REGISTER.title', defaultMessage: 'Register as a Teacher'
+      },
+      subtitle: {
+        id: 'GoalSection.OP_REGISTER.subtitle', defaultMessage: 'If you are not associated with a school you can still register to create events'
+      }
+    }
+    case GoalGroup.VP_MORE: return {
+      title: {
+        id: 'GoalSection.VP_MORE.title', defaultMessage: 'More ways to help out'
+      },
+      subtitle: {
+        id: 'GoalSection.VP_MORE.subtitle', defaultMessage: 'Do you have special skills you can volunteer?'
+      }
+    }
+    case GoalGroup.OP_MORE: return {
+      title: {
+        id: 'GoalSection.VP_MORE.title', defaultMessage: 'Next steps for teachers'
+      },
+      subtitle: {
+        id: 'GoalSection.VP_MORE.subtitle', defaultMessage: 'Finding and running new Activities'
+      }
+    }
+    case GoalGroup.AP_MORE: return {
+      title: {
+        id: 'GoalSection.VP_MORE.title', defaultMessage: 'Next steps for Activity Providers'
+      },
+      subtitle: {
+        id: 'GoalSection.VP_MORE.subtitle', defaultMessage: 'Creating and running new Activities'
+      }
+    }
+    default: return {
+      title: { id: goalGroup },
+      subtitle: { id: 'GoalSection.Default.subtitle', defaultMessage: 'Next steps' }
+    }
+  }
+}

--- a/components/Goal/GoalSection.js
+++ b/components/Goal/GoalSection.js
@@ -4,26 +4,24 @@ import React from 'react'
 import GoalList from '../Goal/GoalList'
 import styled from 'styled-components'
 import { FormattedMessage } from 'react-intl'
+import { goalGroupHeading } from './GoalGroupHeading'
 
 const SectionTitleWrapper = styled.div`
   margin: 2rem 0rem;
 `
 
-const GoalSection = ({ goals }) => (
-  goals &&
+export const GoalSection = ({ goals }) => {
+  if (!goals.length) return ''
+  const heading = goalGroupHeading(goals[0].group)
+  return (
     <>
       <SectionTitleWrapper>
-        <h2>{goals[0].category}</h2>
-        <h5>
-          <FormattedMessage
-            id='GoalSection.subheading'
-            defaultMessage='Here are a few things we recommend doing:'
-            description='subheading under category title for list of goals'
-          />
-        </h5>
+        <h2><FormattedMessage {...heading.title} /></h2>
+        <h5><FormattedMessage {...heading.subtitle} /></h5>
       </SectionTitleWrapper>
       <GoalList goals={goals} />
     </>
-)
+  )
+}
 
 export default GoalSection

--- a/components/Goal/__tests__/GoalCard.spec.js
+++ b/components/Goal/__tests__/GoalCard.spec.js
@@ -16,7 +16,7 @@ const goal = {
   </div>`,
   imgUrl: '/static/img/goals/teacherSetup.png',
   startLink: '/test',
-  category: 'Test',
+  group: 'Test',
   evaluation: () => { console.log('Test Goal Card'); return false }
 }
 
@@ -83,7 +83,7 @@ Test paragraph with *strong text*
 `,
     imgUrl: '/static/img/goals/teacherSetup.png',
     startLink: '/test',
-    category: 'Test',
+    group: 'Test',
     personalGoal,
     status: personalGoal.status,
     evaluation: () => { console.log('Test Goal Card'); return false }

--- a/components/Goal/__tests__/GoalGroupHeading.spec.js
+++ b/components/Goal/__tests__/GoalGroupHeading.spec.js
@@ -1,0 +1,15 @@
+import test from 'ava'
+import { goalGroupHeading } from '../GoalGroupHeading'
+import { GoalGroup } from '../../../server/api/goal/goalGroup'
+
+test('There are known goal groups and a default ', t => {
+  Object.keys(GoalGroup).map(key => {
+    const heading = goalGroupHeading(GoalGroup[key])
+    t.true(Object.keys(heading).includes('title'))
+    t.not(heading[GoalGroup[key]], GoalGroup[key])
+  })
+
+  // check default
+  const defaultHeading = goalGroupHeading('Test')
+  t.deepEqual(defaultHeading.title, { id: 'Test' })
+})

--- a/components/Goal/__tests__/GoalSection.spec.js
+++ b/components/Goal/__tests__/GoalSection.spec.js
@@ -1,12 +1,21 @@
 import test from 'ava'
 import { shallowWithIntl } from '../../../lib/react-intl-test-helper'
 import goals from '../../../server/api/goal/__tests__/goal.fixture'
-import GoalSection from '../GoalSection'
+import { GoalSection } from '../GoalSection'
 
 test('shallow the list with goals', t => {
   const wrapper = shallowWithIntl(
     <GoalSection goals={goals} />
   )
-  t.is(wrapper.find('h2').first().text(), goals[0].category)
+  console.log(wrapper.debug())
+  t.is(wrapper.find('FormattedMessage').first().props().id, 'GoalSection.VP_NEW.title')
   t.is(wrapper.find('GoalList').length, 1)
+})
+
+test('shallow the list with no goals', t => {
+  const wrapper = shallowWithIntl(
+    <GoalSection goals={[]} />
+  )
+  console.log(wrapper.debug())
+  t.is(wrapper.text(), '')
 })

--- a/pages/admin/goals.js
+++ b/pages/admin/goals.js
@@ -12,8 +12,7 @@ import { FullPage, Section } from '../../components/VTheme/VTheme'
 import securePage from '../../hocs/securePage'
 import reduxApi, { withGoals } from '../../lib/redux/reduxApi.js'
 import { Button, message } from 'antd'
-// import Link from 'next/link'
-import callApi from '../../lib/callApi'
+import fetch from 'isomorphic-fetch'
 
 function groupBy (arr, property) {
   return arr.reduce(function (memo, x) {
@@ -23,16 +22,16 @@ function groupBy (arr, property) {
   }, {})
 }
 
-const handleAssignGoalCategory = async (category) => {
+const handleAssignGoalCategory = async (group) => {
   try {
-    await callApi(`xadmin/assignPersonalGoals?category=${category}`)
+    await fetch(`api/xadmin/assignPersonalGoals?group=${group}`)
     message.success('done')
   } catch (e) { console.error('handleAssignGoalCategory Failed', e) }
 }
 
 const handleLoadGoals = async () => {
   try {
-    await callApi('xadmin/loadGoals')
+    await fetch('/api/xadmin/loadGoals')
     message.success('done')
   } catch (e) { console.error('loadGoals Failed', e) }
 }
@@ -52,7 +51,7 @@ class GoalListPage extends Component {
 
   render () {
     const goals = this.props.goals.data
-    const categories = groupBy(goals, 'category')
+    const groups = groupBy(goals, 'group')
     return (
       <FullPage>
         <Helmet>
@@ -64,9 +63,9 @@ class GoalListPage extends Component {
           <p>Clear goals from the database and reload from the sources goals.init.js file</p>
           <Button shape='round' type='primary' onClick={handleLoadGoals}>Load Goals</Button>
         </Section>
-        {Object.keys(categories).map(key =>
+        {Object.keys(groups).map(key =>
           <Section key={key}>
-            <GoalSection goals={categories[key]} />
+            <GoalSection goals={groups[key]} />
             <Button
               shape='round'
               onClick={() => handleAssignGoalCategory(key)}

--- a/pages/admin/goals.js
+++ b/pages/admin/goals.js
@@ -24,7 +24,7 @@ function groupBy (arr, property) {
 
 const handleAssignGoalCategory = async (group) => {
   try {
-    await fetch(`api/xadmin/assignPersonalGoals?group=${group}`)
+    await fetch(`/api/xadmin/assignPersonalGoals?group=${group}`)
     message.success('done')
   } catch (e) { console.error('handleAssignGoalCategory Failed', e) }
 }

--- a/pages/api/notify/org/action.js
+++ b/pages/api/notify/org/action.js
@@ -1,5 +1,5 @@
 import { handleToken } from '../../token/token'
-import { addMember } from '../../../../server/api/member/member.controller'
+import { addMember } from '../../../../server/api/member/member.lib'
 
 /* this url
 http://localhost:3122/api/notify/org/5d9fe64b4eb179218c8d1d30?memberStatus=member&memberValidation=%27test%20invitation%27

--- a/pages/api/xadmin/assignPersonalGoals.js
+++ b/pages/api/xadmin/assignPersonalGoals.js
@@ -1,7 +1,7 @@
 import { addPersonalGoalGroup } from '../../../server/api/personalGoal/personalGoal.lib'
 
 /* The /api/xadmin/ endpoint provides some utility calls that
-  /api/xadmin/assignPersonalGoals?category="name" - loads the given category into the signed in user
+  /api/xadmin/assignPersonalGoals?group="name" - loads the given group into the signed in user
 */
 export default async (req, res) => {
   res.setHeader('Content-Type', 'application/json')
@@ -9,12 +9,12 @@ export default async (req, res) => {
   if (!req.session || !req.session.isAuthenticated) {
     return res.status(403).end()
   }
-  if (!req.query.category) {
-    // bad request if category is missing
-    return res.status(400).json({ error: 'category expected' })
+  if (!req.query.group) {
+    // bad request if group is missing
+    return res.status(400).json({ error: 'group expected' })
   }
   try {
-    await addPersonalGoalGroup(req.query.category, req.session.me._id)
+    await addPersonalGoalGroup(req.query.group, req.session.me._id)
     return res.json({ status: 'OK' })
   } catch (e) {
     console.error('Error in assignPersonalGoals', e)

--- a/server/api/goal/__init__/goal.init.js
+++ b/server/api/goal/__init__/goal.init.js
@@ -3,8 +3,14 @@
   This list of goals is loaded into the database by calling
   /api/xadmin/loadGoals
 */
+import { GoalGroup } from '../goalGroup'
+
 export default [
+  /*********************************************/
+  /* GROUP Getting Started as a Volunteer      */
+  /*********************************************/
   {
+    group: GoalGroup.VP_NEW,
     name: 'Complete your profile',
     slug: 'goal-complete-profile',
     subtitle: 'Help us recommend volunteering opportunities relevant to you',
@@ -19,11 +25,11 @@ export default [
     preconditions: [],
     startLink: '/my/person',
     language: 'en',
-    category: 'Getting Started',
     rank: 1,
     evaluation: () => { console.log('Complete your profile'); return false }
   },
   {
+    group: GoalGroup.VP_NEW,
     name: 'Get School Ready',
     slug: 'goal-school-ready',
     subtitle: 'Complete the training and vetting necessary to work with young people',
@@ -50,11 +56,11 @@ completed in time - there are ways we can handle that.
     preconditions: [],
     startLink: '/todo',
     language: 'en',
-    category: 'Getting Started',
     rank: 2,
     evaluation: () => { console.log('does person have school ready badge'); return false }
   },
   {
+    group: GoalGroup.VP_NEW,
     name: 'Complete first volunteering activity',
     subtitle: 'Its time to find your first volunteering opportunity.',
     slug: 'goal-complete-first-activity',
@@ -73,11 +79,15 @@ You'll get an email notification and can accept or decline the invitation.
     preconditions: [],
     startLink: '/search',
     language: 'en',
-    category: 'Getting Started',
     rank: 3,
     evaluation: () => { console.log('does person have first-volunteer-activity badge'); return false }
   },
+
+  /*********************************************/
+  /* GROUP First steps for a new school        */
+  /*********************************************/
   {
+    group: GoalGroup.ORG_OP_NEW,
     name: 'Tell us about your school',
     slug: 'goal-complete-school-profile',
     subtitle: 'Tell the world about your awesome school - Complete profiles attract more volunteers!',
@@ -93,7 +103,6 @@ This card will disappear when the profile is complete
 `,
     imgUrl: '/static/img/goal/goal-teacherSetup.png',
     startLink: '/my/org/op',
-    category: 'Get Started for Teachers',
     rank: 1,
     evaluation: async (personalGoal) => {
       const { score, count } = await GoalTests.orgCompleteness(personalGoal, 'op')
@@ -101,6 +110,7 @@ This card will disappear when the profile is complete
     }
   },
   {
+    group: GoalGroup.ORG_OP_NEW,
     name: 'Run Inspiring the Future',
     slug: 'goal-run-itfb',
     imgUrl: '/static/img/goal/goal-itf.png',
@@ -115,11 +125,15 @@ This creates a new Activity page where you can setup the time and place details
 Once Published we will start finding volunteers
 `,
     startLink: '/activity/inspiring-the-future',
-    category: 'Get Started for Teachers',
     rank: 2,
     evaluation: (personalGoal) => GoalTests.activityStarted(personalGoal, 'inspiring-the-future')
   },
+
+  /*********************************************/
+  /* GROUP Register as a Teacher               */
+  /*********************************************/
   {
+    group: GoalGroup.OP_REGISTER,
     name: 'Confirm Teacher ID',
     slug: 'goal-confirm-teacher-id',
     subtitle: 'If you are a teacher, click here to enable creating new requests for volunteers.',
@@ -130,39 +144,46 @@ registration number to confirm that you are a teacher and thus enable the abilit
 to view activity templates and create new activities.    
 `,
     startlink: '/action/registerTeacher',
-    category: 'Register as a Teacher',
     rank: 1,
     evaluation: () => { console.log('Confirm Teacher ID'); return false }
   },
+
+  /*********************************************/
+  /* GROUP First steps for teachers            */
+  /*********************************************/
   {
+    group: GoalGroup.OP_NEW,
     name: 'Find Activities',
     slug: 'goal-find-activities',
     subtitle: 'See templates that other educators have created for you to copy',
     description: '',
     imgurl: '/static/img/actions/createAct.png',
-    category: 'Next Steps for Teachers',
     rank: 1,
     evaluation: () => { console.log('Find Activities'); return false }
   },
   {
+    group: GoalGroup.OP_NEW,
     name: 'Create an Opportunity',
     slug: 'goal-create-new-opportunity',
     subtitle: 'Ask skilled volunteers for help by creating an opportunity to help out.',
     description: '',
     imgurl: '/static/img/actions/createOp.png',
     startlink: '/opportunity/registerTeacher',
-    category: 'Next Steps for Teachers',
     rank: 2,
     evaluation: () => { console.log('does person have first-volunteer-activity badge'); return false }
   },
+  /*********************************************/
+  /* GROUP More ways to help out               */
+  /*********************************************/
+
   {
+    group: GoalGroup.VP_MORE,
     name: 'Contribute to the platform',
     slug: 'goal-contribute-to-platform',
     subtitle: 'Help mobilise more volunteers by contributing. All skill levels are welcome, and training is provided.',
     description: '',
     imgurl: '/static/img/actions/github.png',
     startlink: 'https://github.com/voluntarily/vly2',
-    category: 'More ways to help out',
     rank: 1,
     evaluation: () => { console.log('Contribute to the platform'); return false }
   }
@@ -172,7 +193,7 @@ to view activity templates and create new activities.
 //   imgUrl: '/static/img/goal/goal-school-ready.png',
 //   subtitle: '',
 //   startLink: '/search',
-//   category: 'Getting Started',
+//   group: 'Getting Started',
 //   evaluation: () => { console.log('generic'); return false }
 // },
 ]

--- a/server/api/goal/__tests__/goal.fixture.js
+++ b/server/api/goal/__tests__/goal.fixture.js
@@ -1,9 +1,12 @@
+import { GoalGroup } from '../goalGroup'
+
 export default [
   { //   name - a short name that indicates what needs to be done - these use verbs and active voice.
     //   e.g  Complete your profile,
     //        Get Police Vetted
     //        Attend your first event
     //        Complete your safety training
+    group: GoalGroup.VP_NEW,
     name: 'Complete your profile',
     slug: 'goal-complete-profile',
     subtitle: 'Help us recommend volunteering opportunities relevant to you',
@@ -18,12 +21,12 @@ export default [
     preconditions: [],
     startLink: '/home', // should be /profile#edit
     language: 'en',
-    category: 'Getting Started',
     rank: 1,
     evaluation: () => { console.log('evaluates to false'); return false },
     dateAdded: '2019-11-27T10:00:00.000Z'
   },
   {
+    group: GoalGroup.VP_NEW,
     name: 'Get School Ready',
     slug: 'goal-school-ready',
     subtitle: 'Complete the training and vetting necessary to work with young people',
@@ -52,12 +55,12 @@ export default [
     preconditions: [],
     startLink: '/home', // should be /profile#edit
     language: 'en',
-    category: 'Getting Started',
     rank: 2,
     evaluation: () => { console.log('evaluates to true'); return true },
     dateAdded: '2019-11-27T10:00:00.000Z'
   },
   {
+    group: GoalGroup.VP_NEW,
     name: 'Complete first volunteering activity',
     slug: 'goal-complete-first-activity',
     imgUrl: '/static/img/goal/goal-school-ready.png',
@@ -89,17 +92,59 @@ export default [
     preconditions: [],
     startLink: '/search',
     language: 'en',
-    category: 'First Activity',
     evaluation: () => { return true },
     dateAdded: '2019-11-27T10:00:00.000Z'
   },
+  /*********************************************/
+  /* GROUP First steps for a new school        */
+  /*********************************************/
   {
+    group: GoalGroup.ORG_OP_NEW,
+    name: 'Tell us about your school',
+    slug: 'goal-complete-school-profile',
+    subtitle: 'Tell the world about your awesome school - Complete profiles attract more volunteers!',
+    description:
+`Click Start below to open your school profile page, 
+
+Click the Edit button, fill in the profile details, Then Save it. 
+
+Once you have done that return to this page by clicking the 
+*dashboard* menu. 
+
+This card will disappear when the profile is complete
+`,
+    imgUrl: '/static/img/goal/goal-teacherSetup.png',
+    startLink: '/my/org/op',
+    rank: 1,
+    evaluation: async (personalGoal) => { return false }
+  },
+  {
+    group: GoalGroup.ORG_OP_NEW,
+    name: 'Run Inspiring the Future',
+    slug: 'goal-run-itfb',
+    imgUrl: '/static/img/goal/goal-itf.png',
+    subtitle: 'Connect children and young people with volunteers from the world of work through this fun in-school activity.',
+    description:
+`Click Start below to open the Inspiring the Future Activity Template, 
+If it sounds like something you could run in your school then click 
+the DO THIS button. 
+
+This creates a new Activity page where you can setup the time and place details
+
+Once Published we will start finding volunteers
+`,
+    startLink: '/activity/inspiring-the-future',
+    rank: 2,
+    evaluation: async (personalGoal) => { return true }
+  },
+
+  {
+    group: 'Throwers',
     name: 'Test 3 Thrower',
     slug: 'test-003',
     imgUrl: '/static/img/goal/goal-school-ready.png',
     subtitle: 'Test 3',
     startLink: '/search',
-    category: 'Throwers',
     evaluation: () => {
       console.log('Throws an error')
       throw new Error('testing')

--- a/server/api/goal/__tests__/goal.spec.js
+++ b/server/api/goal/__tests__/goal.spec.js
@@ -4,6 +4,7 @@ import { server, appReady } from '../../../server'
 import Goal from '../goal'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import goals from './goal.fixture.js'
+import { GoalGroup } from '../goalGroup'
 
 const testGoal = {
   name: 'Test Goal',
@@ -110,25 +111,16 @@ test.serial('Should fail to find - Bad request ', async t => {
     .expect(400)
   t.is(res.status, 400)
 })
-test.serial('Should correctly give subset of goals of group', async t => {
-  const res = await request(server)
-    .get('/api/goals?q={"group":"First Activity"}')
-    .set('Accept', 'application/json')
-    .expect(200)
-    .expect('Content-Type', /json/)
-  const got = res.body
-  t.is(got.length, 1)
-})
 
 test.serial('Should correctly give reverse sorted goals of group', async t => {
   const res = await request(server)
-    .get('/api/goals?q={"group":"Getting Started"}&s="-name"')
+    .get(`/api/goals?q={"group":"${GoalGroup.ORG_OP_NEW}"}&s="-name"`)
     .set('Accept', 'application/json')
     .expect(200)
     .expect('Content-Type', /json/)
   const got = res.body
   t.is(got.length, 2)
-  t.is(got[0].slug, 'goal-school-ready')
+  t.is(got[0].slug, 'goal-complete-school-profile')
 })
 
 const queryString = params => Object.keys(params).map((key) => {
@@ -137,7 +129,7 @@ const queryString = params => Object.keys(params).map((key) => {
 
 test.serial('Should correctly select just the names and ids', async t => {
   const query = {
-    q: JSON.stringify({ group: 'Getting Started' }),
+    q: JSON.stringify({ group: GoalGroup.VP_NEW }),
     p: 'slug imgUrl group'
   }
   const res = await request(server)
@@ -146,7 +138,7 @@ test.serial('Should correctly select just the names and ids', async t => {
     .expect(200)
     .expect('Content-Type', /json/)
   const got = res.body
-  t.is(got.length, 2)
+  t.is(got.length, 3)
   t.is(got[0].name, undefined)
   t.is(got[0].slug, 'goal-complete-profile')
 })

--- a/server/api/goal/__tests__/goal.spec.js
+++ b/server/api/goal/__tests__/goal.spec.js
@@ -13,7 +13,7 @@ const testGoal = {
   language: 'en',
   imgUrl: '/static/img/goal/goal-complete-profile.png',
   startLink: '/test', // should be /profile#edit
-  category: 'Test',
+  group: 'Test',
   evaluation: () => { return false }
 }
 
@@ -23,7 +23,7 @@ const testGoalDefaults = {
   subtitle: 'Test Subtitle',
   description: 'test goal description',
   startLink: '/test', // should be /profile#edit
-  category: 'Test',
+  group: 'Test',
   evaluation: () => { return false }
 }
 
@@ -110,9 +110,9 @@ test.serial('Should fail to find - Bad request ', async t => {
     .expect(400)
   t.is(res.status, 400)
 })
-test.serial('Should correctly give subset of goals of category', async t => {
+test.serial('Should correctly give subset of goals of group', async t => {
   const res = await request(server)
-    .get('/api/goals?q={"category":"First Activity"}')
+    .get('/api/goals?q={"group":"First Activity"}')
     .set('Accept', 'application/json')
     .expect(200)
     .expect('Content-Type', /json/)
@@ -120,9 +120,9 @@ test.serial('Should correctly give subset of goals of category', async t => {
   t.is(got.length, 1)
 })
 
-test.serial('Should correctly give reverse sorted goals of category', async t => {
+test.serial('Should correctly give reverse sorted goals of group', async t => {
   const res = await request(server)
-    .get('/api/goals?q={"category":"Getting Started"}&s="-name"')
+    .get('/api/goals?q={"group":"Getting Started"}&s="-name"')
     .set('Accept', 'application/json')
     .expect(200)
     .expect('Content-Type', /json/)
@@ -137,8 +137,8 @@ const queryString = params => Object.keys(params).map((key) => {
 
 test.serial('Should correctly select just the names and ids', async t => {
   const query = {
-    q: JSON.stringify({ category: 'Getting Started' }),
-    p: 'slug imgUrl category'
+    q: JSON.stringify({ group: 'Getting Started' }),
+    p: 'slug imgUrl group'
   }
   const res = await request(server)
     .get(`/api/goals?${queryString(query)}`)
@@ -204,7 +204,7 @@ test.serial('Should load a goal into the db and delete them via the api', async 
   const testGoalDelete = {
     name: 'Test Goal Delete',
     slug: 'test-goal-delete',
-    category: 'Delete'
+    group: 'Delete'
   }
 
   const goal = new Goal(testGoalDelete)

--- a/server/api/goal/goal.js
+++ b/server/api/goal/goal.js
@@ -35,7 +35,7 @@ const goalSchema = new Schema({
   language: { type: 'String', default: 'en' },
 
   // Category - 'Getting Started', 'Prepare for volunteering'
-  category: { type: 'String' },
+  group: { type: 'String' },
 
   // evaluation - function that checks whether the goal has been completed - e.g. badge presents, status value etc.
   evaluation: { type: 'String', required: true, default: '() => false' },

--- a/server/api/goal/goalGroup.js
+++ b/server/api/goal/goalGroup.js
@@ -1,0 +1,18 @@
+
+// These will need translation when displayed
+const GoalGroup = {
+  VP_NEW: 'Getting Started as a Volunteer',
+  OP_NEW: 'Getting Started as a Teacher',
+  AP_NEW: 'Getting Started as as Activity Provider',
+  ORG_OP_NEW: 'First steps for a new school',
+  ORG_VP_NEW: 'First steps for a new Business',
+  ORG_AP_NEW: 'First steps for a new Activity Provider organisation',
+  OP_REGISTER: 'Register as a Teacher',
+  VP_MORE: 'More ways to help out',
+  OP_MORE: 'Next steps for teachers',
+  AP_MORE: 'Designing Activities'
+}
+
+module.exports = {
+  GoalGroup
+}

--- a/server/api/member/__tests__/member.controller.spec.js
+++ b/server/api/member/__tests__/member.controller.spec.js
@@ -1,13 +1,12 @@
 import test from 'ava'
 import Member from '../member'
 import { MemberStatus } from '../member.constants'
-import { addMember } from '../member.controller'
 import Organisation from '../../organisation/organisation'
 import Person from '../../person/person'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import people from '../../person/__tests__/person.fixture'
 import orgs from '../../organisation/__tests__/organisation.fixture'
-import { findOrgByPersonIdAndCategory } from '../member.lib'
+import { addMember, findOrgByPersonIdAndCategory } from '../member.lib'
 
 test.before('before connect to database', async (t) => {
   try {

--- a/server/api/member/member.controller.js
+++ b/server/api/member/member.controller.js
@@ -1,17 +1,7 @@
 const Member = require('./member')
 // const Person = require('../person/person')
 const Organisation = require('../organisation/organisation')
-// const { config } = require('../../../config/config')
-// const { MemberStatus } = require('./member.constants')
-// const { emailPerson } = require('../person/person.email')
-
-/* get a single member record with org and person populated out */
-const getMemberbyId = id => {
-  return Member.findOne({ _id: id })
-    .populate({ path: 'person', select: 'nickname name imgUrl email' })
-    .populate({ path: 'organisation', select: 'name imgUrl category' })
-    .exec()
-}
+const { getMemberbyId } = require('./member.lib')
 
 /**
   api/members -> list all members
@@ -68,21 +58,6 @@ const updateMember = async (req, res) => {
   }
 }
 
-// creates a new member or updates status of existing member
-const addMember = async (member) => {
-  const found = await Member.findOneAndUpdate(
-    { // check for a match
-      person: member.person,
-      organisation: member.organisation
-    },
-    member, // create or upsert
-    { new: true, upsert: true }
-  )
-  // get populated out member record
-  const got = await getMemberbyId(found._id)
-  return got
-}
-
 const createMember = async (req, res) => {
   const newMember = new Member(req.body)
   newMember.save(async (err, saved) => {
@@ -131,6 +106,5 @@ const createMember = async (req, res) => {
 module.exports = {
   listMembers,
   updateMember,
-  createMember,
-  addMember
+  createMember
 }

--- a/server/api/organisation/organisation.js
+++ b/server/api/organisation/organisation.js
@@ -15,6 +15,7 @@ const organisationSchema = new Schema({
     required: true,
     default: ['vp'],
     enum: ['admin', 'vp', 'op', 'ap', 'other']
+    // TODO: [VP-905] replace category strings with constants in ./organisation.constants.js
   },
   info: {
     about: String,

--- a/server/api/personalGoal/GoalTests.js
+++ b/server/api/personalGoal/GoalTests.js
@@ -8,9 +8,9 @@ They can fail and throw exceptions, we don't catch them here but
 allow them to be caught at the API layer where we can return a 4xx result
 */
 const GoalTests = {
-  orgCompleteness: async (personalGoal, category) => {
+  orgCompleteness: async (personalGoal, group) => {
     const personId = personalGoal.person._id
-    const orgid = await findOrgByPersonIdAndCategory(personId, category)
+    const orgid = await findOrgByPersonIdAndCategory(personId, group)
     return orgProfileCompletenessById(orgid)
   },
   // test whether an op has been created from an activity for current person or org

--- a/server/api/personalGoal/__tests__/GoalTests.spec.js
+++ b/server/api/personalGoal/__tests__/GoalTests.spec.js
@@ -13,7 +13,7 @@ import Organisation from '../../organisation/organisation'
 import orgs from '../../organisation/__tests__/organisation.fixture'
 import Person from '../../person/person'
 import people from '../../person/__tests__/person.fixture'
-import { addMember } from '../../member/member.controller'
+import { addMember } from '../../member/member.lib'
 import { MemberStatus } from '../../member/member.constants'
 import { OpportunityStatus } from '../../opportunity/opportunity.constants'
 

--- a/server/api/personalGoal/__tests__/personalGoal.lib.spec.js
+++ b/server/api/personalGoal/__tests__/personalGoal.lib.spec.js
@@ -15,6 +15,7 @@ import Organisation from '../../organisation/organisation'
 import orgs from '../../organisation/__tests__/organisation.fixture'
 import Person from '../../person/person'
 import people from '../../person/__tests__/person.fixture'
+import { GoalGroup } from '../../goal/goalGroup'
 
 test.before('before connect to database', async (t) => {
   try {
@@ -91,15 +92,15 @@ test.serial('Should add a personalGoal Group to the person', async t => {
   let dalisGoals = await PersonalGoal.find(q).exec()
   t.is(dalisGoals.length, 0)
 
-  // try with an invalid category
+  // try with an invalid group
   await addPersonalGoalGroup('This should fail', t.context.dali._id)
   dalisGoals = await PersonalGoal.find(q).exec()
   t.is(dalisGoals.length, 0)
 
-  await addPersonalGoalGroup('Getting Started', t.context.dali._id)
+  await addPersonalGoalGroup(GoalGroup.VP_NEW, t.context.dali._id)
   // Dali now has 2 goals
   dalisGoals = await PersonalGoal.find(q).exec()
-  t.is(dalisGoals.length, 2)
+  t.is(dalisGoals.length, 3)
 })
 
 test.serial('Evaluate the personal goals - hidden and unhide', async t => {
@@ -155,7 +156,7 @@ test.serial('Evaluate the personal goals - true completes', async t => {
 test.serial('Evaluate the personal goals - throw failure', async t => {
   const personalGoalAlice = {
     person: t.context.alice._id,
-    goal: t.context.goals[3]._id, // this throws evaluation
+    goal: t.context.goals[5]._id, // this throws evaluation
     status: PersonalGoalStatus.ACTIVE
   }
   let apg = await addPersonalGoal(personalGoalAlice)

--- a/server/api/personalGoal/__tests__/personalGoal.subscribe.spec.js
+++ b/server/api/personalGoal/__tests__/personalGoal.subscribe.spec.js
@@ -1,19 +1,15 @@
 import test from 'ava'
 import express from 'express'
 import PubSub from 'pubsub-js'
-import {
-  TOPIC_GOALGROUP__ADD,
-  TOPIC_MEMBER__UPDATE,
-  TOPIC_PERSON__CREATE
-} from '../../../services/pubsub/topic.constants'
+import { TOPIC_GOALGROUP__ADD, TOPIC_MEMBER__UPDATE, TOPIC_PERSON__CREATE } from '../../../services/pubsub/topic.constants'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import Goal from '../../goal/goal'
 import goals from '../../goal/__tests__/goal.fixture'
+import { MemberStatus } from '../../member/member.constants'
 import Organisation from '../../organisation/organisation'
 import orgs from '../../organisation/__tests__/organisation.fixture'
 import Person from '../../person/person'
 import people from '../../person/__tests__/person.fixture'
-import { MemberStatus } from '../../member/member.constants'
 import PersonalGoal from '../personalGoal'
 import Subscribe from '../personalGoal.subscribe'
 

--- a/server/api/personalGoal/__tests__/personalGoal.subscribe.spec.js
+++ b/server/api/personalGoal/__tests__/personalGoal.subscribe.spec.js
@@ -1,14 +1,17 @@
 import test from 'ava'
-import Person from '../../person/person'
-import PersonalGoal from '../personalGoal'
-import MemoryMongo from '../../../util/test-memory-mongo'
-import people from '../../person/__tests__/person.fixture'
-import Subscribe from '../personalGoal.subscribe'
 import express from 'express'
 import PubSub from 'pubsub-js'
-import { TOPIC_PERSON__CREATE } from '../../../services/pubsub/topic.constants'
+import { TOPIC_GOALGROUP__ADD, TOPIC_MEMBER__UPDATE, TOPIC_PERSON__CREATE } from '../../../services/pubsub/topic.constants'
+import MemoryMongo from '../../../util/test-memory-mongo'
 import Goal from '../../goal/goal'
 import goals from '../../goal/__tests__/goal.fixture'
+import Organisation from '../../organisation/organisation'
+import orgs from '../../organisation/__tests__/organisation.fixture'
+import Person from '../../person/person'
+import people from '../../person/__tests__/person.fixture'
+import { MemberStatus } from '../../member/member.constants'
+import PersonalGoal from '../personalGoal'
+import Subscribe from '../personalGoal.subscribe'
 
 test.before('before connect to database', async (t) => {
   try {
@@ -18,33 +21,54 @@ test.before('before connect to database', async (t) => {
     await t.context.memMongo.start()
     t.context.people = await Person.create(people).catch((err) => console.error('Unable to create people:', err))
     t.context.goals = await Goal.create(goals).catch((e) => console.error('Unable to create goals', e))
-    // t.context.clock = sinon.useFakeTimers()
+    t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create organisations: ${err}`)
+    t.context.org = t.context.orgs[0]
+    t.context.andrew = t.context.people[0]
   } catch (e) {
     console.error('personController.spec.js, before connect to database', e)
   }
 })
 
 test.after.always(async (t) => {
-  // t.context.clock.runAll()
-  // t.context.clock.restore()
   await t.context.memMongo.stop()
 })
 
-function sleep (ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
+test.serial('Trigger TOPIC_PERSON__CREATE', async t => {
+  t.plan(4)
 
-test.serial('Trigger PubSub', async t => {
-  // t.plan(2)
   const newPerson = t.context.people[0]
-  let pgs = await PersonalGoal.find()
+  let pgs = await PersonalGoal.find().exec()
   t.is(pgs.length, 0)
+  const done = new Promise((resolve, reject) => {
+    const x = PubSub.subscribe(TOPIC_GOALGROUP__ADD, async (msg, gg) => {
+      t.is(gg.length, 3)
+      pgs = await PersonalGoal.find().exec()
+      t.is(pgs.length, 3)
+      resolve(true)
+      x.unsubscribe()
+    })
+  })
+  t.true(PubSub.publish(TOPIC_PERSON__CREATE, newPerson))
+  await done
+})
 
-  t.true(PubSub.publishSync(TOPIC_PERSON__CREATE, newPerson))
-  // validate that the goal cards have been allocated.
-  while (pgs.length === 0) {
-    await sleep(1)
-    pgs = await PersonalGoal.find()
+test.only('Trigger TOPIC_MEMBER__UPDATE', async t => {
+  t.plan(3)
+  const member = {
+    person: t.context.andrew._id,
+    organisation: t.context.orgs[1]._id,
+    validation: 'Trigger TOPIC_MEMBER__UPDATE',
+    status: MemberStatus.ORGADMIN
   }
-  t.is(pgs.length, 2)
+
+  const done = new Promise((resolve, reject) => {
+    PubSub.subscribe(TOPIC_GOALGROUP__ADD, async (msg, gg) => {
+      t.is(gg.length, 2)
+      const pgs = await PersonalGoal.find().exec()
+      t.is(pgs.length, 2)
+      resolve(true)
+    })
+  })
+  t.true(PubSub.publish(TOPIC_MEMBER__UPDATE, member))
+  await done
 })

--- a/server/api/personalGoal/personalGoal.lib.js
+++ b/server/api/personalGoal/personalGoal.lib.js
@@ -3,6 +3,8 @@ const Goal = require('../goal/goal')
 const moment = require('moment')
 const { PersonalGoalStatus } = require('./personalGoal.constants')
 const { GoalTests } = require('./GoalTests')
+const PubSub = require('pubsub-js')
+const { TOPIC_GOALGROUP__ADD } = require('../../services/pubsub/topic.constants')
 /* Note These library functions call the database.
 They can fail and throw exceptions, we don't catch them here but
 allow them to be caught at the API layer where we can return a 4xx result
@@ -30,17 +32,21 @@ const addPersonalGoal = async (personalGoal) => {
 }
 
 // creates a new PersonalGoal or updates status of existing PersonalGoal
-const addPersonalGoalGroup = async (category, personId) => {
-  // console.log('addPersonalGoalGroup', category, personId)
-  const goalSet = await Goal.find({ category }).select('name').exec()
+const addPersonalGoalGroup = async (group, personId) => {
+  const goalSet = await Goal.find({ group }).select('name').exec()
+  if (!goalSet.length) return
+
   const pgs = goalSet.map(goal => {
     return {
       person: personId,
       goal: goal._id
     }
   })
-  return PersonalGoal.create(pgs)
+  const personalGoalGroup = await PersonalGoal.create(pgs)
     .catch((err) => console.error('Unable to create personalGoals:', err))
+  PubSub.publish(TOPIC_GOALGROUP__ADD, personalGoalGroup)
+
+  return personalGoalGroup
 }
 
 // true when the momentDate entered is days older than present

--- a/server/api/personalGoal/personalGoal.subscribe.js
+++ b/server/api/personalGoal/personalGoal.subscribe.js
@@ -1,75 +1,38 @@
-import test from 'ava'
-import express from 'express'
-import PubSub from 'pubsub-js'
-import { TOPIC_GOALGROUP__ADD, TOPIC_MEMBER__UPDATE, TOPIC_PERSON__CREATE } from '../../../services/pubsub/topic.constants'
-import MemoryMongo from '../../../util/test-memory-mongo'
-import Goal from '../../goal/goal'
-import goals from '../../goal/__tests__/goal.fixture'
-import Organisation from '../../organisation/organisation'
-import orgs from '../../organisation/__tests__/organisation.fixture'
-import Person from '../../person/person'
-import people from '../../person/__tests__/person.fixture'
-import { MemberStatus } from '../../member/member.constants'
-import PersonalGoal from '../personalGoal'
-import Subscribe from '../personalGoal.subscribe'
+// const { addPersonalGoalGroup } = require('../personalGoal/personalGoal.lib')
+const PubSub = require('pubsub-js')
+const { TOPIC_PERSON__CREATE, TOPIC_MEMBER__UPDATE } = require('../../services/pubsub/topic.constants')
+const { addPersonalGoalGroup } = require('./personalGoal.lib')
+const { MemberStatus } = require('../member/member.constants')
+const Organisation = require('../organisation/organisation')
+const { GoalGroup } = require('../goal/goalGroup.js')
 
-test.before('before connect to database', async (t) => {
-  try {
-    t.context.server = express()
-    Subscribe(t.context.server)
-    t.context.memMongo = new MemoryMongo()
-    await t.context.memMongo.start()
-    t.context.people = await Person.create(people).catch((err) => console.error('Unable to create people:', err))
-    t.context.goals = await Goal.create(goals).catch((e) => console.error('Unable to create goals', e))
-    t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create organisations: ${err}`)
-    t.context.org = t.context.orgs[0]
-    t.context.andrew = t.context.people[0]
-  } catch (e) {
-    console.error('personController.spec.js, before connect to database', e)
-  }
-})
-
-test.after.always(async (t) => {
-  await t.context.memMongo.stop()
-})
-
-test.serial('Trigger TOPIC_PERSON__CREATE', async t => {
-  t.plan(4)
-
-  const newPerson = t.context.people[0]
-  let pgs = await PersonalGoal.find().exec()
-  t.is(pgs.length, 0)
-  const done = new Promise((resolve, reject) => {
-    PubSub.subscribe(TOPIC_GOALGROUP__ADD, async (msg, gg) => {
-      t.is(gg.length, 3)
-      pgs = await PersonalGoal.find().exec()
-      t.is(pgs.length, 3)
-      resolve(true)
-    })
+module.exports = (server) => {
+  PubSub.subscribe(TOPIC_PERSON__CREATE, async (msg, person) => {
+    addPersonalGoalGroup(GoalGroup.VP_NEW, person._id)
   })
-  t.true(PubSub.publish(TOPIC_PERSON__CREATE, newPerson))
-  await done
-})
 
-test.serial('Trigger TOPIC_MEMBER__UPDATE', async t => {
-  t.plan(3)
-  const member = {
-    person: t.context.andrew._id,
-    organisation: t.context.orgs[1]._id,
-    validation: 'Trigger TOPIC_MEMBER__UPDATE',
-    status: MemberStatus.ORGADMIN
-  }
-  const pgs = await PersonalGoal.find().exec()
-  const len = pgs.length
-  const done = new Promise((resolve, reject) => {
-    PubSub.subscribe(TOPIC_GOALGROUP__ADD, async (msg, gg) => {
-      t.is(gg.length, 2)
-      const pgs = await PersonalGoal.find().exec()
-      t.is(pgs.length, len + 2
-      )
-      resolve(true)
-    })
+  PubSub.subscribe(TOPIC_MEMBER__UPDATE, async (msg, member) => {
+    // a new member has been created or a member status has changed
+    // issue new cards accordingly.
+    const orgid = member.organisation
+    const org = await Organisation.findById(orgid)
+    // console.log(msg, member, org)
+    switch (member.status) {
+      case MemberStatus.ORGADMIN:
+        if (org.category.includes('vp')) { await addPersonalGoalGroup(GoalGroup.ORG_VP_NEW, member.person) }
+        if (org.category.includes('op')) { await addPersonalGoalGroup(GoalGroup.ORG_OP_NEW, member.person) }
+        if (org.category.includes('ap')) { await addPersonalGoalGroup(GoalGroup.ORG_AP_NEW, member.person) }
+        break
+      case MemberStatus.FOLLOWER:
+        break
+      case MemberStatus.JOINER:
+        break
+      case MemberStatus.VALIDATOR:
+        break
+      case MemberStatus.MEMBER:
+        break
+      case MemberStatus.EXMEMBER:
+        break
+    }
   })
-  t.true(PubSub.publish(TOPIC_MEMBER__UPDATE, member))
-  await done
-})
+}

--- a/server/api/personalGoal/personalGoal.subscribe.js
+++ b/server/api/personalGoal/personalGoal.subscribe.js
@@ -1,10 +1,38 @@
 // const { addPersonalGoalGroup } = require('../personalGoal/personalGoal.lib')
 const PubSub = require('pubsub-js')
-const { TOPIC_PERSON__CREATE } = require('../../services/pubsub/topic.constants')
+const { TOPIC_PERSON__CREATE, TOPIC_MEMBER__UPDATE } = require('../../services/pubsub/topic.constants')
 const { addPersonalGoalGroup } = require('./personalGoal.lib')
+const { MemberStatus } = require('../member/member.constants')
+const Organisation = require('../organisation/organisation')
+const { GoalGroup } = require('../goal/goalGroup.js')
 
 module.exports = (server) => {
-  PubSub.subscribe(TOPIC_PERSON__CREATE, (msg, person) => {
-    addPersonalGoalGroup('Getting Started', person._id)
+  PubSub.subscribe(TOPIC_PERSON__CREATE, async (msg, person) => {
+    addPersonalGoalGroup(GoalGroup.VP_NEW, person._id)
+  })
+
+  PubSub.subscribe(TOPIC_MEMBER__UPDATE, async (msg, member) => {
+    // a new member has been created or a member status has changed
+    // issue new cards accordingly.
+    const orgid = member.organisation
+    const org = await Organisation.findById(orgid)
+    // console.log(msg, member, org)
+    switch (member.status) {
+      case MemberStatus.ORGADMIN:
+        if (org.category.includes('vp')) { await addPersonalGoalGroup(GoalGroup.ORG_VP_NEW, member.person) }
+        if (org.category.includes('op')) { await addPersonalGoalGroup(GoalGroup.ORG_OP_NEW, member.person) }
+        if (org.category.includes('ap')) { await addPersonalGoalGroup(GoalGroup.ORG_AP_NEW, member.person) }
+        break
+      case MemberStatus.FOLLOWER:
+        break
+      case MemberStatus.JOINER:
+        break
+      case MemberStatus.VALIDATOR:
+        break
+      case MemberStatus.MEMBER:
+        break
+      case MemberStatus.EXMEMBER:
+        break
+    }
   })
 }

--- a/server/api/personalGoal/personalGoal.subscribe.js
+++ b/server/api/personalGoal/personalGoal.subscribe.js
@@ -1,38 +1,75 @@
-// const { addPersonalGoalGroup } = require('../personalGoal/personalGoal.lib')
-const PubSub = require('pubsub-js')
-const { TOPIC_PERSON__CREATE, TOPIC_MEMBER__UPDATE } = require('../../services/pubsub/topic.constants')
-const { addPersonalGoalGroup } = require('./personalGoal.lib')
-const { MemberStatus } = require('../member/member.constants')
-const Organisation = require('../organisation/organisation')
-const { GoalGroup } = require('../goal/goalGroup.js')
+import test from 'ava'
+import express from 'express'
+import PubSub from 'pubsub-js'
+import { TOPIC_GOALGROUP__ADD, TOPIC_MEMBER__UPDATE, TOPIC_PERSON__CREATE } from '../../../services/pubsub/topic.constants'
+import MemoryMongo from '../../../util/test-memory-mongo'
+import Goal from '../../goal/goal'
+import goals from '../../goal/__tests__/goal.fixture'
+import Organisation from '../../organisation/organisation'
+import orgs from '../../organisation/__tests__/organisation.fixture'
+import Person from '../../person/person'
+import people from '../../person/__tests__/person.fixture'
+import { MemberStatus } from '../../member/member.constants'
+import PersonalGoal from '../personalGoal'
+import Subscribe from '../personalGoal.subscribe'
 
-module.exports = (server) => {
-  PubSub.subscribe(TOPIC_PERSON__CREATE, async (msg, person) => {
-    addPersonalGoalGroup(GoalGroup.VP_NEW, person._id)
-  })
+test.before('before connect to database', async (t) => {
+  try {
+    t.context.server = express()
+    Subscribe(t.context.server)
+    t.context.memMongo = new MemoryMongo()
+    await t.context.memMongo.start()
+    t.context.people = await Person.create(people).catch((err) => console.error('Unable to create people:', err))
+    t.context.goals = await Goal.create(goals).catch((e) => console.error('Unable to create goals', e))
+    t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create organisations: ${err}`)
+    t.context.org = t.context.orgs[0]
+    t.context.andrew = t.context.people[0]
+  } catch (e) {
+    console.error('personController.spec.js, before connect to database', e)
+  }
+})
 
-  PubSub.subscribe(TOPIC_MEMBER__UPDATE, async (msg, member) => {
-    // a new member has been created or a member status has changed
-    // issue new cards accordingly.
-    const orgid = member.organisation
-    const org = await Organisation.findById(orgid)
-    // console.log(msg, member, org)
-    switch (member.status) {
-      case MemberStatus.ORGADMIN:
-        if (org.category.includes('vp')) { await addPersonalGoalGroup(GoalGroup.ORG_VP_NEW, member.person) }
-        if (org.category.includes('op')) { await addPersonalGoalGroup(GoalGroup.ORG_OP_NEW, member.person) }
-        if (org.category.includes('ap')) { await addPersonalGoalGroup(GoalGroup.ORG_AP_NEW, member.person) }
-        break
-      case MemberStatus.FOLLOWER:
-        break
-      case MemberStatus.JOINER:
-        break
-      case MemberStatus.VALIDATOR:
-        break
-      case MemberStatus.MEMBER:
-        break
-      case MemberStatus.EXMEMBER:
-        break
-    }
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
+})
+
+test.serial('Trigger TOPIC_PERSON__CREATE', async t => {
+  t.plan(4)
+
+  const newPerson = t.context.people[0]
+  let pgs = await PersonalGoal.find().exec()
+  t.is(pgs.length, 0)
+  const done = new Promise((resolve, reject) => {
+    PubSub.subscribe(TOPIC_GOALGROUP__ADD, async (msg, gg) => {
+      t.is(gg.length, 3)
+      pgs = await PersonalGoal.find().exec()
+      t.is(pgs.length, 3)
+      resolve(true)
+    })
   })
-}
+  t.true(PubSub.publish(TOPIC_PERSON__CREATE, newPerson))
+  await done
+})
+
+test.serial('Trigger TOPIC_MEMBER__UPDATE', async t => {
+  t.plan(3)
+  const member = {
+    person: t.context.andrew._id,
+    organisation: t.context.orgs[1]._id,
+    validation: 'Trigger TOPIC_MEMBER__UPDATE',
+    status: MemberStatus.ORGADMIN
+  }
+  const pgs = await PersonalGoal.find().exec()
+  const len = pgs.length
+  const done = new Promise((resolve, reject) => {
+    PubSub.subscribe(TOPIC_GOALGROUP__ADD, async (msg, gg) => {
+      t.is(gg.length, 2)
+      const pgs = await PersonalGoal.find().exec()
+      t.is(pgs.length, len + 2
+      )
+      resolve(true)
+    })
+  })
+  t.true(PubSub.publish(TOPIC_MEMBER__UPDATE, member))
+  await done
+})

--- a/server/api/school-invite/__tests__/school-invite.controller.spec.js
+++ b/server/api/school-invite/__tests__/school-invite.controller.spec.js
@@ -196,6 +196,6 @@ test('Link person to organisation as admin', async (t) => {
 
   t.is(member.organisation, organisation._id)
   t.is(member.person, person._id)
-  t.is(member.validation, 'orgAdmin')
+  t.is(member.validation, 'orgAdmin from school-invite controller')
   t.is(member.status, MemberStatus.ORGADMIN)
 })

--- a/server/api/school-invite/school-invite.controller.js
+++ b/server/api/school-invite/school-invite.controller.js
@@ -185,7 +185,7 @@ class SchoolInvite {
     const member = {
       person: personId,
       organisation: organisationId,
-      validation: 'orgAdmin',
+      validation: 'orgAdmin from school-invite controller',
       status: MemberStatus.ORGADMIN
     }
 

--- a/server/services/pubsub/topic.constants.js
+++ b/server/services/pubsub/topic.constants.js
@@ -4,7 +4,9 @@
 */
 const Topic = {
   TOPIC_API__HEALTH: Symbol('API.HEALTH'), // /api/health called
-  TOPIC_PERSON__CREATE: Symbol('PERSON.CREATE') // new person created
+  TOPIC_PERSON__CREATE: Symbol('PERSON.CREATE'), // new person created via API
+  TOPIC_MEMBER__UPDATE: Symbol('MEMBER.UPDATE'), // membership changed via service
+  TOPIC_GOALGROUP__ADD: Symbol('GOALGROUP.ADD') // goal group added to person
 }
 
 module.exports = Topic


### PR DESCRIPTION
## I do solemnly swear that I have:
- [X] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. goal category renamed to goal.group and init from constants
2. pubsub message sent when new OrgAdmin member created
3. pubsub handler adds cards to new OrgAdmin member to setup the school

## Additional Info.🧐
* changes to the data format for a goal means the existing goal collection must be removed and re-instated.
* Testing the pubsub is achieved by publishing another message in the handler and watching for this in the test. means we don't have to add any wait loops.
* needs some more testing

## Screenshots 📷
 
### Original


### Updated
