### PR TITLE
Added function to set OrgAdmin value dynamically

### DIFF
--- a/__tests__/op/opdetailpage.spec.js
+++ b/__tests__/op/opdetailpage.spec.js
@@ -365,7 +365,7 @@ test('can create new Op from Activity', t => {
 
 test('page loads when user is not signed in but does not show edit VP-499', t => {
   const props = {
-    me: null,
+    me: '',
     dispatch: t.context.mockStore.dispatch
   }
   const RoutedOpDetailPage = withMockRoute(OpDetailPageWithOps)

--- a/pages/op/opdetailpage.js
+++ b/pages/op/opdetailpage.js
@@ -44,6 +44,7 @@ export class OpDetailPage extends Component {
     this.canManageInterests = this.canManageInterests.bind(this)
     this.canRegisterInterest = this.canRegisterInterest.bind(this)
     this.retrieveOpportunity = this.retrieveOpportunity.bind(this)
+    this.isOrgAdmin = this.isOrgAdmin.bind(this)
   }
 
   static async getInitialProps ({ store, query }) {
@@ -139,9 +140,15 @@ export class OpDetailPage extends Component {
     )
   }
 
+  isOrgAdmin (orgid, meid) {
+    this.props.members.data.find(m => {
+      return orgid === m.organisation._id && meid === m.person && MemberStatus.ORGADMIN === m.status
+    }
+    )
+  }
+
   canEdit (op) {
-    const isOrgAdmin = false // TODO: is this person an admin for the org that person belongs to.
-    return this.isOwner(op) || isOrgAdmin || this.isAdmin()
+    return (this.isOwner(op) || this.isOrgAdmin() || this.isAdmin())
   }
 
   canManageInterests (op) {
@@ -221,6 +228,9 @@ export class OpDetailPage extends Component {
     }
 
     const op = this.retrieveOpportunity()
+    if (op.offerOrg && this.props.me._id) {
+      this.isOrgAdmin(op.offerOrg._id, this.props.me._id)
+    }
 
     if (op && this.state.editing) {
       return (


### PR DESCRIPTION
## I do solemnly swear that I have:
- [ ] Run `npm test` and all the tests pass.
- [ ] Run `npm run lint` and there are no warnings.
- [ ] Not decreased the overall test coverage?
- [ ] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Added a function that would set orgAdmin status to either true or false 
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
