### PR TITLE
VP-977 update package-lock to remove warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28054,9 +28054,9 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "trim": {


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. run npm audit fix to update package-lock so that a high risk library gets updated.
