### PR TITLE
VP-807 Limit text input length for Activity and Opportunity forms

### DIFF
--- a/components/Act/ActDetailForm.js
+++ b/components/Act/ActDetailForm.js
@@ -315,7 +315,7 @@ class ActDetailForm extends Component {
                 >
                   {getFieldDecorator('name', {
                     rules: [{ required: true, message: 'Title is required' }]
-                  })(<Input placeholder='Title' maxlength="100" required />)}
+                  })(<Input placeholder='Title' maxlength='100' required />)}
                 </Form.Item>
 
                 <Form.Item label={actSubtitle}>

--- a/components/Act/ActDetailForm.js
+++ b/components/Act/ActDetailForm.js
@@ -315,7 +315,7 @@ class ActDetailForm extends Component {
                 >
                   {getFieldDecorator('name', {
                     rules: [{ required: true, message: 'Title is required' }]
-                  })(<Input placeholder='Title' required />)}
+                  })(<Input placeholder='Title' maxlength="100" required />)}
                 </Form.Item>
 
                 <Form.Item label={actSubtitle}>

--- a/components/Op/OpDetailForm.js
+++ b/components/Op/OpDetailForm.js
@@ -379,7 +379,7 @@ class OpDetailForm extends Component {
                 >
                   {getFieldDecorator('name', {
                     rules: [{ required: true, message: 'name is required' }]
-                  })(<Input placeholder='name' />)}
+                  })(<Input placeholder='name' maxlength="100" />)}
                 </Form.Item>
 
                 <Form.Item label={opSubtitle}>

--- a/components/Op/OpDetailForm.js
+++ b/components/Op/OpDetailForm.js
@@ -379,7 +379,7 @@ class OpDetailForm extends Component {
                 >
                   {getFieldDecorator('name', {
                     rules: [{ required: true, message: 'name is required' }]
-                  })(<Input placeholder='name' maxlength="100" />)}
+                  })(<Input placeholder='name' maxlength='100' />)}
                 </Form.Item>
 
                 <Form.Item label={opSubtitle}>


### PR DESCRIPTION
## I do solemnly swear that I have:
- [✔ ] Run `npm test` and all the tests pass.
- [✔ ] Run `npm run lint` and there are no warnings.
- [ ] Not decreased the overall test coverage?
- [✔ ] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Activity provider and requestor cannot put long titles when creating a new request and activity.
