### PR TITLE
Vp 781 create find first opportunity goal

### DIFF
--- a/server/api/goal/__init__/goal.init.js
+++ b/server/api/goal/__init__/goal.init.js
@@ -52,7 +52,7 @@ volunteer opportunities.
     startLink: '/goal/school/ready',
     language: 'en',
     rank: 2,
-    evaluation: (personalGoal) => GoalTests.personBadged(personalGoal)
+    evaluation: (personalGoal) => { return GoalTests.personBadged(personalGoal) }
   },
   {
     group: GoalGroup.VP_NEW,
@@ -79,9 +79,9 @@ This goal will collect the required information and your permission to run the c
   },
   {
     group: GoalGroup.VP_NEW,
-    name: 'Complete first volunteering activity',
+    name: 'Find first volunteering activity',
     subtitle: 'Its time to find your first volunteering opportunity.',
-    slug: 'goal-complete-first-activity',
+    slug: 'goal-find-first-activity',
     imgUrl: '/static/img/goal/goal-first-volunteer.png',
     description: `
 Its time to find your first volunteering opportunity.
@@ -91,14 +91,12 @@ Or you can click *Start* here to open the search page.
 
 Once you find something click the <strong>Interested</strong> button.
 You can leave a message and the organiser will be notified.
-
-You'll get an email notification and can accept or decline the invitation.
 `,
     preconditions: [],
     startLink: '/search',
     language: 'en',
     rank: 3,
-    evaluation: () => { console.log('does person have first-volunteer-activity badge'); return false }
+    evaluation: (personalGoal) => { return GoalTests.personInterested(personalGoal) }
   },
 
   /*********************************************/

--- a/server/api/goal/__tests__/loadGoals.spec.js
+++ b/server/api/goal/__tests__/loadGoals.spec.js
@@ -21,5 +21,5 @@ test('Should correctly give count of all goals sorted by rank', async t => {
   t.is(count, goals.length)
   await loadGoals()
   count = await Goal.countDocuments()
-  t.is(count, 11) // union of the two sources
+  t.is(count, 12) // union of the two sources
 })

--- a/server/api/interest/__tests__/interest.lib.spec.js
+++ b/server/api/interest/__tests__/interest.lib.spec.js
@@ -1,6 +1,5 @@
 import test from 'ava'
 import Interest from '../interest'
-import { InterestStatus } from '../interest.constants'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import Person from '../../person/person'
 import people from '../../person/__tests__/person.fixture'
@@ -8,9 +7,7 @@ import Opportunity from '../../opportunity/opportunity'
 import ops from '../../opportunity/__tests__/opportunity.fixture'
 import Organisation from '../../organisation/organisation'
 import orgs from '../../organisation/__tests__/organisation.fixture'
-
 import { personInterestCount } from '../interest.lib'
