### PR TITLE
add CASL abilities to tags

### DIFF
--- a/lib/callApi.js
+++ b/lib/callApi.js
@@ -25,7 +25,7 @@ const callApi = async (endpoint, method = 'get', body, cookies) => {
     const url = `${API_URL}/${endpoint}`
     const options = { method, headers: { } }
     if (method === 'post' || method === 'put') {
-      options.headers = { 'content-type': 'application/json' }
+      options.headers = { 'Content-Type': 'application/json' }
       options.body = JSON.stringify(body)
     }
     if (cookies) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7400,9 +7400,9 @@
           }
         },
         "make-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.1.tgz",
+          "integrity": "sha512-NFCymdWS4z/T+3AQ6tjsknt/+4hikbOe6zdq9ZBoPFfoX1S3fthRUbQWzZhI4WZBOM0kQ0GkhdCdfdan3HK+wg==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
@@ -15984,9 +15984,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA==",
       "dev": true
     },
     "http-errors": {

--- a/server/api/tag/__tests__/tag.spec.js
+++ b/server/api/tag/__tests__/tag.spec.js
@@ -119,9 +119,11 @@ test('Tag API - admin - CRUD', async t => {
 
   // get by id - non admin check
   response = await request(server)
-    .put(`/api/tags/${id}`)
-    .set('Cookie', [`idToken=${jwtData.idToken}`])
+    .get(`/api/tags/${id}`)
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+
   t.is(response.statusCode, 200)
+  t.is(response.body.tags.length, 3)
 
   // update
   response = await request(server)

--- a/server/api/tag/__tests__/tag.spec.js
+++ b/server/api/tag/__tests__/tag.spec.js
@@ -19,18 +19,11 @@ test.before('before connect to database', async (t) => {
   ]
   t.context.people = await Person.create(people).catch((err) => console.error('Unable to create people', err))
   t.context.tags = await Tag.create(tagCollection).catch((err) => console.error('Unable to create tags', err))
-  console.log(t.context.tags)
 })
 
 test.after.always(async (t) => {
   await Tag.deleteMany()
   await t.context.memMongo.stop()
-})
-
-test('verify fixture database has tags', async t => {
-  const p = await Tag.find()
-  t.is(2, p.length)
-  t.truthy(p[0].tags.includes('robots'))
 })
 
 /* -- Anon person */

--- a/server/api/tag/__tests__/tag.spec.js
+++ b/server/api/tag/__tests__/tag.spec.js
@@ -4,37 +4,142 @@ import { server, appReady } from '../../../server'
 import Tag from '../tag'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import tags from './tag.fixture.js'
+import { jwtData, jwtDataDali } from '../../../middleware/session/__tests__/setSession.fixture'
+import people from '../../person/__tests__/person.fixture'
+import Person from '../../person/person'
 
 test.before('before connect to database', async (t) => {
   t.context.memMongo = new MemoryMongo()
   await t.context.memMongo.start()
   await appReady
+
+  const tagCollection = [
+    { tags: tags },
+    { tags: ['one', 'two', 'three'] }
+  ]
+  t.context.people = await Person.create(people).catch((err) => console.error('Unable to create people', err))
+  t.context.tags = await Tag.create(tagCollection).catch((err) => console.error('Unable to create tags', err))
+  console.log(t.context.tags)
 })
 
 test.after.always(async (t) => {
+  await Tag.deleteMany()
   await t.context.memMongo.stop()
 })
 
-test.beforeEach('connect and add tag entries', async (t) => {
-  t.context.tags = await Tag.create({ tags: tags }).catch((err) => console.error('Unable to create tags', err))
-})
-
-test.afterEach.always(async () => {
-  await Tag.deleteMany()
-})
-
-test.serial('verify fixture database has tags', async t => {
+test('verify fixture database has tags', async t => {
   const p = await Tag.find()
-  t.is(1, p.length)
+  t.is(2, p.length)
   t.truthy(p[0].tags.includes('robots'))
 })
 
-test.serial('Should correctly give count of all tags', async t => {
+/* -- Anon person */
+test('Tag API - anon - create', async t => {
+  const response = await request(server)
+    .post('/api/tags')
+    .send({ tags: ['a', 'b', 'c'] })
+
+  t.is(response.statusCode, 403)
+})
+
+test('Tag API - anon - read', async t => {
   const res = await request(server)
     .get('/api/tags')
     .set('Accept', 'application/json')
+    .expect(403)
+  t.is(res.status, 403)
+})
+test('Tag API - anon - update', async t => {
+  const tag = t.context.tags[0]
+
+  const response = await request(server)
+    .put(`/api/tags/${tag._id}`)
+    .send({ tags: ['a', 'b', 'c'] })
+
+  t.is(response.statusCode, 403)
+})
+
+test('Tag API - anon - delete', async t => {
+  const tag = t.context.tags[0]
+
+  const response = await request(server)
+    .delete(`/api/tags/${tag._id}`)
+
+  t.is(response.statusCode, 403)
+})
+
+/* -- Signed in person */
+
+test('Tag API - signed - create', async t => {
+  const response = await request(server)
+    .post('/api/tags')
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+    .send({ tags: ['a', 'b', 'c'] })
+
+  t.is(response.statusCode, 403)
+})
+
+test('Tag API - signed - read', async t => {
+  const res = await request(server)
+    .get('/api/tags')
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
     .expect(200)
     .expect('Content-Type', /json/)
+
   const got = res.body
   t.is(tags.length, got.length)
+})
+
+test('Tag API - signed - update', async t => {
+  const tag = t.context.tags[0]
+
+  const response = await request(server)
+    .put(`/api/tags/${tag._id}`)
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+    .send({ tags: ['a', 'b', 'c'] })
+
+  t.is(response.statusCode, 403)
+})
+
+test('Tag API - signed - delete', async t => {
+  const tag = t.context.tags[0]
+
+  const response = await request(server)
+    .delete(`/api/tags/${tag._id}`)
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+
+  t.is(response.statusCode, 403)
+})
+
+/* -- Admin person */
+
+test('Tag API - admin - CRUD', async t => {
+  let response = await request(server)
+    .post('/api/tags')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+    .send({ tags: ['a', 'b', 'c'] })
+
+  t.is(response.statusCode, 200)
+  const newtags = response.body
+  const id = newtags._id
+
+  // get by id - non admin check
+  response = await request(server)
+    .put(`/api/tags/${id}`)
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+  t.is(response.statusCode, 200)
+
+  // update
+  response = await request(server)
+    .put(`/api/tags/${id}`)
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+    .send({ tags: ['a', 'b', 'c', 'd'] })
+  t.is(response.statusCode, 200)
+
+  response = await request(server)
+    .delete(`/api/tags/${id}`)
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+
+  t.is(response.statusCode, 200)
 })

--- a/server/api/tag/tag.ability.js
+++ b/server/api/tag/tag.ability.js
@@ -1,0 +1,51 @@
+const { Role } = require('../../services/authorize/role')
+const { Action } = require('../../services/abilities/ability.constants')
+const { SchemaName } = require('./tag.constants')
+
+/*
+// TypeScript definition
+interface Rule {
+  actions: string | string[],
+  subject: string | string[],
+  conditions?: Object,
+  fields?: string[],
+  inverted?: boolean, // default is `false`
+  reason?: string // mainly to specify why user can't do something. See forbidden reasons for details
+}
+*/
+const ruleBuilder = (session) => {
+  // block all api call for non log in user
+  const anonAbilities = [
+    {
+      subject: SchemaName,
+      action: Action.CRUD,
+      inverted: true,
+      reason: 'You must be signed in to access this resource'
+    }
+  ]
+
+  // allow log in person to list the tags
+  // no create, update, delete via the API
+  const defaultAbilities = [
+    {
+      subject: SchemaName,
+      action: Action.READ
+    }
+  ]
+
+  const adminAbilities = [{
+    subject: SchemaName,
+    action: Action.MANAGE
+  }]
+
+  return {
+    [Role.ANON]: anonAbilities,
+    [Role.ACTIVITY_PROVIDER]: defaultAbilities,
+    [Role.VOLUNTEER_PROVIDER]: defaultAbilities,
+    [Role.OPPORTUNITY_PROVIDER]: defaultAbilities,
+    [Role.TESTER]: defaultAbilities,
+    [Role.ADMIN]: adminAbilities
+  }
+}
+
+module.exports = ruleBuilder

--- a/server/api/tag/tag.constants.js
+++ b/server/api/tag/tag.constants.js
@@ -1,0 +1,4 @@
+
+module.exports = {
+  SchemaName: 'TagList'
+}

--- a/server/api/tag/tag.controller.js
+++ b/server/api/tag/tag.controller.js
@@ -4,7 +4,6 @@ const Tag = require('./tag')
  * Creates one or more tags and sends a JSON response of the created objects
  */
 async function listTags (req, res) {
-  console.log('listTags', req.query)
   try {
     // note: currently we just return the first tag collection.
     // there's no way to identify other dictionaries.

--- a/server/api/tag/tag.controller.js
+++ b/server/api/tag/tag.controller.js
@@ -4,7 +4,10 @@ const Tag = require('./tag')
  * Creates one or more tags and sends a JSON response of the created objects
  */
 async function listTags (req, res) {
+  console.log('listTags', req.query)
   try {
+    // note: currently we just return the first tag collection.
+    // there's no way to identify other dictionaries.
     const fetched = await Tag.findOne({}, 'tags', { lean: true })
 
     let responseData = []

--- a/server/api/tag/tag.js
+++ b/server/api/tag/tag.js
@@ -1,7 +1,10 @@
 const mongoose = require('mongoose')
+const { SchemaName } = require('./tag.constants')
 
 const tagSchema = {
-  tags: [{ type: String, lowercase: true, unique: true }]
+  tags: [
+    { type: String, lowercase: true, unique: true }
+  ]
 }
 
-module.exports = mongoose.model('TagList', tagSchema)
+module.exports = mongoose.model(SchemaName, tagSchema)

--- a/server/api/tag/tag.routes.js
+++ b/server/api/tag/tag.routes.js
@@ -2,6 +2,8 @@ const mongooseCrudify = require('mongoose-crudify')
 const helpers = require('../../services/helpers')
 const Tag = require('./tag')
 const { listTags } = require('./tag.controller.js')
+const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
+const { SchemaName } = require('./tag.constants')
 
 module.exports = server => {
   // Docs: https://github.com/ryo718/mongoose-crudify
@@ -11,14 +13,12 @@ module.exports = server => {
       Model: Tag,
       selectFields: '-__v', // Hide '__v' property
       endResponseInAction: false,
-
-      // beforeActions: [],
+      beforeActions: [{ middlewares: [authorizeActions(SchemaName)] }],
       // actions: {}, // list (GET), create (POST), read (GET), update (PUT), delete (DELETE)
       actions: {
         list: listTags
       },
       afterActions: [
-        // this is the place to require user be authed.
         { middlewares: [helpers.formatResponse] }
       ]
     })

--- a/server/middleware/authorize/authorizeRequest.js
+++ b/server/middleware/authorize/authorizeRequest.js
@@ -18,6 +18,7 @@ const defaultConvertRequestToAction = (req) => {
 const authorizeActions = (subject, convertRequestToAction = defaultConvertRequestToAction) => (req, res, next) => {
   const action = convertRequestToAction(req)
   const authorized = req.ability.can(action, subject)
+  // console.log('authorizeActions', subject, action, req.ability, authorized)
   if (authorized) {
     next()
   } else {


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Access to the Tags API is now controlled by Role Based Access Permissions. 
see : https://voluntarily.atlassian.net/wiki/spaces/VP/pages/18677761/API+Access+Security+Rules

Anon people - cannot access tags
Authorised people - can read and list tags but not create or change them
Admins - can perform all CRUD actions.


## Additional Info.🧐
The tags word list collection feature is only partially implemented.  There is currently a single word list (tags) that is used for all tagging activities. It is read by edit forms that want to autocomplete new tag fields.  It is not updated through the API but is updated when a person saves a profile, activity or opportunity containing new tags. 
Admins have full crud access in order to allow the future tidying up of the tag lists.
