### PR TITLE
VP-884 my/org puts admins first

### DIFF
--- a/server/api/member/__tests__/findMy.spec.js
+++ b/server/api/member/__tests__/findMy.spec.js
@@ -25,6 +25,12 @@ test.before('before connect to database', async (t) => {
     const members = [
       {
         person: t.context.andrew._id,
+        organisation: t.context.orgs[1]._id,
+        validation: 'follower',
+        status: MemberStatus.FOLLOWER
+      },
+      {
+        person: t.context.andrew._id,
         organisation: t.context.orgs[0]._id,
         validation: 'orgAdmin',
         status: MemberStatus.ORGADMIN

--- a/server/api/member/member.lib.js
+++ b/server/api/member/member.lib.js
@@ -1,6 +1,7 @@
 const Member = require('./member')
 const PubSub = require('pubsub-js')
 const { TOPIC_MEMBER__UPDATE } = require('../../services/pubsub/topic.constants')
+const { MemberStatus } = require('./member.constants')
 
 /* get a single member record with org and person populated out */
 const getMemberbyId = id => {
@@ -28,6 +29,19 @@ const addMember = async (member) => {
   return got
 }
 
+function compareMemberStatus (a, b) {
+  if (a.status === b.status) return 0
+  if (a.status === MemberStatus.ORGADMIN) return -1
+  if (b.status === MemberStatus.ORGADMIN) return 1
+  if (a.status === MemberStatus.MEMBER) return -1
+  if (b.status === MemberStatus.MEMBER) return 1
+  if (a.status === MemberStatus.FOLLOWER) return -1
+  if (b.status === MemberStatus.FOLLOWER) return 1
+
+  // all others return arbitary a
+  return -1
+}
+
 const findOrgByPersonIdAndCategory = async (personId, category) => {
   // search membership table for org matching category and person id
   const query = { person: personId }
@@ -41,6 +55,8 @@ const findOrgByPersonIdAndCategory = async (personId, category) => {
   if (!myorgs.length) { // failed to find matching org
     return null
   }
+  // sort to give most important level of membership first.
+  myorgs.sort(compareMemberStatus)
   // get id of Organisation
   return myorgs[0].organisation._id
 }


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
When a person visits /my/org they are redirected to the organisation they belong to.
If they belong to more than one organisation we want to ensure that they are routed to the 'most important' of the choices. first priority is given to orgs for which the person is OrgAdmin, then Membership then followers. 

This is achieved by sorting the members list returned for the person by membership status. 
