### PR TITLE
VP-951 dump and restore alpha and beta databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ public/static/upload/*
 public/static/upload-test/*
 .vs/
 /.test/
+dump

--- a/x/atlas/alpha-dump
+++ b/x/atlas/alpha-dump
@@ -1,0 +1,2 @@
+# Dumps the vly-alpha database to dump/vly-alpha locally
+mongodump --host Cluster0-shard-0/cluster0-shard-00-00-kwmsu.mongodb.net:27017,cluster0-shard-00-01-kwmsu.mongodb.net:27017,cluster0-shard-00-02-kwmsu.mongodb.net:27017 --ssl --username vly-client --password ZhF3BUDiwpy8C3xK --authenticationDatabase admin --db vly-alpha

--- a/x/atlas/alpha-restore
+++ b/x/atlas/alpha-restore
@@ -1,0 +1,2 @@
+# restores the vly-alpha database from dump/vly-alpha locally
+mongorestore --host Cluster0-shard-0/cluster0-shard-00-00-kwmsu.mongodb.net:27017,cluster0-shard-00-01-kwmsu.mongodb.net:27017,cluster0-shard-00-02-kwmsu.mongodb.net:27017 --ssl --username vly-client --password ZhF3BUDiwpy8C3xK --authenticationDatabase admin --db vly-alpha

--- a/x/atlas/beta-dump
+++ b/x/atlas/beta-dump
@@ -1,0 +1,3 @@
+
+mongodump --host Cluster0-shard-0/cluster0-shard-00-00-kwmsu.mongodb.net:27017,cluster0-shard-00-01-kwmsu.mongodb.net:27017,cluster0-shard-00-02-kwmsu.mongodb.net:27017 --ssl --username vly-client --password ZhF3BUDiwpy8C3xK --authenticationDatabase admin --db vly-beta
+

--- a/x/atlas/beta-restore
+++ b/x/atlas/beta-restore
@@ -1,0 +1,1 @@
+mongorestore --host Cluster0-shard-0/cluster0-shard-00-00-kwmsu.mongodb.net:27017,cluster0-shard-00-01-kwmsu.mongodb.net:27017,cluster0-shard-00-02-kwmsu.mongodb.net:27017 --ssl --username vly-client --password ZhF3BUDiwpy8C3xK --authenticationDatabase admin --db vly-beta


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. add scripts to x/atlas to dump and restore test databases vly-alpha and vly-beta
2. used script to move data from vly2-alpha to vly-alpha to make db names consistent
3. added dump folder to .gitignore so that backups are not put into git.

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
