### PR TITLE
VP-828 remove website from banner, add return home btn

### DIFF
--- a/components/Org/OrgBanner.js
+++ b/components/Org/OrgBanner.js
@@ -7,9 +7,8 @@ const OrgBanner = ({ org, children }) =>
   <ProfileBanner>
     <img src={org.imgUrl} alt={org.name} />
     <ProfileBannerTitle>
-      <h1>{org.name}</h1>
-      <OrgCategory orgCategory={org.category} />
-      {org.website && <a href='{org.website}'>{org.website}</a>}
+      <h1><OrgCategory orgCategory={org.category} />{org.name}</h1>
+      {/* {org.website && <a href='{org.website}'>{org.website}</a>} */}
       {children}
     </ProfileBannerTitle>
   </ProfileBanner>

--- a/components/Org/OrgCategory.js
+++ b/components/Org/OrgCategory.js
@@ -5,7 +5,7 @@ import { Category } from '../../server/api/organisation/organisation.constants'
 const HorUl = styled.ul`
   margin:0;
   padding:0;
-
+  display inline-block;
   li {
     display: inline;
     padding-right: 1em;

--- a/components/Org/__tests__/OrgBanner.spec.js
+++ b/components/Org/__tests__/OrgBanner.spec.js
@@ -15,28 +15,28 @@ const org = {
   facebook: 'voluntarilyAotearoa',
   twitter: 'voluntarilyHQ'
 }
-const orgNoWeb = {
-  _id: objectid(),
-  name: 'OMGTech',
-  slug: 'hello-omgtech',
-  imgUrl: '/static/andrew.jpg',
-  category: ['vp', 'ap']
-}
 
 test('OrgBanner has image, title and category icon', t => {
   const children = <p>Test</p>
   const wrapper = shallow(<OrgBanner org={org} children={children} />)
-  t.is(wrapper.find('h1').first().text(), org.name)
+  t.is(wrapper.find('h1').first().text(), `<OrgCategory />${org.name}`)
   t.is(wrapper.find('img').first().prop('src'), org.imgUrl)
   t.true(wrapper.exists('OrgCategory'))
-  t.is(wrapper.find('a').first().text(), org.website)
+  // t.is(wrapper.find('a').first().text(), org.website)
   t.is(wrapper.find('p').first().text(), 'Test')
 })
 
-test('OrgBanner with no website', t => {
-  const children = <p>Test</p>
-  const wrapper = shallow(<OrgBanner org={orgNoWeb} children={children} />)
-  t.is(wrapper.find('h1').first().text(), org.name)
-  t.is(wrapper.find('img').first().prop('src'), org.imgUrl)
-  t.not(wrapper.exists('a'))
-})
+// test('OrgBanner with no website', t => {
+// const orgNoWeb = {
+//   _id: objectid(),
+//   name: 'OMGTech',
+//   slug: 'hello-omgtech',
+//   imgUrl: '/static/andrew.jpg',
+//   category: ['vp', 'ap']
+// }
+//   const children = <p>Test</p>
+//   const wrapper = shallow(<OrgBanner org={orgNoWeb} children={children} />)
+//   t.is(wrapper.find('h1').first().text(), org.name)
+//   t.is(wrapper.find('img').first().prop('src'), org.imgUrl)
+//   t.not(wrapper.exists('a'))
+// })

--- a/components/VTheme/Profile.js
+++ b/components/VTheme/Profile.js
@@ -12,6 +12,7 @@ justify-self: center;
 
 img {
   width: 16rem;
+  max-height: 12rem;
   object-fit: cover;
   align-self: center;
   justify-self: center;
@@ -24,10 +25,6 @@ export const ProfileBannerTitle = styled.div`
   text-align: left;
 }
 
-a {
-  display: block;
-  padding: 1rem 0;
-}
 `
 export const ProfileTabs = styled.nav`
   text-align: left;

--- a/pages/org/orgdetailpage.js
+++ b/pages/org/orgdetailpage.js
@@ -28,7 +28,7 @@ const blankOrg = {
 
 export const OrgEditButton = ({ onClick }) =>
   <Button
-    type='secondary'
+    type='primary'
     shape='round'
     onClick={onClick}
     style={{ float: 'right' }}
@@ -37,6 +37,20 @@ export const OrgEditButton = ({ onClick }) =>
       id='orgDetailPage.button.edit'
       defaultMessage='Edit'
       description='Button to edit an organisation on orgDetailPage'
+    />
+  </Button>
+
+export const HomeButton = () =>
+  <Button
+    type='secondary'
+    shape='round'
+    href='/'
+    style={{ float: 'right' }}
+  >
+    <FormattedMessage
+      id='orgDetailPage.button.home'
+      defaultMessage='Return Home'
+      description='Button to return home after editing'
     />
   </Button>
 
@@ -62,6 +76,7 @@ export const OrgUnknown = () =>
 
 export const OrgDetailPage = ({ members, me, organisations, isNew, dispatch, isAuthenticated }) => {
   const [editing, setEditing] = useState(false)
+  const [saved, setSaved] = useState(false)
   const handleCancel = useCallback(
     () => {
       setEditing(false)
@@ -92,6 +107,7 @@ export const OrgDetailPage = ({ members, me, organisations, isNew, dispatch, isA
         Router.replace(`/orgs/${org._id}`)
       }
       setEditing(false)
+      setSaved(true)
       message.success('Saved.')
     }, [])
 
@@ -127,8 +143,10 @@ export const OrgDetailPage = ({ members, me, organisations, isNew, dispatch, isA
       <Helmet>
         <title>{org.name} / Voluntarily</title>
       </Helmet>
+
       <OrgBanner org={org}>
         {isAuthenticated && <RegisterMemberSection orgid={org._id} meid={me._id} />}
+        {saved && <HomeButton />}
         {canEdit && <OrgEditButton onClick={() => setEditing(true)} />}
       </OrgBanner>
       <OrgTabs org={org} />


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Move website link from banner as it already appears in the contact details block below the tab line. Also we don't want to encourage people to leave the site.
2. Restrict the height of the image to 12rem as this controls the overall height of the banner.  keep the images about 16/12 (4/3) aspect ratio.
3. Move the Org Type icon to just in front of the org name. 
4. When page is edited and then saved set a saved state var and show the return home button. 
This button will remain visible until the page is clean loaded. 

## Additional Info.🧐

## Screenshots 📷

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/1596437/72115166-fff62600-33aa-11ea-8fd7-e9ffcbe2cd8a.png">
