### PR TITLE
VP-959 My Profile page has an edit button

### DIFF
--- a/__tests__/person/persondetailpage.spec.js
+++ b/__tests__/person/persondetailpage.spec.js
@@ -1,0 +1,310 @@
+import test from 'ava'
+import sinon from 'sinon'
+import { shallowWithIntl } from '../../lib/react-intl-test-helper'
+import withMockRoute from '../../server/util/mockRouter'
+import { PersonDetailPage } from '../../pages/person/persondetailpage'
+import objectid from 'objectid'
+import orgs from '../../server/api/organisation/__tests__/organisation.fixture'
+import people from '../../server/api/person/__tests__/person.fixture'
+
+test.before('Setup fixtures', (t) => {
+  people.map(p => { p._id = objectid().toString() })
+  orgs.map(p => { p._id = objectid().toString() })
+  const me = people[0]
+
+  // I am orgAdmin of the first org (voluntarily) and member of the second org (OMGTech)
+  const orgMembership = [
+    {
+      _id: objectid().toString(),
+      status: 'orgadmin',
+      person: me._id,
+      organisation: orgs[0]
+    },
+    {
+      _id: objectid().toString(),
+      status: 'member',
+      person: me._id,
+      organisation: orgs[1]
+    }
+  ]
+
+  t.context.store = {
+    session: {
+      isAuthenticated: true,
+      user: { nickname: me.nickname },
+      me
+    },
+    people: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: [me],
+      request: null
+    },
+    tags: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: ['one', 'two', 'three'],
+      request: null
+    },
+    locations: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: ['Auckland, Wellington, Christchurch'],
+      request: null
+    },
+    members: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: orgMembership,
+      request: null
+    }
+  }
+})
+
+test('PersonDetailPage GetInitialProps existing person', async t => {
+  const me = people[0]
+  const query = {
+    id: me._id
+  }
+  const store = {
+    dispatch: sinon.fake(),
+    getState: () => {
+      return ({ session: { me } })
+    }
+  }
+
+  const props = await PersonDetailPage.getInitialProps({ store, query })
+  t.false(props.isNew)
+  t.is(props.personid, me._id)
+  t.is(store.dispatch.callCount, 4)
+})
+
+test('PersonDetailPage GetInitialProps new person', async t => {
+  const me = people[0]
+  const query = {
+    new: 'new'
+  }
+  const store = {
+    dispatch: sinon.fake(),
+    getState: () => {
+      return ({ session: { me } })
+    }
+  }
+
+  const props = await PersonDetailPage.getInitialProps({ store, query })
+  t.true(props.isNew)
+  t.is(props.personid, null)
+  t.is(store.dispatch.callCount, 2)
+})
+
+test('render Loading PersonDetailPage ', async t => {
+  const dali = people[1]
+  const props = {
+    ...t.context.store,
+    me: dali,
+    isNew: false,
+    personid: dali._id,
+    people: {
+      sync: false,
+      syncing: false,
+      loading: true,
+      data: [],
+      request: null
+    },
+    members: {
+      sync: false,
+      syncing: false,
+      loading: false,
+      data: [],
+      request: null
+    }
+  }
+
+  const RoutedPersonDetailPage = withMockRoute(PersonDetailPage)
+  const outer = shallowWithIntl(<RoutedPersonDetailPage {...props} />)
+  const wrapper = outer.dive()
+
+  t.false(wrapper.exists('PersonDetail'))
+})
+
+test('render unknown person PersonDetailPage ', async t => {
+  const unknown = objectid.toString()
+  const dali = people[1]
+
+  const props = {
+    ...t.context.store,
+    me: dali,
+    isNew: false,
+    personid: unknown,
+    people: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: [],
+      request: null
+    },
+    members: {
+      sync: false,
+      syncing: false,
+      loading: false,
+      data: [],
+      request: null
+    }
+  }
+
+  const RoutedPersonDetailPage = withMockRoute(PersonDetailPage)
+  const outer = shallowWithIntl(<RoutedPersonDetailPage {...props} />)
+  const wrapper = outer.dive()
+
+  t.false(wrapper.exists('PersonDetail'))
+  t.is(wrapper.find('FormattedMessage').first().props().id, 'person.notavailable')
+})
+
+test('render Dalis PersonDetailPage as non admin random person alice', async t => {
+  const dali = people[1]
+  const alice = people[2]
+  const props = {
+    ...t.context.store,
+    me: alice,
+    isNew: false,
+    personid: dali._id,
+    people: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: [dali],
+      request: null
+    }
+  }
+
+  const RoutedPersonDetailPage = withMockRoute(PersonDetailPage)
+  const outer = shallowWithIntl(<RoutedPersonDetailPage {...props} />)
+  const wrapper = outer.dive()
+
+  t.true(wrapper.exists('PersonDetail'))
+  t.is(wrapper.find('PersonDetail').first().props().person, dali)
+
+  // as I am no one there should be no buttons
+  t.false(wrapper.exists('Button'))
+})
+
+test('render Dalis PersonDetailPage as admin ', async t => {
+  const admin = people[0]
+  const dali = people[1]
+  const props = {
+    ...t.context.store,
+    me: admin,
+    isNew: false,
+    personid: dali._id,
+    people: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: [dali],
+      request: null
+    },
+    dispatch: sinon.fake()
+  }
+
+  const RoutedPersonDetailPage = withMockRoute(PersonDetailPage)
+  const outer = shallowWithIntl(<RoutedPersonDetailPage {...props} />)
+  const wrapper = outer.dive()
+
+  t.true(wrapper.exists('PersonDetail'))
+  t.is(wrapper.find('PersonDetail').first().props().person, dali)
+
+  // as I am no one there should be two buttons
+  t.is(wrapper.find('Button').length, 2)
+  t.true(wrapper.exists('IssueBadge'))
+  t.true(wrapper.exists('#deletePersonBtn'))
+  await wrapper.find('#deletePersonConfirm').first().props().onCancel()
+  await wrapper.find('#deletePersonConfirm').first().props().onConfirm(dali)
+  t.is(props.dispatch.callCount, 1)
+})
+
+test('render Dalis PersonDetailPage as self dali', async t => {
+  const dali = people[1]
+  const props = {
+    ...t.context.store,
+    me: dali,
+    isNew: false,
+    personid: dali._id,
+    people: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: [dali],
+      request: null
+    },
+    dispatch: sinon.fake()
+  }
+
+  const RoutedPersonDetailPage = withMockRoute(PersonDetailPage)
+  const outer = shallowWithIntl(<RoutedPersonDetailPage {...props} />)
+  const wrapper = outer.dive()
+
+  t.true(wrapper.exists('PersonDetail'))
+  t.is(wrapper.find('PersonDetail').first().props().person, dali)
+
+  // as I am me there should be only an edit button
+  t.is(wrapper.find('Button').length, 1)
+  t.true(wrapper.exists('#editPersonBtn'))
+
+  // click the edit button
+  const editPerson = wrapper.find('Button#editPersonBtn')
+  editPerson.props().onClick()
+  // we should now be in edit mode
+  t.true(wrapper.exists('Form(PersonDetailForm)'))
+  // cancel the edit
+  wrapper.find('Form(PersonDetailForm)').first().props().onCancel()
+  t.is(wrapper.find('Button').length, 1)
+
+  // edit again
+  editPerson.props().onClick()
+  t.true(wrapper.exists('Form(PersonDetailForm)'))
+  // save the edit
+  await wrapper.find('Form(PersonDetailForm)').first().props().onSubmit(dali)
+  t.true(wrapper.exists('#editPersonBtn'))
+  t.is(props.dispatch.callCount, 1)
+})
+
+test('render new PersonDetailPage as admin ', async t => {
+  const admin = people[0]
+  const alice = people[2]
+  const props = {
+    ...t.context.store,
+    me: admin,
+    isNew: true,
+    personid: null,
+    people: {
+      sync: true,
+      syncing: false,
+      loading: false,
+      data: [],
+      request: null
+    },
+    dispatch: sinon.fake.returns([alice])
+  }
+
+  const RoutedPersonDetailPage = withMockRoute(PersonDetailPage)
+  const outer = shallowWithIntl(<RoutedPersonDetailPage {...props} />)
+  const router = outer.props().router
+  router.back = sinon.fake()
+  router.replace = sinon.fake()
+  const wrapper = outer.dive()
+
+  // we should start in edit mode
+  t.true(wrapper.exists('Form(PersonDetailForm)'))
+  // cancel the edit
+  wrapper.find('Form(PersonDetailForm)').first().props().onCancel()
+  t.is(router.back.callCount, 1)
+
+  // save the edit
+  await wrapper.find('Form(PersonDetailForm)').first().props().onSubmit(alice)
+  t.is(props.dispatch.callCount, 1)
+  t.is(router.replace.lastArg, '/people')
+})

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -52,7 +52,6 @@ export const getPersonFromUser = async (user, cookies) => {
   try {
     const query = encodeURIComponent(JSON.stringify({ email: user.email }))
     const person = await callApi(`people/?q=${query}`, 'get', null, cookies)
-    console.log('got Person', person)
     return person
   } catch (err) {
     // here if we get 403 forbidden - which indicates the person doesn't exist yet.

--- a/pages/person/persondetailpage.js
+++ b/pages/person/persondetailpage.js
@@ -165,7 +165,7 @@ export class PersonDetailPage extends Component {
           content =
             <>
               {canEdit &&
-                <Button id='editPersonBtn' style={{ float: 'right' }} type='secondary' shape='round' onClick={() => this.setState({ editing: true })}>
+                <Button id='editPersonBtn' style={{ float: 'right' }} type='primary' shape='round' onClick={() => this.setState({ editing: true })}>
                   <FormattedMessage id='person.edit' defaultMessage='Edit' description='Button to edit a person' />
                 </Button>}
               <PersonDetail person={person} />

--- a/pages/person/persondetailpage.js
+++ b/pages/person/persondetailpage.js
@@ -81,15 +81,14 @@ export class PersonDetailPage extends Component {
   }
 
   handleCancelEdit = () => {
-    this.setState({ editing: false })
     if (this.props.isNew) { // return to previous
-      Router.back()
+      return Router.back()
     }
+    this.setState({ editing: false })
   }
 
   // TODO: [VP-209] only show person delete button for admins
-  async handleDelete (person) {
-    if (!person) return
+  async handleDeletePerson (person) {
     await this.props.dispatch(reduxApi.actions.people.delete({ id: person._id }))
     // TODO error handling - how can this fail?
     message.success('Deleted. ')
@@ -97,17 +96,16 @@ export class PersonDetailPage extends Component {
   }
 
   async handleSubmit (person) {
-    if (!person) return
     // Actual data request
     let res = {}
     if (person._id) {
       res = await this.props.dispatch(reduxApi.actions.people.put({ id: person._id }, { body: JSON.stringify(person) }))
+      this.setState({ editing: false })
     } else {
       res = await this.props.dispatch(reduxApi.actions.people.post({}, { body: JSON.stringify(person) }))
       person = res[0]
       Router.replace(`/people/${person._id}`)
     }
-    this.setState({ editing: false })
     message.success('Saved.')
   }
 
@@ -116,7 +114,6 @@ export class PersonDetailPage extends Component {
   render () {
     const isOrgAdmin = false // TODO: [VP-473] is this person an admin for the org that person belongs to.
     const isAdmin = (this.props.me && this.props.me.role.includes('admin'))
-    const canEdit = (isOrgAdmin || isAdmin)
     const canRemove = isAdmin
     const showPeopleButton = isAdmin
 
@@ -132,6 +129,7 @@ export class PersonDetailPage extends Component {
         person = people[0]
       }
     }
+    const canEdit = (isOrgAdmin || isAdmin || (person && person._id === this.props.me._id))
 
     if (this.props.members.sync && this.props.members.data.length > 0) {
       person.orgMembership = this.props.members.data.filter(m => m.status === MemberStatus.MEMBER)
@@ -167,15 +165,15 @@ export class PersonDetailPage extends Component {
           content =
             <>
               {canEdit &&
-                <Button style={{ float: 'right' }} type='secondary' shape='round' onClick={() => this.setState({ editing: true })}>
+                <Button id='editPersonBtn' style={{ float: 'right' }} type='secondary' shape='round' onClick={() => this.setState({ editing: true })}>
                   <FormattedMessage id='person.edit' defaultMessage='Edit' description='Button to edit a person' />
                 </Button>}
               <PersonDetail person={person} />
             &nbsp;
               {canRemove &&
-                <Popconfirm title='Confirm removal of this person.' onConfirm={this.handleDeletePerson} onCancel={this.handleCancelDelete.bind(this)} okText='Yes' cancelText='No'>
-                  <Button type='danger' shape='round'>
-                    <FormattedMessage id='deletePerson' defaultMessage='Remove Person' description='Button to remove an person on PersonDetails page' />
+                <Popconfirm id='deletePersonConfirm' title='Confirm removal of this person.' onConfirm={this.handleDeletePerson.bind(this, person)} onCancel={this.handleCancelDelete.bind(this)} okText='Yes' cancelText='No'>
+                  <Button id='deletePersonBtn' type='danger' shape='round'>
+                    <FormattedMessage id='person.delete' defaultMessage='Remove Person' description='Button to remove an person on PersonDetails page' />
                   </Button>
                 </Popconfirm>}
             &nbsp;
@@ -189,7 +187,7 @@ export class PersonDetailPage extends Component {
     return (
       <FullPage>
         <Helmet>
-          <title>Voluntarily - Person Details</title>
+          <title>Person Details - Voluntarily</title>
         </Helmet>
         {content}
       </FullPage>


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. The /person/id page shows a persons profile independently of the home page.  This is visible to all people and is their public profile.  This page can be edited by Admins, OrgAdmins and the person themselves.  A missing test meant that people could not edit their own profile on this page. 
This change makes the edit button available to people and also adds a full unit test for the persondetailpage.

## Additional Info.🧐
This is important as this page is the one linked to by the Complete your profile goal card.

## Screenshots 📷
 
<img width="898" alt="image" src="https://user-images.githubusercontent.com/1596437/72017237-31e38b80-32ca-11ea-92f8-de64b45f29e6.png">
