### PR TITLE
VP-1045 Refactor findOrgByPersonIdAndCategory to remove variable code coverage results

### DIFF
--- a/server/api/member/__tests__/member.lib.fixtures.js
+++ b/server/api/member/__tests__/member.lib.fixtures.js
@@ -1,0 +1,40 @@
+module.exports = {
+  people: [
+    {
+      name: 'Test name 1',
+      email: 'test1@example.com'
+    },
+    {
+      name: 'Test name 2',
+      email: 'test2@example.com'
+    },
+    {
+      name: 'Test name 3',
+      email: 'test3@example.com'
+    },
+    {
+      name: 'Test name 4',
+      email: 'test4@example.com'
+    }
+  ],
+  organisations: [
+    {
+      name: 'Test organisation 1',
+      slug: 'test-org-1',
+      category: 'vp'
+    },
+    {
+      name: 'Test organisation 2',
+      slug: 'test-org-2',
+      category: 'ap'
+    },
+    {
+      name: 'Test organisation 3',
+      slug: 'test-org-3'
+    },
+    {
+      name: 'Test organisation 4',
+      slug: 'test-org-4'
+    }
+  ]
+}

--- a/server/api/member/__tests__/member.lib.fixtures.js
+++ b/server/api/member/__tests__/member.lib.fixtures.js
@@ -11,10 +11,6 @@ module.exports = {
     {
       name: 'Test name 3',
       email: 'test3@example.com'
-    },
-    {
-      name: 'Test name 4',
-      email: 'test4@example.com'
     }
   ],
   organisations: [

--- a/server/api/member/__tests__/member.lib.spec.js
+++ b/server/api/member/__tests__/member.lib.spec.js
@@ -1,0 +1,115 @@
+import test from 'ava'
+import MemoryMongo from '../../../util/test-memory-mongo'
+import fixtures from './member.lib.fixtures'
+import Member from '../member'
+import Person from '../../person/person'
+import Organisation from '../../organisation/organisation'
+import { MemberStatus } from '../member.constants'
+import { findOrgByPersonIdAndCategory } from '../member.lib'
+
+test.before('Database start', async (t) => {
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
+})
+
+test.beforeEach('Load fixtures', async (t) => {
+  const [organisations, people] = await Promise.all([
+    Organisation.create(fixtures.organisations),
+    Person.create(fixtures.people)
+  ])
+
+  const members = [
+    {
+      person: people[0]._id,
+      organisation: organisations[0]._id,
+      validation: 'orgAdmin',
+      status: MemberStatus.ORGADMIN
+    },
+    {
+      person: people[0]._id,
+      organisation: organisations[1]._id,
+      validation: 'member',
+      status: MemberStatus.MEMBER
+    },
+    {
+      person: people[1]._id,
+      organisation: organisations[0]._id,
+      validation: 'joiner',
+      status: MemberStatus.JOINER
+    },
+    {
+      person: people[1]._id,
+      organisation: organisations[1]._id,
+      validation: 'follower',
+      status: MemberStatus.FOLLOWER
+    },
+    {
+      person: people[1]._id,
+      organisation: organisations[2]._id,
+      validation: 'member',
+      status: MemberStatus.MEMBER
+    },
+    {
+      person: people[1]._id,
+      organisation: organisations[3]._id,
+      validation: 'orgAdmin',
+      status: MemberStatus.ORGADMIN
+    }
+  ]
+
+  t.context.members = await Member.create(members)
+  t.context.organisations = organisations
+  t.context.people = people
+})
+
+test.afterEach.always('Clear fixtures', async (t) => {
+  await Promise.all([
+    Organisation.deleteMany({}),
+    Person.deleteMany({}),
+    Member.deleteMany({})
+  ])
+})
+
+test.after.always('Database stop', async (t) => {
+  await t.context.memMongo.stop()
+})
+
+test.serial('Find org by person and category', async (t) => {
+  const testData = [
+    {
+      personId: t.context.people[0]._id,
+      category: null,
+      expectedOrgId: t.context.organisations[0]._id.str
+    },
+    {
+      personId: t.context.people[0]._id,
+      category: 'ap',
+      expectedOrgId: t.context.organisations[1]._id.str
+    },
+    {
+      personId: t.context.people[1]._id,
+      category: null,
+      expectedOrgId: t.context.organisations[3]._id.str
+    },
+    {
+      personId: t.context.people[2]._id,
+      category: null,
+      expectedOrgId: null
+    }
+  ]
+
+  t.plan(testData.length)
+
+  for (const testRecord of testData) {
+    let orgId = await findOrgByPersonIdAndCategory(testRecord.personId, testRecord.category)
+
+    if (orgId !== null) {
+      orgId = orgId.str
+    }
+
+    t.is(
+      testRecord.expectedOrgId,
+      orgId
+    )
+  }
+})

--- a/server/api/member/member.lib.js
+++ b/server/api/member/member.lib.js
@@ -29,19 +29,6 @@ const addMember = async (member) => {
   return got
 }
 
-function compareMemberStatus (a, b) {
-  if (a.status === b.status) return 0
-  if (a.status === MemberStatus.ORGADMIN) return -1
-  if (b.status === MemberStatus.ORGADMIN) return 1
-  if (a.status === MemberStatus.MEMBER) return -1
-  if (b.status === MemberStatus.MEMBER) return 1
-  if (a.status === MemberStatus.FOLLOWER) return -1
-  if (b.status === MemberStatus.FOLLOWER) return 1
-
-  // all others return arbitary a
-  return -1
-}
-
 const findOrgByPersonIdAndCategory = async (personId, category) => {
   // search membership table for org matching category and person id
   const query = { person: personId }
@@ -55,10 +42,23 @@ const findOrgByPersonIdAndCategory = async (personId, category) => {
   if (!myorgs.length) { // failed to find matching org
     return null
   }
+
   // sort to give most important level of membership first.
-  myorgs.sort(compareMemberStatus)
+  const orgAdminOrgs = myorgs.filter((member) => member.status === MemberStatus.ORGADMIN)
+  const memberOrgs = myorgs.filter((member) => member.status === MemberStatus.MEMBER)
+  const followerOrgs = myorgs.filter((member) => member.status === MemberStatus.FOLLOWER)
+  const otherOrgs = myorgs.filter((member) => {
+    return [
+      MemberStatus.ORGADMIN,
+      MemberStatus.MEMBER,
+      MemberStatus.FOLLOWER
+    ].includes(member.status) === false
+  })
+
+  const sortedOrgs = [].concat(orgAdminOrgs, memberOrgs, followerOrgs, otherOrgs)
+
   // get id of Organisation
-  return myorgs[0].organisation._id
+  return sortedOrgs[0].organisation._id
 }
 
 module.exports = {


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Remove the sort function compareMemberStatus
2. Split member records into separate arrays based on the status fields recombine with important member status records at the top

## Additional Info.🧐

This change fixes an issue that causes the code coverage percentages to change between test runs.