### PR TITLE
getPersonRoles include org admins as members , expand test cover for …

### DIFF
--- a/server/api/member/__tests__/member.lib.fixtures.js
+++ b/server/api/member/__tests__/member.lib.fixtures.js
@@ -9,8 +9,13 @@ module.exports = {
       email: 'test2@example.com'
     },
     {
-      name: 'Test name 3',
-      email: 'test3@example.com'
+      name: 'System Admin hard coded',
+      email: 'admin3@example.com',
+      role: ['admin']
+    },
+    {
+      name: 'Member of None',
+      email: 'test4@example.com'
     }
   ],
   organisations: [
@@ -26,11 +31,15 @@ module.exports = {
     },
     {
       name: 'Test organisation 3',
-      slug: 'test-org-3'
+      slug: 'test-org-3',
+      category: 'op'
+
     },
     {
       name: 'Test organisation 4',
-      slug: 'test-org-4'
+      slug: 'test-org-4',
+      category: 'admin'
+
     }
   ]
 }

--- a/server/api/member/__tests__/member.lib.spec.js
+++ b/server/api/member/__tests__/member.lib.spec.js
@@ -5,7 +5,12 @@ import Member from '../member'
 import Person from '../../person/person'
 import Organisation from '../../organisation/organisation'
 import { MemberStatus } from '../member.constants'
-import { findOrgByPersonIdAndCategory } from '../member.lib'
+import {
+  findOrgByPersonIdAndCategory,
+  getPersonRoles,
+  getMemberbyId,
+  addMember
+} from '../member.lib'
 
 test.before('Database start', async (t) => {
   t.context.memMongo = new MemoryMongo()
@@ -74,6 +79,38 @@ test.after.always('Database stop', async (t) => {
   await t.context.memMongo.stop()
 })
 
+test('get member by id fills in some org and person details', async (t) => {
+  const member = t.context.members[0]
+  const m = await getMemberbyId(member._id)
+  // check fields populated out
+  t.is(m.person.email, t.context.people[0].email)
+  t.is(m.organisation.name, t.context.organisations[0].name)
+})
+
+test.serial('add member creates a new member', async (t) => {
+  const newMember = {
+    person: t.context.people[3]._id,
+    organisation: t.context.organisations[3]._id,
+    validation: 'test new member',
+    status: MemberStatus.FOLLOWER
+  }
+
+  const savedMember = await addMember(newMember)
+
+  // member is in database
+  t.is(savedMember.status, MemberStatus.FOLLOWER)
+  t.is(savedMember.person.email, t.context.people[3].email)
+  t.is(savedMember.organisation.name, t.context.organisations[3].name)
+
+  // update the savedmember
+  savedMember.status = MemberStatus.VALIDATOR
+  const updatedMember = await addMember(savedMember)
+  t.is(updatedMember.status, MemberStatus.VALIDATOR)
+
+  // remove the newMember
+  await updatedMember.remove()
+})
+
 test.serial('Find org by person and category', async (t) => {
   const testData = [
     {
@@ -112,4 +149,22 @@ test.serial('Find org by person and category', async (t) => {
       orgId
     )
   }
+})
+
+test.serial('role of person with no membership is what is in the person.role field.', async (t) => {
+  const person = t.context.people[3]
+  const [role, orgAdminFor] = await getPersonRoles(person)
+  t.is(role.length, 1)
+  t.is(role[0], 'volunteer')
+  t.is(orgAdminFor.length, 0)
+})
+
+test.serial('role of person with various memberships.', async (t) => {
+  const person = t.context.people[1]
+  const [role, orgAdminFor] = await getPersonRoles(person)
+  t.is(role.length, 4) // ["volunteer","opportunityProvider","orgAdmin","admin"]
+  t.is(role[1], 'opportunityProvider') // because org[2] is OP
+  t.is(role[3], 'admin') // because org[3] is admin category
+  t.is(orgAdminFor.length, 1)
+  t.deepEqual(orgAdminFor[0], t.context.organisations[3]._id)
 })

--- a/server/api/member/member.lib.js
+++ b/server/api/member/member.lib.js
@@ -76,7 +76,7 @@ const getPersonRoles = async person => {
     .populate({ path: 'organisation', select: 'name category' })
     .lean()
     .exec()
-  const role = person.role.toObject() // role is required and has a defult
+  const role = person.role // role is required and has a defult
   const orgAdminFor = []
   membership.map(m => {
     if (m.status === MemberStatus.ORGADMIN) {

--- a/server/api/person/person.js
+++ b/server/api/person/person.js
@@ -15,14 +15,14 @@ const personSchema = new Schema({
   nickname: { type: 'String', default: '' }, // how we should address you - eg. Andrew
   about: { type: 'String', default: '' }, // person description
   location: { type: 'String', default: '' },
-  phone: { type: 'String', required: false }, // +64 27 7031007
+  phone: { type: 'String' }, // +64 27 7031007
   imgUrl: { type: 'String', default: '/static/img/person/person.png' }, // url to large profile image (256x256)
   imgUrlSm: { type: 'String', default: '/static/img/person/person.png' }, // url to small profile image (24x24)
   pronoun: { type: 'Object', default: { subject: 'they', object: 'them', possessive: 'their' } },
   language: { type: 'String', default: 'EN', lowercase: true }, // en, mi, fr etc
-  website: { type: 'String', required: false },
-  facebook: { type: 'String', required: false },
-  twitter: { type: 'String', required: false },
+  website: { type: 'String' },
+  facebook: { type: 'String' },
+  twitter: { type: 'String' },
   education: { type: 'String' },
   sendEmailNotifications: { type: 'Boolean', default: true, required: true },
   role: {


### PR DESCRIPTION
…member.lib

## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. If you are an orgAdmin for an OP or AP org you will be given op or ap role status. This was only happening for Members. 
2. Increased test cover for functions in member.lib to 100% fully testing getMemberbyId  addMember,  findOrgByPersonIdAndCategory, and  getPersonRoles

There should be no visual changes. 