### PR TITLE
VP-885 bookmarkable tabs and useRouter tests

### DIFF
--- a/__tests__/home.spec.js
+++ b/__tests__/home.spec.js
@@ -253,10 +253,11 @@ test.serial('run GetInitialProps', async t => {
     .get('path:/api/archivedOpportunities/', { body: t.context.archivedOpportunities })
     .get('path:/api/members/', { body: t.context.members })
     .get('path:/api/opportunities/recommended', { body: [t.context.recommendedOps] })
+    .get('path:/api/interestsArchived/', { body: t.context.archivedInterestFixture })
   reduxApi.use('fetch', adapterFetch(t.context.mockServer))
 
   await PersonHomePageTest.getInitialProps({ store: t.context.mockStore })
-  t.is(t.context.mockStore.getActions().length, 10)
+  t.is(t.context.mockStore.getActions().length, 18)
 })
 
 test.serial('render volunteer home page - Active tab', t => {

--- a/components/Op/OpAboutPanel.js
+++ b/components/Op/OpAboutPanel.js
@@ -30,7 +30,7 @@ OpAboutPanel.propTypes = {
   op: PropTypes.shape({
     tags: PropTypes.arrayOf(
       PropTypes.string
-    ).isRequired,
+    ),
     description: PropTypes.string,
     requestor: PropTypes.object
   }).isRequired

--- a/components/Op/OpBanner.js
+++ b/components/Op/OpBanner.js
@@ -75,7 +75,7 @@ OpBanner.propTypes = {
     imgUrl: PropTypes.any,
     duration: PropTypes.string,
     location: PropTypes.string,
-    _id: PropTypes.string.isRequired
+    _id: PropTypes.string
   })
 }
 

--- a/components/Op/OpCloseOpportunity.js
+++ b/components/Op/OpCloseOpportunity.js
@@ -1,12 +1,13 @@
 import { useCallback } from 'react'
 import { Button, Divider, message, Popconfirm } from 'antd'
-import Router from 'next/router'
+import { useRouter } from 'next/router'
 import { FormattedMessage } from 'react-intl'
 import { ControlGrid } from '../VTheme/VTheme'
 import reduxApi, { withOps } from '../../lib/redux/reduxApi.js'
 import { OpportunityStatus } from '../../server/api/opportunity/opportunity.constants'
 
 export const OpCloseOpportunity = ({ op, dispatch }) => {
+  const router = useRouter()
   const handleCompleteOpportunity = useCallback(
     async () => {
       await dispatch(
@@ -16,7 +17,7 @@ export const OpCloseOpportunity = ({ op, dispatch }) => {
         )
       )
       message.success('Opportunity Confirmed')
-      Router.replace(`/archivedops/${op._id}`)
+      router.replace(`/archivedops/${op._id}`)
       // MAYBE: publish topic for completed op
     }, [])
 
@@ -29,7 +30,7 @@ export const OpCloseOpportunity = ({ op, dispatch }) => {
         )
       )
       message.success('Request Cancelled')
-      Router.replace('/home')
+      router.replace('/home')
       // MAYBE: publish topic for completed op
     }, [])
 

--- a/components/Op/OpTabs.js
+++ b/components/Op/OpTabs.js
@@ -46,30 +46,30 @@ const opEditTab =
 
 const isNotProd = process.env.NODE_ENV !== 'production'
 
-export const OpTabs = ({ op, onChange, canManage }) => (
+export const OpTabs = ({ op, onChange, canManage, defaultTab }) => (
   <>
-    <Tabs style={shadowStyle} defaultActiveKey='1' onChange={onChange}>
-      <TabPane tab={opAboutTab} key='1'>
+    <Tabs style={shadowStyle} size='large' defaultActiveKey={defaultTab} onChange={onChange}>
+      <TabPane tab={opAboutTab} key='about'>
         <OpAboutPanel op={op} />
       </TabPane>
 
       {isNotProd && (
-        <TabPane tab={opForumTab} key='2'>
+        <TabPane tab={opForumTab} key='question'>
           <OpQuestionPanel op={op} />
         </TabPane>
       )}
       {isNotProd && (
-        <TabPane tab={opNewsTab} key='3'>
+        <TabPane tab={opNewsTab} key='news'>
           <OpUpdatePanel op={op} />
         </TabPane>
       )}
       {canManage && (
-        <TabPane tab={opManageTab} key='4'>
+        <TabPane tab={opManageTab} key='manage'>
           <OpManagePanel op={op} />
         </TabPane>
       )}
       {canManage && (
-        <TabPane tab={opEditTab} key='5' />
+        <TabPane tab={opEditTab} key='edit' />
       )}
     </Tabs>
   </>
@@ -78,22 +78,16 @@ export const OpTabs = ({ op, onChange, canManage }) => (
 OpTabs.propTypes = {
   op: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    info: PropTypes.shape({
-      about: PropTypes.string,
-      followers: PropTypes.string,
-      joiners: PropTypes.string,
-      forum: PropTypes.string,
-      outsiders: PropTypes.string
-    }),
-    category: PropTypes.arrayOf(
-      PropTypes.oneOf(['admin', 'op', 'vp', 'ap', 'other'])
-    ).isRequired,
-    imgUrl: PropTypes.string,
-    website: PropTypes.string,
-    contactEmail: PropTypes.string,
-    facebook: PropTypes.string,
-    twitter: PropTypes.string
-  }).isRequired
+    subtitle: PropTypes.string,
+    imgUrl: PropTypes.any,
+    duration: PropTypes.string,
+    location: PropTypes.string,
+    _id: PropTypes.string
+  }),
+  canManage: PropTypes.bool.isRequired,
+  onChange: PropTypes.func,
+  params: PropTypes.shape({
+    id: PropTypes.string.isRequired
+  })
 }
