### PR TITLE
VP-911 remove hidden goals from GoalSection data

### DIFF
--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -14,6 +14,7 @@ import { FullPage, P, PageBanner, PageBannerButtons } from '../../components/VTh
 import securePage from '../../hocs/securePage'
 import reduxApi, { withHomeData, withPeople } from '../../lib/redux/reduxApi.js'
 import { MemberStatus } from '../../server/api/member/member.constants'
+import { PersonalGoalStatus } from '../../server/api/personalGoal/personalGoal.constants'
 
 const { TabPane } = Tabs
 
@@ -123,13 +124,16 @@ class PersonHomePage extends Component {
     const vops = this.interestedOps()
     // create inverted list of goals with the pg as a child.
     // this lets us use the same goal cards
-    const personalGoals = this.props.personalGoals.data.map(pg => {
-      return ({
-        ...pg.goal,
-        personalGoal: pg,
-        status: pg.status
+    // also remove goals flagged as hidden
+    const personalGoals = this.props.personalGoals.data
+      .filter(pg => pg.status !== PersonalGoalStatus.HIDDEN)
+      .map(pg => {
+        return ({
+          ...pg.goal,
+          personalGoal: pg,
+          status: pg.status
+        })
       })
-    })
     const opsTab = (
       <span style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
         <Icon type='inbox' />


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
The title of the Goals Section is taken from the group of the first card in the list.  This allows the section title to gradually change from Getting Started to new things to do as the goals progress. 
The user has a feature where they can click on the (x) in the top right corner to hide a card for a week. While hidden cards are not drawn they are still in the list and affect the section title.

This change removes hidden personal goals from the list when preparing them for display. 


## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
