### PR TITLE
VP_1223 ensure sendEmailNofifications is included in interest and member details

### DIFF
--- a/server/api/interest/interest.controller.js
+++ b/server/api/interest/interest.controller.js
@@ -42,11 +42,11 @@ const listInterests = async (req, res) => {
 const getInterestDetail = async (interestID) => {
   // Get the interest and populate out key information needed for emailing
   const interestDetail = await Interest.findById(interestID)
-    .populate({ path: 'person', select: 'nickname name email pronoun language' })
+    .populate({ path: 'person', select: 'nickname name email pronoun language sendEmailNotifications' })
     .populate({ path: 'opportunity', select: 'name requestor imgUrl date duration' })
     .exec()
 
-  const requestorDetail = await Person.findById(interestDetail.opportunity.requestor, 'name nickname email imgUrl')
+  const requestorDetail = await Person.findById(interestDetail.opportunity.requestor, 'name nickname email imgUrl sendEmailNotifications')
   interestDetail.opportunity.requestor = requestorDetail
   interestDetail.opportunity.imgUrl = `${config.appUrl}${interestDetail.opportunity.imgUrl}`
   interestDetail.opportunity.href = `${config.appUrl + '/ops/' + interestDetail.opportunity._id}`

--- a/server/api/member/member.controller.js
+++ b/server/api/member/member.controller.js
@@ -21,7 +21,7 @@ const listMembers = async (req, res) => {
         query.person = req.query.meid
       }
       // Return enough info for a personCard
-      got = await Member.find(query).populate({ path: 'person', select: 'nickname name imgUrl email phone' }).sort(sort).exec()
+      got = await Member.find(query).populate({ path: 'person', select: 'nickname name imgUrl email phone sendEmailNotifications' }).sort(sort).exec()
     } else if (req.query.meid) {
       // a person is asking for the orgs they follow or are members of
       const query = { person: req.query.meid }

--- a/server/api/member/member.lib.js
+++ b/server/api/member/member.lib.js
@@ -7,7 +7,7 @@ const { Role } = require('../../services/authorize/role')
 /* get a single member record with org and person populated out */
 const getMemberbyId = id => {
   return Member.findOne({ _id: id })
-    .populate({ path: 'person', select: 'nickname name imgUrl email' })
+    .populate({ path: 'person', select: 'nickname name imgUrl email sendEmailNotifications' })
     .populate({ path: 'organisation', select: 'name imgUrl category' })
     .exec()
 }


### PR DESCRIPTION

## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
The sendEmailNotifications flag was added to person schema to track whether the person has unsubscribed from emails.  This data is sent when a GET request is performed on a person. However, the interested email process uses the person record populated into the interest record clicked by the person.  This populate out did not include sendEmailNotifications. 

By adding sendEmailNotifications whenever a person reference is populated out that includes the email address we ensure that sendEmail respects the settings


2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
