### PR TITLE
VP-1040 Add sendEmailNotifications flag to person

### DIFF
--- a/server/api/person/__tests__/person.spec.js
+++ b/server/api/person/__tests__/person.spec.js
@@ -264,3 +264,28 @@ test('Should correctly handle missing inputs', async t => {
   t.is(res.body.message, 'Person validation failed: email: Path `email` is required.')
   t.is(res.body.name, 'ValidationError')
 })
+
+test.serial('Email notifications flag set correctly', async (t) => {
+  const people = await Person.create([
+    {
+      name: 'Test default flag',
+      email: 'test1@example.com'
+    },
+    {
+      name: 'Test true flag',
+      email: 'test2@example.com',
+      sendEmailNotifications: true
+    },
+    {
+      name: 'Test false flag',
+      email: 'test3@example.com',
+      sendEmailNotifications: false
+    }
+  ])
+
+  t.is(people[0].sendEmailNotifications, true)
+  t.is(people[1].sendEmailNotifications, true)
+  t.is(people[2].sendEmailNotifications, false)
+
+  await Person.remove({ _id: { $in: people.map(person => person._id) } })
+})

--- a/server/api/person/person.js
+++ b/server/api/person/person.js
@@ -23,6 +23,7 @@ const personSchema = new Schema({
   facebook: { type: 'String', required: false },
   twitter: { type: 'String', required: false },
   education: { type: 'String' },
+  sendEmailNotifications: { type: 'Boolean', default: true, required: true },
   role: {
     type: [String],
     required: true,


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Add a new field to the person schema to track whether or not a person wants to receive email notifications from Voluntarily. The field is a required boolean field that defaults to true (opted in to notifications).

## Additional Info.🧐

This flag will be used to decide if we send the user email notifications. VP-1041 will add the ability to update this flag on a person's profile, VP-1042 will update any existing emails to respect this flag when deciding whether or not to send an email notification