### PR TITLE
VP-893 hide goal cards once completed and seen

### DIFF
--- a/server/api/personalGoal/__tests__/personalGoal.lib.spec.js
+++ b/server/api/personalGoal/__tests__/personalGoal.lib.spec.js
@@ -134,6 +134,37 @@ test.serial('Evaluate the personal goals - hidden and unhide', async t => {
   t.falsy(apg)
 })
 
+test.serial('Evaluate the personal goals - complete to closed ', async t => {
+  const personalGoalAlice = {
+    person: t.context.alice._id,
+    goal: t.context.goal._id,
+    status: PersonalGoalStatus.COMPLETED,
+    dateCompleted: Date.now()
+  }
+
+  let apg = await addPersonalGoal(personalGoalAlice)
+  t.truthy(apg)
+  t.is(apg.status, PersonalGoalStatus.COMPLETED)
+
+  // run the evaluation - not much should happen
+  evaluatePersonalGoals(t.context.alice._id)
+  apg = await PersonalGoal.findById(apg._id).exec()
+  t.is(apg.status, PersonalGoalStatus.COMPLETED)
+
+  // set date back in time
+  apg.dateCompleted = '2019-01-01T00:00:00.000Z'
+  await apg.save()
+  // run the evaluation - record becomes unhidden
+  await evaluatePersonalGoals(t.context.alice._id)
+  apg = await PersonalGoal.findById(apg._id).exec()
+  t.is(apg.status, PersonalGoalStatus.CLOSED)
+
+  // clean up - check record is removed
+  await apg.remove()
+  apg = await PersonalGoal.findById(apg._id).exec()
+  t.falsy(apg)
+})
+
 test.serial('Evaluate the personal goals - true completes', async t => {
   const personalGoalAlice = {
     person: t.context.alice._id,

--- a/server/api/personalGoal/__tests__/personalGoal.spec.js
+++ b/server/api/personalGoal/__tests__/personalGoal.spec.js
@@ -86,7 +86,7 @@ test.serial('Should give a list of goals for a person', async t => {
   const personalGoals = res.body
   t.deepEqual(3, personalGoals.length)
   // sorted by status
-  t.is(personalGoals[0].status, PersonalGoalStatus.COMPLETED)
+  t.is(personalGoals[0].status, PersonalGoalStatus.CLOSED)
   t.is(personalGoals[1].status, PersonalGoalStatus.COMPLETED)
   t.is(personalGoals[2].status, PersonalGoalStatus.QUEUED)
 })

--- a/server/api/personalGoal/personalGoal.constants.js
+++ b/server/api/personalGoal/personalGoal.constants.js
@@ -5,7 +5,8 @@ const PersonalGoalStatus = {
   ACTIVE: 'active', // goal has been started but not finished - in progress
   COMPLETED: 'completed', // goal has been completed - met its evaluation test
   HIDDEN: 'hidden', // goal has been hidden (but not deleted)
-  CANCELLED: 'cancelled' // goal has been cancelled.
+  CANCELLED: 'cancelled', // goal has been cancelled.
+  CLOSED: 'closed' // completed and expired
 }
 
 module.exports = {

--- a/server/api/personalGoal/personalGoal.js
+++ b/server/api/personalGoal/personalGoal.js
@@ -16,7 +16,8 @@ const personalGoalSchema = new Schema({
       PersonalGoalStatus.ACTIVE,
       PersonalGoalStatus.COMPLETED,
       PersonalGoalStatus.HIDDEN,
-      PersonalGoalStatus.CANCELLED
+      PersonalGoalStatus.CANCELLED,
+      PersonalGoalStatus.CLOSED
     ]
   },
   // date when goal added to persons queue

--- a/server/api/personalGoal/personalGoal.lib.js
+++ b/server/api/personalGoal/personalGoal.lib.js
@@ -68,6 +68,12 @@ const evaluatePersonalGoals = async (person) => {
       delete pg.dateHidden
       return Promise.resolve(pg.save())
     }
+    // close items after a week of being completed
+    if (pg.status === PersonalGoalStatus.COMPLETED &&
+      isDaysAgo(moment(pg.dateCompleted), 7)) {
+      pg.status = PersonalGoalStatus.CLOSED
+      return Promise.resolve(pg.save())
+    }
     // dump the evaluation
     try {
       /* eslint-disable no-eval */


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1.  Once a personal goal passes the evaluation test it is marked as 'COMPLETED'.  The completed goal is still visible to the person and has a 'trophy' icon superimposed.  Once the goal has been completed for more than 7 days the state is changed to CLOSED. Closed goals are not displayed and will disappear from the goals tray. 

