### PR TITLE
VP-951 update deploy-beta to use southeast-2 Repository

### DIFF
--- a/x/aws/deploy-beta
+++ b/x/aws/deploy-beta
@@ -1,17 +1,15 @@
 #!/bin/bash
 MY_DIR=$( dirname "${BASH_SOURCE[0]}" )
 
-# Get a docker login and run it
-source ${MY_DIR}/login-singapore
-
-# pull latest alpha image
-docker pull 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly-alpha:master
-
-# retag
-docker image tag 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-beta:master
-
 # login to sydney
 source ${MY_DIR}/login-sydney
+
+# pull latest alpha image
+docker pull 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-alpha:master
+
+# retag
+docker image tag 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-beta:master
+
 
 # push the new image
 docker push 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-beta:master


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Deploy beta script now pulls from the alpha repo tags and pushes again.
2. 
3. 

## Additional Info.🧐
There is probably an AWS API call that could be called to retag the image without having to pull and push it. 

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
