### PR TITLE
Vp 1226 persondetailpage not showing membership

### DIFF
--- a/__tests__/person/persondetailpage.spec.js
+++ b/__tests__/person/persondetailpage.spec.js
@@ -161,7 +161,8 @@ test('render unknown person PersonDetailPage ', async t => {
   const wrapper = outer.dive()
 
   t.false(wrapper.exists('PersonDetail'))
-  t.is(wrapper.find('FormattedMessage').first().props().id, 'person.notavailable')
+  t.true(wrapper.exists('PersonNotAvailable'))
+  t.is(wrapper.dive().find('FormattedMessage').first().props().id, 'person.notavailable')
 })
 
 test('render Dalis PersonDetailPage as non admin random person alice', async t => {

--- a/components/Person/PersonDetail.js
+++ b/components/Person/PersonDetail.js
@@ -113,7 +113,6 @@ const PersonDetail = ({ person }, ...props) => (
             description='Header for list of badges I have obtained'
           />
         </H4>
-        <Divider />
         <PersonBadgeSection person={person} />
       </DetailItem>
     </GridContainer>

--- a/components/Person/PersonDetail.js
+++ b/components/Person/PersonDetail.js
@@ -85,16 +85,34 @@ const PersonDetail = ({ person }, ...props) => (
       <ProfileImage src={person.imgUrl} alt={person.nickname} />
       {person.orgMembership &&
         <DetailItem>
-          <h3><FormattedMessage id='person.memberof' defaultMessage='Member of' description='Header for list of orgs I belong to' /></h3>
+          <H4>
+            <FormattedMessage
+              id='PersonDetail.subheading.membership'
+              defaultMessage='Member of'
+              description='Header for list of orgs I belong to'
+            />
+          </H4>
           <MemberUl members={person.orgMembership} />
         </DetailItem>}
       {person.orgFollowership &&
         <DetailItem>
-          <h3><FormattedMessage id='person.following' defaultMessage='Following' description='Header for list of orgs I follow' /></h3>
+          <H4>
+            <FormattedMessage
+              id='PersonDetail.subheading.following'
+              defaultMessage='Following'
+              description='Header for list of orgs I follow'
+            />
+          </H4>
           <MemberUl members={person.orgFollowership} />
         </DetailItem>}
       <DetailItem>
-        <H4>Latest Achievements</H4>
+        <H4>
+          <FormattedMessage
+            id='PersonDetail.subheading.achievements'
+            defaultMessage='Recognition'
+            description='Header for list of badges I have obtained'
+          />
+        </H4>
         <Divider />
         <PersonBadgeSection person={person} />
       </DetailItem>

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -17,6 +17,8 @@ import { MemberStatus } from '../../server/api/member/member.constants'
 import { InterestStatus } from '../../server/api/interest/interest.constants'
 import { PersonalGoalStatus } from '../../server/api/personalGoal/personalGoal.constants'
 import VTabs from '../../components/VTheme/VTabs'
+import Loading from '../../components/Loading'
+
 const { TabPane } = Tabs
 
 const SectionTitleWrapper = styled.div`
@@ -132,10 +134,12 @@ class PersonHomePage extends Component {
   }
 
   render () {
+    if (!this.props.people.sync) { return <Loading /> }
+    const person = this.props.people.data[0]
     const shadowStyle = { overflow: 'visible', textAlign: 'left' }
     if (this.props.members.sync && this.props.members.data.length > 0) {
-      this.props.me.orgMembership = this.props.members.data.filter(m => [MemberStatus.MEMBER, MemberStatus.ORGADMIN].includes(m.status))
-      this.props.me.orgFollowership = this.props.members.data.filter(m => m.status === MemberStatus.FOLLOWER)
+      person.orgMembership = this.props.members.data.filter(m => [MemberStatus.MEMBER, MemberStatus.ORGADMIN].includes(m.status))
+      person.orgFollowership = this.props.members.data.filter(m => m.status === MemberStatus.FOLLOWER)
     }
 
     const ops = this.props.opportunities.data // list of ops I own
@@ -185,7 +189,7 @@ class PersonHomePage extends Component {
     return (
       <FullPage>
         <Helmet>
-          <title>Home / Voluntarily</title>
+          <title>Home - Voluntarily</title>
         </Helmet>
         <PageBanner>
           <h1>
@@ -281,7 +285,7 @@ class PersonHomePage extends Component {
             <SectionWrapper>
               {this.state.editProfile ? (
                 <PersonDetailForm
-                  person={this.props.people.data[0]}
+                  person={person}
                   existingTags={this.props.tags.data}
                   locations={this.props.locations.data[0].locations}
                   onSubmit={this.handleUpdate}
@@ -301,7 +305,7 @@ class PersonHomePage extends Component {
                       description='Button to edit an person on PersonDetails page'
                     />
                   </Button>
-                  <PersonDetail person={this.props.people.data[0]} />
+                  <PersonDetail person={person} />
                 </div>
               )}
             </SectionWrapper>

--- a/pages/person/persondetailpage.js
+++ b/pages/person/persondetailpage.js
@@ -37,6 +37,31 @@ const blankPerson = {
   tags: []
 }
 
+const PersonNotAvailable = ({ isAdmin }) =>
+  <FullPage>
+    <Helmet>
+      <title>Person Unavailable - Voluntarily</title>
+    </Helmet>
+    <h2><FormattedMessage id='person.notavailable' defaultMessage='Sorry, this person is not available' description='message on person not found page' /></h2>
+    {isAdmin &&
+      <>
+        <Button shape='round'>
+          <Link href='/people'>
+            <a>
+              <FormattedMessage id='showPeople' defaultMessage='Show All' description='Button to show all People' />
+            </a>
+          </Link>
+        </Button>
+        <Button shape='round'>
+          <Link href='/person/new'>
+            <a>
+              <FormattedMessage id='person.altnew' defaultMessage='New Person' description='Button to create a new person' />
+            </a>
+          </Link>
+        </Button>
+      </>}
+  </FullPage>
+
 export class PersonDetailPage extends Component {
   state = {
     editing: false
@@ -107,84 +132,62 @@ export class PersonDetailPage extends Component {
   handleCancelDelete = () => { message.error('Delete Cancelled') }
 
   render () {
-    const isOrgAdmin = false // TODO: [VP-473] is this person an admin for the org that person belongs to.
-    const isAdmin = (this.props.me && this.props.me.role.includes('admin'))
-    const canRemove = isAdmin
-    const showPeopleButton = isAdmin
+    if (!this.props.people.sync) {
+      return <Loading />
+    }
 
-    let content = ''
     let person = null
-    if (this.props.people.loading) {
-      content = <Loading />
-    } else if (this.props.isNew) {
+    if (this.props.isNew) {
       person = blankPerson
     } else {
       const people = this.props.people.data
-      if (people.length === 1) {
+      if (people.length > 0) {
         person = people[0]
-      }
-    }
-    const canEdit = (isOrgAdmin || isAdmin || (person && person._id === this.props.me._id))
-
-    if (!this.props.people.loading) {
-      if (this.props.members.sync && this.props.members.data.length > 0) {
-        person.orgMembership = this.props.members.data.filter(m => m.status === MemberStatus.MEMBER)
-      }
-      if (!person) {
-        content =
-          <div>
-            <h2><FormattedMessage id='person.notavailable' defaultMessage='Sorry, this person is not available' description='message on person not found page' /></h2>
-            {showPeopleButton &&
-              <Button shape='round'>
-                <Link href='/people'>
-                  <a>
-                    <FormattedMessage id='showPeople' defaultMessage='Show All' description='Button to show all People' />
-                  </a>
-                </Link>
-              </Button>}
-            {isAdmin &&
-              <>
-                <Button shape='round'>
-                  <Link href='/person/new'>
-                    <a>
-                      <FormattedMessage id='person.altnew' defaultMessage='New Person' description='Button to create a new person' />
-                    </a>
-                  </Link>
-                </Button>
-              </>}
-          </div>
-      } else {
-        if (this.state.editing) {
-          content = <PersonDetailForm person={person} onSubmit={this.handleSubmit.bind(this, person)} onCancel={this.handleCancelEdit.bind(this)} locations={this.props.locations.data} existingTags={this.props.tags.data} />
-        } else {
-          content =
-            <>
-              {canEdit &&
-                <Button id='editPersonBtn' style={{ float: 'right' }} type='primary' shape='round' onClick={() => this.setState({ editing: true })}>
-                  <FormattedMessage id='person.edit' defaultMessage='Edit' description='Button to edit a person' />
-                </Button>}
-              <PersonDetail person={person} />
-            &nbsp;
-              {canRemove &&
-                <Popconfirm id='deletePersonConfirm' title='Confirm removal of this person.' onConfirm={this.handleDeletePerson.bind(this, person)} onCancel={this.handleCancelDelete.bind(this)} okText='Yes' cancelText='No'>
-                  <Button id='deletePersonBtn' type='danger' shape='round'>
-                    <FormattedMessage id='person.delete' defaultMessage='Remove Person' description='Button to remove an person on PersonDetails page' />
-                  </Button>
-                </Popconfirm>}
-            &nbsp;
-              {
-                (isAdmin) && <IssueBadgeButton person={this.props.people.data[0]} />
-              }
-            </>
+        if (this.props.members.sync && this.props.members.data.length > 0) {
+          person.orgMembership = this.props.members.data.filter(m => [MemberStatus.MEMBER, MemberStatus.ORGADMIN].includes(m.status))
+          person.orgFollowership = this.props.members.data.filter(m => m.status === MemberStatus.FOLLOWER)
         }
       }
     }
+
+    if (!person) {
+      return <PersonNotAvailable isAdmin />
+    }
+    const isAdmin = (this.props.me && this.props.me.role.includes('admin'))
+    const canRemove = isAdmin
+    const isOrgAdmin = false // TODO: [VP-473] is this person an admin for the org that person belongs to.
+    const canEdit = (isOrgAdmin || isAdmin || (person && person._id === this.props.me._id))
+
+    if (this.state.editing) {
+      return (
+        <FullPage>
+          <Helmet>
+            <title>Edit {person.name} - Voluntarily</title>
+          </Helmet>
+          <PersonDetailForm person={person} onSubmit={this.handleSubmit.bind(this, person)} onCancel={this.handleCancelEdit.bind(this)} locations={this.props.locations.data} existingTags={this.props.tags.data} />
+        </FullPage>)
+    }
+
     return (
       <FullPage>
         <Helmet>
-          <title>Person Details - Voluntarily</title>
+          <title>{person.nickname} - Voluntarily</title>
         </Helmet>
-        {content}
+        {canEdit &&
+          <Button id='editPersonBtn' style={{ float: 'right' }} type='primary' shape='round' onClick={() => this.setState({ editing: true })}>
+            <FormattedMessage id='person.edit' defaultMessage='Edit' description='Button to edit a person' />
+          </Button>}
+        <PersonDetail person={person} />
+            &nbsp;
+        {canRemove &&
+          <Popconfirm id='deletePersonConfirm' title='Confirm removal of this person.' onConfirm={this.handleDeletePerson.bind(this, person)} onCancel={this.handleCancelDelete.bind(this)} okText='Yes' cancelText='No'>
+            <Button id='deletePersonBtn' type='danger' shape='round'>
+              <FormattedMessage id='person.delete' defaultMessage='Remove Person' description='Button to remove an person on PersonDetails page' />
+            </Button>
+          </Popconfirm>}
+            &nbsp;
+        {isAdmin &&
+          <IssueBadgeButton person={this.props.people.data[0]} />}
       </FullPage>
     )
   }

--- a/server/api/goal/__tests__/goal.fixture.js
+++ b/server/api/goal/__tests__/goal.fixture.js
@@ -22,7 +22,7 @@ export default [
     startLink: '/home', // should be /profile#edit
     language: 'en',
     rank: 1,
-    evaluation: () => { console.log('evaluates to false'); return false },
+    evaluation: "() => { console.log('evaluates to false'); return false }",
     dateAdded: '2019-11-27T10:00:00.000Z'
   },
   {
@@ -56,7 +56,7 @@ export default [
     startLink: '/home', // should be /profile#edit
     language: 'en',
     rank: 2,
-    evaluation: () => { console.log('evaluates to true'); return true },
+    evaluation: "() => { console.log('evaluates to true'); return true }",
     dateAdded: '2019-11-27T10:00:00.000Z'
   },
   {
@@ -92,7 +92,7 @@ export default [
     preconditions: [],
     startLink: '/search',
     language: 'en',
-    evaluation: () => { return true },
+    evaluation: '() => { return true }',
     dateAdded: '2019-11-27T10:00:00.000Z'
   },
   /*********************************************/
@@ -116,7 +116,7 @@ This card will disappear when the profile is complete
     imgUrl: '/static/img/goal/goal-teacherSetup.png',
     startLink: '/my/org/op',
     rank: 1,
-    evaluation: async (personalGoal) => { return false }
+    evaluation: 'async (personalGoal) => { return false }'
   },
   {
     group: GoalGroup.ORG_OP_NEW,
@@ -135,7 +135,7 @@ Once Published we will start finding volunteers
 `,
     startLink: '/activity/inspiring-the-future',
     rank: 2,
-    evaluation: async (personalGoal) => { return true }
+    evaluation: 'async (personalGoal) => { return true }'
   },
 
   {
@@ -145,10 +145,10 @@ Once Published we will start finding volunteers
     imgUrl: '/static/img/goal/goal-school-ready.png',
     subtitle: 'Test 3',
     startLink: '/search',
-    evaluation: () => {
-      console.log('Throws an error')
+    evaluation: `() => {
+      console.log('Throws an error');
       throw new Error('testing')
-    }
+    }`
   }
 
 ]

--- a/server/middleware/session/setSession.js
+++ b/server/middleware/session/setSession.js
@@ -73,7 +73,7 @@ const setSession = async (req, res, next) => {
   try {
     user = await jwtVerify(idToken)
   } catch (e) {
-    console.error('Jwt Verify failed', e)
+    // console.error('Jwt Verify failed', e)
     user = false
   }
   if (!user) {


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. recent changes to the home and person detail pages resulted in the pages displaying an API fetched person(meid) instead of as previously using the session.me value.  This because session.me now does not include any personal or private data for the person and only id and role info.   However, the lines to associated current membership with the person were still updating the me variable. This has been changed to that orgMembership and orgFollowership are now attached to the person.  Once this is done the personDetail membership sidebar updates correctly. 

Also changed some of the complex flow in home.js factored out the NoPersonAvailable component. and return early from render once the output is known.  This reads more clearly and avoids executing code that is not needed.

Also added loading state for if client side is loading and data not available.
I also standardised the subtitle size in the side bar and moved some strings into formattedMessage.

## Additional Information
Having updated to a more recent version of AVA I found that eval was being stricter and required that eval strings be actual strings. In the test fixture they were functions.  The functions are now enclosed in quotes.  This should not affect the server as the database will always hold the content as a string. 


## Screenshots 📷

<img width="296" alt="image" src="https://user-images.githubusercontent.com/1596437/73786027-5a916f00-47fd-11ea-98cd-3a7d69c87094.png">