-import objectid from 'objectid'
 
 test.before('before connect to database', async (t) => {
   try {
@@ -62,5 +59,4 @@ test.serial('personInterestCount ', async t => {
 
   count = await personInterestCount(t.context.alice._id)
   t.is(count, 1)
-
 })

--- a/server/api/interest/__tests__/interest.lib.spec.js
+++ b/server/api/interest/__tests__/interest.lib.spec.js
@@ -1,0 +1,66 @@
+import test from 'ava'
+import Interest from '../interest'
+import { InterestStatus } from '../interest.constants'
+import MemoryMongo from '../../../util/test-memory-mongo'
+import Person from '../../person/person'
+import people from '../../person/__tests__/person.fixture'
+import Opportunity from '../../opportunity/opportunity'
+import ops from '../../opportunity/__tests__/opportunity.fixture'
+import Organisation from '../../organisation/organisation'
+import orgs from '../../organisation/__tests__/organisation.fixture'
+
+import { personInterestCount } from '../interest.lib'
+import objectid from 'objectid'
+
+test.before('before connect to database', async (t) => {
+  try {
+    t.context.memMongo = new MemoryMongo()
+    await t.context.memMongo.start()
+  } catch (e) {
+    console.error('Interest.spec.js - error in test setup', e)
+  }
+  t.context.people = await Person.create(people).catch((err) => `Unable to create people: ${err}`)
+  t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create organisations: ${err}`)
+  t.context.me = t.context.people[0] // I am the first person.
+  t.context.dali = t.context.people[1]
+  t.context.alice = t.context.people[2]
+
+  // setup opportunities 5 items
+  ops.map((op, index) => {
+    // each op has a different person as requestor, but not me
+    op.requestor = t.context.people[index + 1]._id
+    // all the ops belong to the OMGTech org
+    op.offerOrg = t.context.orgs[1]._id
+  })
+  t.context.ops = await Opportunity.create(ops).catch((err) => console.error('Unable to create opportunities', err))
+
+  // setup interests
+  // each op has person + 2 interested.
+  const interests = t.context.ops.map((op, index) => {
+    const enquirer = t.context.people[index + 2]
+    return {
+      person: enquirer._id,
+      opportunity: op._id,
+      comment: `${index} ${enquirer.nickname} interested in ${op.name}`
+    }
+  })
+  t.context.interests = await Interest.create(interests).catch(() => 'Unable to create interests')
+  console.log(t.context.interests)
+})
+
+test.afterEach.always(async (t) => {
+  await Interest.deleteMany()
+})
+
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
+})
+
+test.serial('personInterestCount ', async t => {
+  let count = await personInterestCount(t.context.me._id)
+  t.is(count, 0)
+
+  count = await personInterestCount(t.context.alice._id)
+  t.is(count, 1)
+
+})

--- a/server/api/interest/interest.js
+++ b/server/api/interest/interest.js
@@ -48,4 +48,12 @@ const interestSchema = new Schema({
 */
 
 interestSchema.plugin(idvalidator)
-module.exports = mongoose.model('Interest', interestSchema)
+// protect multiple imports
+var Interest
+
+if (mongoose.models.Interest) {
+  Interest = mongoose.model('Interest')
+} else {
+  Interest = mongoose.model('Interest', interestSchema)
+}
+module.exports = Interest

--- a/server/api/interest/interest.lib.js
+++ b/server/api/interest/interest.lib.js
@@ -1,0 +1,20 @@
+const Interest = require('./interest')
+const { InterestStatus } = require('./interest.constants')
+
+const personInterestCount = (personId) => {
+  const query = {
+    person: personId,
+    status: {
+      $in: [
+        InterestStatus.INTERESTED,
+        InterestStatus.INVITED,
+        InterestStatus.COMMITTED
+      ]
+    }
+  }
+  return Interest.countDocuments(query).exec()
+}
+
+module.exports = {
+  personInterestCount
+}

--- a/server/api/person/__tests__/person.spec.js
+++ b/server/api/person/__tests__/person.spec.js
@@ -105,7 +105,7 @@ test('Get person by id', async t => {
   t.is(res.body.email, p.email)
 })
 
-test.only('create a new person', async t => {
+test.serial('create a new person', async t => {
   t.plan(7)
 
   // subscribe to published new person messages
@@ -201,7 +201,7 @@ test('Update people', async t => {
   t.is(resUpdated.body.phone, p.phone)
 })
 
-test('Should correctly add a person and sanitise inputs', async t => {
+test.serial('Should correctly add a person and sanitise inputs', async t => {
   t.plan(6)
   const p = {
     name: 'Bobby; DROP TABLES', // is allowed

--- a/server/api/personalGoal/GoalTests.js
+++ b/server/api/personalGoal/GoalTests.js
@@ -4,7 +4,7 @@ const { OpportunityStatus } = require('../opportunity/opportunity.constants')
 const { orgProfileCompletenessById } = require('../organisation/organisation.lib')
 const { personProfileCompletenessById, personHasBadge } = require('../person/person.lib')
 const { findOrgByPersonIdAndCategory } = require('../member/member.lib')
-
+const { personHasInterest: personInterestCount } = require('../interest/interest.lib')
 /* Note These library functions call the database.
 They can fail and throw exceptions, we don't catch them here but
 allow them to be caught at the API layer where we can return a 4xx result
@@ -21,6 +21,12 @@ const GoalTests = {
   },
   personBadged: (personalGoal) => {
     return personHasBadge(personalGoal.person, personalGoal.goal.badgeclass)
+  },
+  // test whether a person has an interested record in an opportunity
+  personInterested: async (personalGoal) => {
+    const count = await personInterestCount(personalGoal.person._id)
+    console.log('personInterested', count)
+    return count > 0
   },
   // test whether an op has been created from an activity for current person or org
   activityStarted: async (personalGoal, activitySlug) => {

--- a/server/api/personalGoal/personalGoal.controller.js
+++ b/server/api/personalGoal/personalGoal.controller.js
@@ -9,7 +9,11 @@ const listPersonalGoals = async (req, res) => {
   // if (!req.session || !req.session.isAuthenticated) { return res.status(403).end() }
 
   const me = req.query.meid
-  await evaluatePersonalGoals(me, req)
+  try {
+    await evaluatePersonalGoals(me, req)
+  } catch (err) {
+    res.status(500)
+  }
   // Return enough info for a goalCard
   const got = await PersonalGoal.find({ person: me })
     .populate({ path: 'goal' })


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
New volunteers after first signing in are given the getting started collection of cards. This includes Find your first activity. The start button on the card links to the search page.  
The evaluation of the card is true when the person has clicked i'm interested on a card.  i.e. it passes so long as there is any interested record for the person. 

## Additional Info.🧐
This doesn't wait for the person to commit or carry out a volunteering activity.  But it will be sufficient to get the first activity into the home page.

## Screenshots 📷
 
### Original


### Updated
