### PR TITLE
VP-942 Automatically prefix http to a profile website url if no scheme is supplied

### DIFF
--- a/components/Person/PersonDetail.js
+++ b/components/Person/PersonDetail.js
@@ -1,3 +1,4 @@
+import { defaultToHttpScheme } from '../../lib/urlUtil'
 import { Divider, Icon } from 'antd'
 import Markdown from 'markdown-to-jsx'
 import Head from 'next/head'
@@ -116,7 +117,7 @@ const PersonDetail = ({ person }, ...props) => (
             </a>
           </li>
           <li>
-            <a href={person.website} rel='noopener noreferrer' target='_blank'>
+            <a href={defaultToHttpScheme(person.website)} rel='noopener noreferrer' target='_blank'>
               <StyledIcon type='global' />
               {person.website}
             </a>

--- a/lib/__tests__/urlUtil.spec.js
+++ b/lib/__tests__/urlUtil.spec.js
@@ -1,0 +1,26 @@
+import test from 'ava'
+import { defaultToHttpScheme } from '../urlUtil'
+
+test('defaultToHttpScheme - falsey returns empty string', t => {
+  t.is(defaultToHttpScheme(''), '')
+  t.is(defaultToHttpScheme(undefined), '')
+  t.is(defaultToHttpScheme(null), '')
+  t.is(defaultToHttpScheme('   '), '')
+})
+
+test('defaultToHttpScheme - no scheme', t => {
+  t.is(defaultToHttpScheme('space.com'), 'http://space.com')
+  t.is(defaultToHttpScheme('subdomain.space.com'), 'http://subdomain.space.com')
+})
+
+test('defaultToHttpScheme - scheme', t => {
+  t.is(defaultToHttpScheme('http://space.com'), 'http://space.com')
+  t.is(defaultToHttpScheme('http://subdomain.space.com'), 'http://subdomain.space.com')
+
+  t.is(defaultToHttpScheme('https://space.com'), 'https://space.com')
+  t.is(defaultToHttpScheme('https://subdomain.space.com'), 'https://subdomain.space.com')
+})
+
+test('defaultToHttpScheme - existing scheme', t => {
+  t.is(defaultToHttpScheme('ftp://space.com'), 'ftp://space.com')
+})

--- a/lib/urlUtil.js
+++ b/lib/urlUtil.js
@@ -1,0 +1,25 @@
+/**
+ * Ensures that the URL string begins with either http or https scheme if no scheme is supplied.
+ * @param {string} url A URL.
+ */
+const defaultToHttpScheme = (url) => {
+  url = (url || '').trim()
+
+  if (!url) {
+    return ''
+  }
+
+  if (/^.+:\/\//.test(url)) {
+    return url
+  }
+
+  if (!/^https?:\/\//.test(url)) {
+    return `http://${url}`
+  }
+
+  return url
+}
+
+module.exports = {
+  defaultToHttpScheme
+}


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. 
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
