### PR TITLE
VP-939 Fix react intl error messages

### DIFF
--- a/__tests__/404.spec.js
+++ b/__tests__/404.spec.js
@@ -9,16 +9,16 @@ const E500 = 500
 const E200 = 200
 
 test('render 404', t => {
-  const wrapper = mountWithIntl(<ErrorPageTest router={router} url='/404' errorCode={E404} />)
+  const wrapper = mountWithIntl(<ErrorPageTest locale='en' router={router} url='/404' errorCode={E404} />)
   t.is(wrapper.find('h1').first().text(), 'Oh no! Page not found')
 })
 
 test('render 200', t => {
-  const wrapper = mountWithIntl(<ErrorPageTest router={router} url='/_error' errorCode={E200} />)
+  const wrapper = mountWithIntl(<ErrorPageTest locale='en' router={router} url='/_error' errorCode={E200} />)
   t.is(wrapper.find('h1').first().text(), 'Oh no! Page not found')
 })
 
 test('render 500', t => {
-  const wrapper = mountWithIntl(<ErrorPageTest router={router} url='/404' errorCode={E500} />)
+  const wrapper = mountWithIntl(<ErrorPageTest locale='en' router={router} url='/404' errorCode={E500} />)
   t.regex(wrapper.find('h2').first().text(), /Sorry, there was a problem/)
 })

--- a/components/Interest/__tests__/InterestItem.spec.js
+++ b/components/Interest/__tests__/InterestItem.spec.js
@@ -1,9 +1,9 @@
 import InterestItem from '../InterestItem'
 import test from 'ava'
