### PR TITLE
VP-908 Fix "organisation is not available" message when creating new organisation

### DIFF
--- a/components/Org/OrgDetailForm.js
+++ b/components/Org/OrgDetailForm.js
@@ -605,7 +605,7 @@ OrgDetailForm.propTypes = {
   org: PropTypes.shape({
     name: PropTypes.string,
     info: PropTypes.shape({
-      about: PropTypes.string.isRequired,
+      about: PropTypes.string,
       followers: PropTypes.string,
       joiners: PropTypes.string,
       members: PropTypes.string,

--- a/pages/org/orgdetailpage.js
+++ b/pages/org/orgdetailpage.js
@@ -148,7 +148,7 @@ class OrgDetailPage extends Component {
         </div>
       )
     } else {
-      content = this.state.editing ? (
+      content = (this.state.editing || this.props.isNew) ? (
         <div>
           <OrgDetailForm
             org={org}

--- a/pages/org/orgdetailpage.js
+++ b/pages/org/orgdetailpage.js
@@ -79,6 +79,7 @@ class OrgDetailPage extends Component {
 
   async handleSubmit (org) {
     if (!org) return
+
     // Actual data request
     let res = {}
     if (org._id) {
@@ -88,6 +89,8 @@ class OrgDetailPage extends Component {
           { body: JSON.stringify(org) }
         )
       )
+
+      this.setState({ editing: false })
     } else {
       res = await this.props.dispatch(
         reduxApi.actions.organisations.post({}, { body: JSON.stringify(org) })
@@ -95,7 +98,7 @@ class OrgDetailPage extends Component {
       org = res[0]
       Router.replace(`/orgs/${org._id}`)
     }
-    this.setState({ editing: false })
+
     message.success('Saved.')
   }
 
@@ -114,18 +117,19 @@ class OrgDetailPage extends Component {
 
     let content = ''
     let org = null
-    if (this.props.organisations.loading) {
+
+    if (this.props.organisations.data.length === 1 && this.props.isNew) {
+      // we've just submitted the form but haven't redirected to the org URL yet
+      content = <Loading />
+    } else if (this.props.organisations.data.length === 1) {
+      org = this.props.organisations.data[0]
+    } else if (this.props.organisations.loading) {
       content = <Loading />
     } else if (this.props.isNew) {
       org = blankOrg
-    } else {
-      const orgs = this.props.organisations.data
-      if (orgs.length === 1) {
-        org = orgs[0]
-      }
     }
 
-    if (!org) {
+    if (!org && !content) {
       content = (
         <div>
           <h2>Sorry this organisation is not available</h2>
@@ -147,7 +151,7 @@ class OrgDetailPage extends Component {
         </Button> */}
         </div>
       )
-    } else {
+    } else if (org) {
       content = (this.state.editing || this.props.isNew) ? (
         <div>
           <OrgDetailForm
@@ -213,6 +217,7 @@ class OrgDetailPage extends Component {
         </div>
       )
     }
+
     return <FullPage>{content}</FullPage>
   }
 }


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Remove flash of empty org detail when clicking the new organisation button
2. Remove flash of "Sorry this organisation is not available" when submitting the org detail form for a new org
3. Removed the `isRequired` from OrgDetailForm prop `org.info.about` as this field is not required on the form so probably shouldn't be required in the prop type definition

## Additional Info.🧐

@avowkind feel free to close this if you have already fixed it, just thought I'd create this now because I'd already done the work