### PR TITLE
VP-1080 add robots to stop search engines indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
This change adds a robots.txt file to the domain for deployments. This is currently set to 
User-agent: *
Disallow: /

which should stop all robots.

The idea is that this is the default deployment and we change the file on production when we are ready to attract search engines.
