### PR TITLE
VP-1229 catch errors in badge api if server not available

### DIFF
--- a/components/IssueBadge/issueBadge.js
+++ b/components/IssueBadge/issueBadge.js
@@ -56,8 +56,12 @@ function BadgeList ({ badgeList, setBadgeChosen }) {
 }
 
 const setAvailableBadgeData = async (setBadgeList) => {
-  const badgeList = await callApi('badges')
-  setBadgeList(badgeList)
+  try {
+    const badgeList = await callApi('badges')
+    setBadgeList(badgeList)
+  } catch (e) {
+    console.error('Either Badgr server is down or you have not set BADGR credentials in environment', e)
+  }
 }
 
 const sendIssuingBadgeRequest = async ({ _id, email }, badgeId) => {


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. add try catch block around setAvailableBadgeData to handle error returned if the Badgr server is not available or if the platform has not set access credentials.

error was visible only on person detail page when signed in as admin so that the Add Badge button was present.

