### PR TITLE
VP-1269 deploy to gamma and delta scripts updated for new repository location

### DIFF
--- a/x/aws/deploy-delta
+++ b/x/aws/deploy-delta
@@ -1,17 +1,14 @@
 #!/bin/bash
 MY_DIR=$( dirname "${BASH_SOURCE[0]}" )
 
-# Get a docker login and run it
-source ${MY_DIR}/login-singapore
+# login to sydney
+source ${MY_DIR}/login-sydney
 
 # pull latest alpha image
-docker pull 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly-alpha:master
+docker pull 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-alpha:master
 
 # retag
-docker image tag 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-delta:master
-
-# login to signapore
-source ${MY_DIR}/login-sydney
+docker image tag 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-delta:master
 
 # push the new image
 docker push 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-delta:master

--- a/x/aws/deploy-gamma
+++ b/x/aws/deploy-gamma
@@ -1,20 +1,15 @@
 #!/bin/bash
 MY_DIR=$( dirname "${BASH_SOURCE[0]}" )
 
-# Get a docker login and run it
-source ${MY_DIR}/login-singapore
-
-# pull latest alpha image
-docker pull 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly-alpha:master
-
-# retag
-docker image tag 585172581592.dkr.ecr.ap-southeast-1.amazonaws.com/vly-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-gamma:master
-
-# login to signapore
+# login to sydney
 source ${MY_DIR}/login-sydney
 
+# pull latest alpha image
+docker pull 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-alpha:master
+
+# retag
+docker image tag 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-alpha:master 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-gamma:master
 # push the new image
 docker push 585172581592.dkr.ecr.ap-southeast-2.amazonaws.com/vly-gamma:master
-
 # restart
-aws ecs update-service --service vly-gamma --cluster vly-gamma-ECSCluster --desired-count 3 --deployment-configuration maximum  
+aws ecs update-service --service vly-gamma --cluster vly-gamma-ECSCluster --desired-count 3 --deployment-configuration maximumPercent=100,minimumHealthyPercent=50 --force-new-deployment 


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
the deploy scripts were still referencing the singapore docker repository. They now reference the sydney repo.
