### PR TITLE
VP-1229 Only ADMIN role can set the category of an organisation

### DIFF
--- a/server/api/organisation/organisation.controller.js
+++ b/server/api/organisation/organisation.controller.js
@@ -31,9 +31,16 @@ const getOrganisations = async (req, res) => {
 
 // Update
 const putOrganisation = async (req, res) => {
+  const isAdmin = req.session.me.role.includes(Role.ADMIN)
+
   // The current user must be; an ADMIN, or an ORG_ADMIN of the requested organisation
-  if (!req.session.me.role.includes(Role.ADMIN) && !req.session.me.orgAdminFor.includes(req.params._id)) {
+  if (!isAdmin && !req.session.me.orgAdminFor.includes(req.params._id)) {
     return res.status(403).end()
+  }
+
+  // Category field can only be set by ADMIN
+  if (!isAdmin) {
+    delete req.body.category
   }
 
   await Organisation.findByIdAndUpdate(req.params._id, { $set: req.body })


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [ ] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Only ADMIN role can set the category of an organisation via the PUT /api/organisations API
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