-
 export default OpTabs

--- a/components/Tags/TagDisplay.js
+++ b/components/Tags/TagDisplay.js
@@ -19,6 +19,7 @@ color: #666;
 `
 
 export function TagDisplay ({ tags }) {
+  if (!tags) return ''
   return (
     <span>
       {tags.map(tag => {

--- a/components/examples/UseRouter.js
+++ b/components/examples/UseRouter.js
@@ -1,0 +1,29 @@
+/* Example of using useRouter in a functional component
+   and matching test
+*/
+
+import { useRouter } from 'next/router'
+export const UseRouter = (props, context) => {
+  const router = useRouter()
+  const { children, href } = props
+  const handleClick = () => {
+    router.push(href)
+  }
+
+  return (
+    <>
+      <h1>Router Example</h1>
+      <dl>
+        <dt>pathname</dt><dd>{router.pathname}</dd>
+        <dt>asPath</dt><dd>{router.asPath}</dd>
+        <dt>query</dt><dd>{JSON.stringify(router.query)}</dd>
+
+      </dl>
+      <button onClick={handleClick}>
+        {children}
+      </button>
+    </>
+  )
+}
+
+export default UseRouter

--- a/components/examples/__tests__/UseRouter.spec.js
+++ b/components/examples/__tests__/UseRouter.spec.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import test from 'ava'
+import { shallow } from 'enzyme'
+import * as nextRouter from 'next/router'
+import sinon from 'sinon'
+import { UseRouter } from '../UseRouter'
+
+test.before('Setup Route', (t) => {
+  const router = () => {
+    return ({
+      pathname: '/test',
+      route: '/test',
+      query: { id: 12345 },
+      asPath: '/test/12345',
+      initialProps: {},
+      pageLoader: sinon.fake(),
+      App: sinon.fake(),
+      Component: sinon.fake(),
+      replace: sinon.fake(),
+      push: sinon.fake(),
+      back: sinon.fake()
+    })
+  }
+  sinon.replace(nextRouter, 'useRouter', router)
+})
+
+test('renders shallow', t => {
+  const wrapper = shallow(
+    <UseRouter href='/'>
+      Test Route
+    </UseRouter>
+  )
+  // console.log(wrapper.debug())
+  t.is(wrapper.find('dd').first().text(), '/test')
+})

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -89,7 +89,6 @@ class PersonHomePage extends Component {
 
       await Promise.all([
         store.dispatch(reduxApi.actions.tags.get()),
-        // store.dispatch(reduxApi.actions.opportunities.get(filters)),
         store.dispatch(reduxApi.actions.opportunities.get(myOpportunities)),
         store.dispatch(reduxApi.actions.archivedOpportunities.get(myOpportunities)),
         store.dispatch(reduxApi.actions.locations.get({ withRelationships: true })),

--- a/pages/test/test-router.js
+++ b/pages/test/test-router.js
@@ -1,0 +1,11 @@
+import { UseRouter } from '../../components/examples/UseRouter.js'
+import publicPage from '../../hocs/publicPage'
+import { FullPage } from '../../components/VTheme/VTheme'
+
+const TestRouter = () =>
+  <FullPage>
+    <UseRouter href='/'>
+      Routes to Home page
+    </UseRouter>
+  </FullPage>
+export default publicPage(TestRouter)


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
On the Opportunity Detail page when you switch tabs the URL is updated with ?tab=manage etc. 
This means that the location can be bookmarked, visited directly and reloaded keeping the same page. 

## Additional Info.🧐
updated components use useRouter instead of withRouter. This requires a change to the way the router is injected in unit tests.   New way is to use sinon to override useRouter with a mock router - this is cleaner and easier to use. 

## Screenshots 📷
![opdetailpage-tabs](https://user-images.githubusercontent.com/1596437/72317940-b6397280-36ff-11ea-8411-9650986c1941.gif)
 
