### PR TITLE
fix signin for emails containing + char

### DIFF
--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -50,13 +50,13 @@ export const getPersonFromUser = async (user, cookies) => {
     // return false
   }
   try {
-    const query = {
-      email: user.email
-    }
-    const person = await callApi(`people/?q=${JSON.stringify(query)}`, 'get', null, cookies)
+    const query = encodeURIComponent(JSON.stringify({ email: user.email }))
+    const person = await callApi(`people/?q=${query}`, 'get', null, cookies)
+    console.log('got Person', person)
     return person
   } catch (err) {
     // here if we get 403 forbidden - which indicates the person doesn't exist yet.
+
     return createPersonFromUser(user, cookies)
   }
 }
@@ -95,6 +95,7 @@ export const getSession = async (req, store) => {
     isAuthenticated: false,
     me: false
   }
+  // I think this is redundant - we are always on the server side for this call
   const loggedUser = process.browser
     ? getUserFromLocalCookie()
     : getUserFromServerCookie(req)


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Fix a bug where people signing in with email addresses of the form name+name@domain.co.etc. would not be found in the database (due to the + being interpreted as space). 
The fix is to correctly URI encode the query parameters containing the email address.
