### PR TITLE
Vp 1221 getinitprops for home returning 403 forbidden on s

### DIFF
--- a/lib/redux/reduxApi.js
+++ b/lib/redux/reduxApi.js
@@ -110,7 +110,7 @@ const thisReduxApi = reduxApi({
     const options = { ...config.jsonOptions }
     const idToken = getState().session.idToken
     if (idToken) {
-      options.headers.Authorization = `Bearer ${idToken}`
+      options.headers.authorization = `Bearer ${idToken}`
     }
     return options
   })

--- a/server/middleware/session/__tests__/setSession.spec.js
+++ b/server/middleware/session/__tests__/setSession.spec.js
@@ -61,7 +61,7 @@ test('Check session set when user logged in', async t => {
 
 test('Check session set for API call with Bearer header', async t => {
   const next = sinon.spy()
-  const req = { url: '/api/foo', headers: { Authorization: `Bearer ${jwtData.idToken}` } }
+  const req = { url: '/api/foo', headers: { authorization: `Bearer ${jwtData.idToken}` } }
   await setSession(req, null, next)
   t.true(req.session.isAuthenticated)
   t.is(req.session.user.email, jwtData.idTokenPayload.email)
@@ -71,7 +71,7 @@ test('Check session set for API call with Bearer header', async t => {
 
 test('Check session not Auth if email not verified', async t => {
   const next = sinon.spy()
-  const req = { url: '/api/foo', headers: { Authorization: `Bearer ${jwtDataBob.idToken}` } }
+  const req = { url: '/api/foo', headers: { authorization: `Bearer ${jwtDataBob.idToken}` } }
   await setSession(req, null, next)
   t.false(req.session.isAuthenticated)
   t.truthy(next.calledOnce)
@@ -79,7 +79,7 @@ test('Check session not Auth if email not verified', async t => {
 
 test('a person is created if new user signs in', async t => {
   const next = sinon.spy()
-  const req = { url: '/api/foo', headers: { Authorization: `Bearer ${jwtDataCharles.idToken}` } }
+  const req = { url: '/api/foo', headers: { authorization: `Bearer ${jwtDataCharles.idToken}` } }
   await setSession(req, null, next)
   t.true(req.session.isAuthenticated)
   t.is(req.session.user.email, jwtDataCharles.idTokenPayload.email)

--- a/server/middleware/session/setSession.js
+++ b/server/middleware/session/setSession.js
@@ -33,9 +33,9 @@ const openPath = url => {
 const getIdToken = (req) => {
   if (req && req.cookies && req.cookies.idToken) { return req.cookies.idToken }
 
-  if (req.headers.Authorization) {
+  if (req.headers.authorization) {
     const regex = /Bearer (.*)/
-    const found = req.headers.Authorization.match(regex)
+    const found = req.headers.authorization.match(regex)
     return found[1]
   }
 }


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Case sensitivity in the Authorization header used by API calls caused the idToken to not be recognised when handling server side API calls. This resulted in the person appearing to be not signed in and an ANON session being created. which in turn refused permission to allow a person to get their own data. 
The correction is to make all uses of Authorization headers lower case. 

From RFC 2616 - “Hypertext Transfer Protocol -- HTTP/1.1”, Section 4.2, “Message Headers”:
Each header field consists of a name followed by a colon (“:”) and the field value. Field names are case-insensitive.  
However somewhere along the line the header was being lowercased. 
