### PR TITLE
VP-943 Use exists instead of isEmpty

### DIFF
--- a/components/Person/__tests__/PersonBadge.spec.js
+++ b/components/Person/__tests__/PersonBadge.spec.js
@@ -27,5 +27,5 @@ test('PersonBadge renders properly', async t => {
   }
   global.fetch = mockServer
   const PersonBadgeRendered = mount(<PersonBadgeSection person={person} />)
-  t.falsy(PersonBadgeRendered.isEmpty())
+  t.true(PersonBadgeRendered.exists())
 })


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Fix a deprecation warning that was being generated while running unit tests

## Additional info

Enzyme has deprecated use of isEmpty and recommend using exists instead.

There is a brief discussion of the deprecation here: https://github.com/airbnb/enzyme/issues/705