### PR TITLE
VP-912 Setup nodemon to watch lang directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "testcafe-tests": "wait-on -t 60000 -w 2000 -l http://localhost:3122 && node node_modules/testcafe/bin/testcafe.js firefox:headless systemtest/landing.test.js",
     "lint": "standard",
     "fix": "standard --fix",
-    "dev": "nodemon -w server -w package.json server/server.js",
+    "dev": "nodemon -w lang -w server -w package.json server/server.js",
     "build": "next build && node ./x/default-lang",
     "build:lang": "formatjs extract --messages-dir lang/.messages $(find . -type f -name '*.js' ! -path './node_modules/*' ! -path './.next/*' ! -path './.storybook/*' ! -path './coverage/*' ! -path './docs/*' ! -path './x/*') && node ./x/default-lang",
     "prod-build": "next build",


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. The server needs to be restarted to reflect updates to lang/*.json files but this doesn't happen automatically in dev environments at the moment. This change configures nodemon to also watch the lang directory so those changes will show up without needing to manually restart the server.
