### PR TITLE
VP-1102 Activity which volunteer showed interest before RESETS BACK and allows to add another interested record

### DIFF
--- a/components/Interest/InterestArchivedSection.js
+++ b/components/Interest/InterestArchivedSection.js
@@ -16,7 +16,7 @@ class InterestArchivedSection extends Component {
     // Get all interests
     const opid = this.props.opid
     try {
-      await this.props.dispatch(reduxApi.actions.interestsArchived.get({ id: '', op: opid }))
+      await this.props.dispatch(reduxApi.actions.interestsArchived.get({ op: opid }))
     } catch (err) {
       console.error('error in getting interests', err)
     }

--- a/components/Interest/InterestSection.js
+++ b/components/Interest/InterestSection.js
@@ -19,7 +19,7 @@ class InterestSection extends Component {
     // Get all interests
     const opid = this.props.opid
     try {
-      await this.props.dispatch(reduxApi.actions.interests.get({ id: '', op: opid }))
+      await this.props.dispatch(reduxApi.actions.interests.get({ op: opid }))
     } catch (err) {
       // console.error('error in getting interests', err)
     }

--- a/components/Interest/RegisterInterestSection.js
+++ b/components/Interest/RegisterInterestSection.js
@@ -24,10 +24,10 @@ class RegisterInterestSection extends Component {
   // When component mounts, make initial API call.
   // TODO do we need to change this to getInitialProps?
   async componentDidMount () {
-    const op = this.props.op
-    const me = this.props.meID
+    const opid = this.props.op._id
+    const meid = this.props.meID
     try {
-      await this.props.dispatch(reduxApi.actions.interests.get({ id: '', op, me }))
+      await this.props.dispatch(reduxApi.actions.interests.get({ op: opid, me: meid }))
     } catch (err) {
       console.error('error in getting interests', err)
     }

--- a/components/Interest/RegisterInterestSection.js
+++ b/components/Interest/RegisterInterestSection.js
@@ -24,7 +24,7 @@ class RegisterInterestSection extends Component {
   // When component mounts, make initial API call.
   // TODO do we need to change this to getInitialProps?
   async componentDidMount () {
-    const opid = this.props.op._id
+    const opid = this.props.opID
     const meid = this.props.meID
     try {
       await this.props.dispatch(reduxApi.actions.interests.get({ op: opid, me: meid }))
@@ -55,7 +55,7 @@ class RegisterInterestSection extends Component {
   // Render the component depending on whether we've completed the initial api call, and what information is contained in the store.
   render () {
     // If we haven't finished making the API request to the server yet...
-    if (this.props.interests.loading) {
+    if (!this.props.interests.sync) {
       return (<Loading />)
     }
 

--- a/components/Interest/__tests__/RegisterInterestSection.spec.js
+++ b/components/Interest/__tests__/RegisterInterestSection.spec.js
@@ -65,7 +65,7 @@ test.serial('mount RegisterInterestSection with with no existing interest', asyn
   const wrapper = await mountWithIntl(
     <Provider store={realStore}>
       <RegisterInterestSection
-        op={opid}
+        opID={opid}
         meID={meid}
       />
     </Provider>
@@ -106,7 +106,7 @@ test.serial('mount RegisterInterestSection with op and me', async t => {
   const wrapper = await mountWithIntl(
     <Provider store={realStore}>
       <RegisterInterestSection
-        op={opid}
+        opID={opid}
         meID={meid}
       />
     </Provider>

--- a/components/Op/OpVolunteerInterestSection.js
+++ b/components/Op/OpVolunteerInterestSection.js
@@ -1,28 +1,26 @@
 import { Button } from 'antd'
 import Link from 'next/link'
-import { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import RegisterInterestSection from '../Interest/RegisterInterestSection'
 
-export default class OpVolunteerInterestSection extends Component {
-  render () {
+export const OpVolunteerInterestSection = ({ isAuthenticated, canRegisterInterest, opID, meID }) => {
+  // if not signed in then the interested button signs in first
+  if (!isAuthenticated) {
     return (
-      // if not signed in then the interested button signs in first
-      !this.props.isAuthenticated
-        ? (
-          <div>
-            <Link href='/auth/sign-in'>
-              <Button type='primary' size='large' shape='round'>
-                <FormattedMessage id='iminterested-anon' defaultMessage="I'm Interested" description="I'm interested button that leads to sign in page" />
-              </Button>
-            </Link>
-
-          </div>)
-        : this.props.canRegisterInterest &&
-          <div>
-            <RegisterInterestSection op={this.props.op} meID={this.props.meID} />
-
-          </div>
+      <Link href={`/auth/sign-thru?redirect=/ops/${opID}`}>
+        <Button type='primary' size='large' shape='round'>
+          <FormattedMessage id='iminterested-anon' defaultMessage="I'm Interested" description="I'm interested button that leads to sign in page" />
+        </Button>
+      </Link>
     )
   }
+
+  if (canRegisterInterest) {
+    return (
+      <RegisterInterestSection opID={opID} meID={meID} />
+    )
+  }
+  return null
 }
+
+export default OpVolunteerInterestSection

--- a/pages/op/opdetailpage.js
+++ b/pages/op/opdetailpage.js
@@ -183,7 +183,7 @@ export const OpDetailPage = ({
         <OpVolunteerInterestSection
           isAuthenticated={isAuthenticated}
           canRegisterInterest={canRegisterInterest}
-          op={op}
+          opID={op && op._id}
           meID={me && me._id}
         />
       </OpBanner>


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Cause is opsdetailpage loading interested list. placing entire op into query instead of opid.  which blows out the URL and returns a 413 having no interested record causes the page to show the button.   Side effect is that we can create multiple records.

Fix is to replace op with op._id  when api/interests/?op called in RegisterInterestSection.js:30

## Additional Information
The interested records are pulled down by the client after the page loads - in RegisterInterestSection. i.e. its acting independently.  This means that for a second the control does not show the right interested button.  

Changed props to the component so that it does not show anything if the data is not provided. and shows loading indicator if data is not synced.