-import { mount } from 'enzyme'
+import { mountWithIntl } from '../../../lib/react-intl-test-helper'
 
 test('constructs properly', t => {
-  const wrapper = mount(
+  const wrapper = mountWithIntl(
     <InterestItem interest={{
       person: { nickname: 'Test Name' },
       opportunity: 'Test Opportunity',

--- a/components/VTheme/__tests__/ItemList.spec.js
+++ b/components/VTheme/__tests__/ItemList.spec.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import { ItemVolunteers } from '../ItemList'
-import { renderWithIntl} from '../../../lib/react-intl-test-helper'
+import { renderWithIntl } from '../../../lib/react-intl-test-helper'
 
 test('render Volunteers per student properly if the value is < 1', t => {
 //   t.context.act.volunteers = 0.2

--- a/components/VTheme/__tests__/ItemList.spec.js
+++ b/components/VTheme/__tests__/ItemList.spec.js
@@ -1,19 +1,19 @@
 import test from 'ava'
 import { ItemVolunteers } from '../ItemList'
-import { render } from 'enzyme'
+import { renderWithIntl} from '../../../lib/react-intl-test-helper'
 
 test('render Volunteers per student properly if the value is < 1', t => {
 //   t.context.act.volunteers = 0.2
-  const wrapper = render(<ItemVolunteers volunteers={0.2} type='act' />)
+  const wrapper = renderWithIntl(<ItemVolunteers volunteers={0.2} type='act' />)
   t.is(wrapper.find('span').first().text(), 'Volunteers per student:')
 })
 test('render volunteer properly if the value is >= 1', t => {
 //   t.context.act.volunteers = 5
-  const wrapper = render(<ItemVolunteers volunteers={5} type='act' />)
+  const wrapper = renderWithIntl(<ItemVolunteers volunteers={5} type='act' />)
   t.is(wrapper.find('span').first().text(), 'Volunteers:')
 })
 test('render volunteer values === 0 properly', t => {
 //   t.context.volunteers = 0
-  const wrapper = render(<ItemVolunteers volunteers={0} type='act' />)
+  const wrapper = renderWithIntl(<ItemVolunteers volunteers={0} type='act' />)
   t.is(wrapper.find('span').first().text(), '')
 })

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -5,7 +5,7 @@ import React from 'react'
 import Head from 'next/head'
 import PropTypes from 'prop-types'
 import { withRouter } from 'next/router'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, IntlProvider } from 'react-intl'
 import { FullPage, Spacer } from '../components/VTheme/VTheme'
 import styled from 'styled-components'
 import publicPage from '../hocs/publicPage'
@@ -33,9 +33,17 @@ const BugContainer = styled.div`
 `
 
 class ErrorPage extends React.Component {
-  static getInitialProps ({ res, xhr }) {
+  static getInitialProps ({ res, xhr, req }) {
     const errorCode = res ? res.statusCode : xhr ? xhr.status : null
-    return { errorCode }
+
+    const { locale, messages } = req || window.__NEXT_DATA__.props.initialProps
+    const initialNow = Date.now()
+    return {
+      errorCode,
+      locale,
+      messages,
+      initialNow
+    }
   }
 
   render () {
@@ -45,78 +53,102 @@ class ErrorPage extends React.Component {
       case 200: // Also display a 404 if someone requests /_error explicitly
       case 404:
         response = (
-          <FullPage>
-            <Head>
-              <FormattedMessage
-                id='error.pagenotfound.title'
-                description='Page title for the 404 error'
-                defaultMessage='Oh no! Page not found'
-                tagName='title'
-              />
-            </Head>
-            <Spacer />
-            <Spacer />
-            <div>
-              <FormattedMessage
-                id='error.pagenotfound.title'
-                description='Page title for the 404 error'
-                defaultMessage='Oh no! Page not found'
-                tagName='h1'
-              />
-              <FormattedMessage
-                id='error.pagenotfound.description'
-                defaultMessage="The page you are looking for is not here. We have looked everywhere but it doesn't seem to exist. Perhaps it just hasn't been built yet."
-              />
-              &nbsp;
-              <a href='https://voluntarily.nz/get-involved'>
+          <IntlProvider
+            locale={this.props.locale}
+            messages={this.props.messages}
+            initialNow={this.props.initialNow}
+          >
+            <FullPage>
+              <Head>
+                <IntlProvider
+                  locale={this.props.locale}
+                  messages={this.props.messages}
+                  initialNow={this.props.initialNow}
+                >
+                  <FormattedMessage
+                    id='error.pagenotfound.title'
+                    description='Page title for the 404 error'
+                    defaultMessage='Oh no! Page not found'
+                    tagName='title'
+                  />
+                </IntlProvider>
+              </Head>
+              <Spacer />
+              <Spacer />
+              <div>
                 <FormattedMessage
-                  id='error.pagenotfound.contribute'
-                  defaultMessage='If you can write code you can help fix that by becoming a contributor to the project.'
+                  id='error.pagenotfound.title'
+                  description='Page title for the 404 error'
+                  defaultMessage='Oh no! Page not found'
+                  tagName='h1'
                 />
-              </a>
-              &nbsp;
-            </div>
-            <Spacer />
-            <BugImage src='/static/img/bug.png' />
-            <BugContainer>
-              <p>
-                  An <strong>HTTP {this.props.errorCode}</strong> error occurred
-                  while trying to access{' '}
-                <strong>{this.props.router.asPath}</strong>
-              </p>
-            </BugContainer>
-          </FullPage>
+                <FormattedMessage
+                  id='error.pagenotfound.description'
+                  defaultMessage="The page you are looking for is not here. We have looked everywhere but it doesn't seem to exist. Perhaps it just hasn't been built yet."
+                />
+                &nbsp;
+                <a href='https://voluntarily.nz/get-involved'>
+                  <FormattedMessage
+                    id='error.pagenotfound.contribute'
+                    defaultMessage='If you can write code you can help fix that by becoming a contributor to the project.'
+                  />
+                </a>
+                &nbsp;
+              </div>
+              <Spacer />
+              <BugImage src='/static/img/bug.png' />
+              <BugContainer>
+                <p>
+                    An <strong>HTTP {this.props.errorCode}</strong> error occurred
+                    while trying to access{' '}
+                  <strong>{this.props.router.asPath}</strong>
+                </p>
+              </BugContainer>
+            </FullPage>
+          </IntlProvider>
         )
         break
       default:
         response = (
-          <FullPage>
-            <Head>
-              <FormattedMessage
-                id='error.servererror.title'
-                description='Page title for error pages'
-                defaultMessage='There was a problem'
-                tagName='title'
-              />
-            </Head>
-            <Spacer />
-            <Spacer />
-            <div>
-              <FormattedMessage
-                id='error.servererror.description'
-                description='A server error'
-                defaultMessage='Sorry, there was a problem and we can not complete this task. We have let our team know so they can take a look and fix it. For now try to refresh the page, or go back to the previous page'
-                tagName='h2'
-              />
-              <h4 className='display-4'>HTTP {this.props.errorCode} Error</h4>
-              <p>
-                  An <strong>HTTP {this.props.errorCode}</strong> error occurred
-                  while trying to access{' '}
-                <strong>{this.props.router.asPath}</strong>
-              </p>
-              &nbsp;
-            </div>
-          </FullPage>
+          <IntlProvider
+            locale={this.props.locale}
+            messages={this.props.messages}
+            initialNow={this.props.initialNow}
+          >
+            <FullPage>
+              <Head>
+                <IntlProvider
+                  locale={this.props.locale}
+                  messages={this.props.messages}
+                  initialNow={this.props.initialNow}
+                >
+                  <FormattedMessage
+                    id='error.servererror.title'
+                    description='Page title for error pages'
+                    defaultMessage='There was a problem'
+                    tagName='title'
+                  />
+                </IntlProvider>
+              </Head>
+              <Spacer />
+              <Spacer />
+              <div>
+                <FormattedMessage
+                  id='error.servererror.description'
+                  description='A server error'
+                  defaultMessage='Sorry, there was a problem and we can not complete this task. We have let our team know so they can take a look and fix it. For now try to refresh the page, or go back to the previous page'
+                  tagName='h2'
+                />
+                <h4 className='display-4'>HTTP {this.props.errorCode} Error</h4>
+                <p>
+                    An <strong>HTTP {this.props.errorCode}</strong> error occurred
+                    while trying to access{' '}
+                  <strong>{this.props.router.asPath}</strong>
+                </p>
+                &nbsp;
+              </div>
+            </FullPage>
+          </IntlProvider>
         )
     }
 


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Fix errors relating to React Intl not being able to find the intl object

## Additional Info.🧐

For the fixes to the `ErrorPage` I first attempted to make it extend the `IntlDocument` (from `pages/_document.js`) but this didn't give the results I was hoping for and generated lots of errors. It seems like what gets passed to `getInitialProps` is different for `_error.js` compared to `_document.js` (e.g. `context.renderPage` was not available in `_error.js`). This is why I went with the approach you can see in these changes (using the `IntlProvider` where appropriate in `_error.js`).