### PR TITLE
Vp 1093 personal goal api permissions management casl

### DIFF
--- a/hocs/securePage.js
+++ b/hocs/securePage.js
@@ -12,13 +12,11 @@ const securePageHoc = Page => class SecurePage extends React.Component {
     if (!session || !session.user) {
       // no session or not auth - redirect to sign in
       if (ctx.isServer) {
-        console.log('securePage - redirect to sign-thru')
         const redirectUrl = encodeURIComponent(ctx.req.url)
         const signThruUrl = `/auth/sign-thru?redirect=${redirectUrl}`
         ctx.res.writeHead(302, { Location: signThruUrl })
         ctx.res.end()
       } else {
-        console.log('securePage - router push to sign-thru')
         const redirectUrl = encodeURIComponent(ctx.asPath)
         const signThruUrl = `/auth/sign-thru?redirect=${redirectUrl}`
         Router.push(signThruUrl)

--- a/server/api/personalGoal/__tests__/personalGoal.ability.spec.js
+++ b/server/api/personalGoal/__tests__/personalGoal.ability.spec.js
@@ -1,0 +1,249 @@
+import test from 'ava'
+import request from 'supertest'
+import { server, appReady } from '../../../server'
+import PersonalGoal from '../personalGoal'
+import MemoryMongo from '../../../util/test-memory-mongo'
+
+import Person from '../../person/person'
+import people from '../../person/__tests__/person.fixture'
+import Goal from '../../goal/goal'
+import goals from '../../goal/__tests__/goal.fixture'
+import { PersonalGoalStatus } from '../personalGoal.constants'
+
+import { jwtData, jwtDataAlice, jwtDataDali } from '../../../middleware/session/__tests__/setSession.fixture'
+
+test.before('before connect to database', async (t) => {
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
+  await appReady
+})
+
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
+})
+
+test.before('connect and add two personalgoal entries', async (t) => {
+  // connect each personalgoal to an owner and org
+  [t.context.people, t.context.goals] = await Promise.all([
+    Person.create(people),
+    Goal.create(goals)
+  ])
+  // link people to goals
+  const admin = t.context.people[0]
+  const dali = t.context.people[1]
+  const alice = t.context.people[2]
+  const personalGoals = [
+    {
+      person: admin._id,
+      goal: t.context.goals[0]._id,
+      status: PersonalGoalStatus.QUEUED
+    },
+    {
+      person: dali._id,
+      goal: t.context.goals[1]._id,
+      status: PersonalGoalStatus.QUEUED
+    },
+    {
+      person: alice._id,
+      goal: t.context.goals[2]._id,
+      status: PersonalGoalStatus.ACTIVE
+    }
+  ]
+  t.context.personalGoals = await PersonalGoal.create(personalGoals)
+})
+
+// test.after.always(async () => {
+//   await Promise.all([
+//     PersonalGoal.deleteMany(),
+//     Person.deleteMany(),
+//     Goal.deleteMany()
+//   ])
+// })
+
+// ANON
+test('PersonalGoal API - anon - cannot read', async t => {
+  let response = await request(server)
+    .get('/api/personalGoals')
+    .set('Accept', 'application/json')
+  t.is(response.statusCode, 403)
+
+  const id = t.context.personalGoals[1]._id
+  response = await request(server)
+    .get(`/api/personalGoals/${id}`)
+    .set('Accept', 'application/json')
+
+  t.is(response.statusCode, 403)
+})
+
+test('PersonalGoal API - anon - cannot write', async t => {
+  let response = await request(server)
+    .post('/api/personalGoals')
+    .send({
+      person: t.context.people[3]._id,
+      goal: t.context.goals[1]._id
+    })
+
+  t.is(response.statusCode, 403)
+  const id = t.context.personalGoals[1]._id
+  response = await request(server)
+    .get(`/api/personalGoals/${id}`)
+    .send({
+      status: PersonalGoalStatus.ACTIVE
+    })
+
+  t.is(response.statusCode, 403)
+
+  response = await request(server)
+    .get(`/api/personalGoals/${id}`)
+    .send({
+      status: PersonalGoalStatus.ACTIVE
+    })
+
+  t.is(response.statusCode, 403)
+})
+// NORMAL
+test('PersonalGoal API - normal - list self', async t => {
+  const id = t.context.people[1]._id
+  const response = await request(server)
+    .get(`/api/personalGoals?meid=${id}`)
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+
+  const actualPersonalGoals = response.body
+
+  t.is(response.statusCode, 200)
+  t.is(actualPersonalGoals.length, 1, `actualPersonalGoals =${actualPersonalGoals.toString()}`)
+  t.is(actualPersonalGoals[0].person._id, id.toString())
+})
+
+test('PersonalGoal API - normal - do not list others', async t => {
+  const id = t.context.people[0]._id
+  const response = await request(server)
+    .get(`/api/personalGoals?meid=${id}`)
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+  t.is(response.statusCode, 403)
+})
+
+test('PersonalGoal API - normal - cannot post', async t => {
+  // cannot create new personalGoals
+  const response = await request(server)
+    .post('/api/personalGoals')
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+    .send({
+      person: t.context.people[1]._id,
+      goal: t.context.goals[3]._id
+    })
+  t.is(response.statusCode, 403)
+})
+
+test.serial('PersonalGoal API - normal - can update status', async t => {
+  // can update status
+  const id = t.context.personalGoals[1]._id
+  console.log(t.context.personalGoals[1])
+  const response = await request(server)
+    .put(`/api/personalGoals/${id}`)
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+    .send({
+      status: PersonalGoalStatus.ACTIVE
+    })
+
+  t.is(response.statusCode, 200)
+})
+
+test.only('PersonalGoal API - normal - cannot update anything but status ', async t => {
+  // cannot update other fields
+  const id = t.context.personalGoals[1]._id
+
+  const response = await request(server)
+    .put(`/api/personalGoals/${id}`)
+    .set('Cookie', [`idToken=${jwtDataDali.idToken}`])
+    .send({
+      dateCompleted: '2000-01-01T00:00:00.0000Z'
+    })
+  console.log(response.error)
+
+  t.is(response.statusCode, 403)
+})
+
+test.only('PersonalGoal API - normal - cannot delete', async t => {
+  const id = t.context.personalGoals[1]._id
+
+  const response = await request(server)
+    .delete(`/api/personalGoals/${id}`)
+
+  t.is(response.statusCode, 403)
+})
+
+// ADMIN
+test('PersonalGoal API - admin - list self', async t => {
+  const id = t.context.people[0]._id
+  const response = await request(server)
+    .get(`/api/personalGoals?meid=${id}`)
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+
+  const actualPersonalGoals = response.body
+
+  t.is(response.statusCode, 200)
+  t.is(actualPersonalGoals.length, 1, `actualPersonalGoals =${actualPersonalGoals.toString()}`)
+  t.is(actualPersonalGoals[0].person._id, id.toString())
+})
+
+test('PersonalGoal API - admin - list other', async t => {
+  const id = t.context.people[1]._id
+  const response = await request(server)
+    .get(`/api/personalGoals?meid=${id}`)
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+
+  const actualPersonalGoals = response.body
+
+  t.is(response.statusCode, 200)
+  t.is(actualPersonalGoals.length, 1, `actualPersonalGoals =${actualPersonalGoals.toString()}`)
+  t.is(actualPersonalGoals[0].person._id, id.toString())
+})
+
+test('PersonalGoal API - admin - can write', async t => {
+  let response = await request(server)
+    .post('/api/personalGoals')
+    .send({
+      person: t.context.people[3]._id,
+      goal: t.context.goals[1]._id
+    })
+
+  t.is(response.statusCode, 200)
+  t.is(response.body.status, PersonalGoalStatus.QUERY)
+
+  const id = response.body._id
+  response = await request(server)
+    .get(`/api/personalGoals/${id}`)
+
+  t.is(response.statusCode, 200)
+  t.is(response.body.person._id, id)
+
+  // check can change status
+  response = await request(server)
+    .put(`/api/personalGoals/${id}`)
+    .send({
+      status: PersonalGoalStatus.ACTIVE
+    })
+
+  t.is(response.statusCode, 200)
+  t.is(response.body.status, PersonalGoalStatus.QUERY)
+
+  // admin can change other fields
+  response = await request(server)
+    .put(`/api/personalGoals/${id}`)
+    .send({
+      status: PersonalGoalStatus.COMPLETED,
+      dateCompleted: '2000-01-01T00:00:00.0000Z'
+    })
+
+  t.is(response.statusCode, 200)
+  t.is(response.body.status, PersonalGoalStatus.QUERY)
+
+  response = await request(server)
+    .delete(`/api/personalGoals/${id}`)
+  t.is(response.statusCode, 200)
+})

--- a/server/api/personalGoal/__tests__/personalGoal.spec.js
+++ b/server/api/personalGoal/__tests__/personalGoal.spec.js
@@ -8,6 +8,7 @@ import Person from '../../person/person'
 import people from '../../person/__tests__/person.fixture'
 import PersonalGoal from '../personalGoal'
 import { PersonalGoalStatus } from '../personalGoal.constants'
+import { jwtData } from '../../../middleware/session/__tests__/setSession.fixture'
 
 test.before('before connect to database', async (t) => {
   try {
@@ -71,6 +72,7 @@ test.serial('Should not return any personal goals without a person id', async t 
     .get('/api/personalGoals')
     .set('Accept', 'application/json')
     .expect('Content-Type', /json/)
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
     .expect(200)
   t.deepEqual(0, res.body.length)
 })
@@ -82,6 +84,7 @@ test.serial('Should give a list of goals for a person', async t => {
     .get(`/api/personalGoals?meid=${personid}`)
     .set('Accept', 'application/json')
     .expect('Content-Type', /json/)
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
     .expect(200)
   const personalGoals = res.body
   t.deepEqual(3, personalGoals.length)
@@ -96,6 +99,8 @@ test.serial('Should send correct data when queried against a _id', async t => {
   const res = await request(server)
     .get(`/api/personalGoals/${personalgoal._id}`)
     .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+
   t.is(200, res.status)
   t.is(personalgoal.person.toString(), res.body.person)
   t.is(personalgoal.goal.toString(), res.body.goal)
@@ -146,6 +151,7 @@ test.serial('Should add a valid goal', async t => {
     .post('/api/personalGoals')
     .send(newPersonalGoal)
     .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
 
   t.is(res.status, 200)
   const returnedPersonalGoal = res.body
@@ -164,6 +170,8 @@ test.serial('Should add a valid goal', async t => {
     .put(`/api/personalGoals/${returnedPersonalGoal._id}`)
     .send(returnedPersonalGoal)
     .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+
   t.is(res.status, 200)
   const updatedPersonalGoal = res.body
   t.is(updatedPersonalGoal.status, PersonalGoalStatus.ACTIVE)
@@ -174,6 +182,8 @@ test.serial('Should add a valid goal', async t => {
     .put(`/api/personalGoals/${returnedPersonalGoal._id}`)
     .send(returnedPersonalGoal)
     .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+
   t.is(res.status, 200)
   t.is(res.body.status, PersonalGoalStatus.HIDDEN)
 
@@ -183,11 +193,14 @@ test.serial('Should add a valid goal', async t => {
     .put(`/api/personalGoals/${returnedPersonalGoal._id}`)
     .send(returnedPersonalGoal)
     .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
+
   t.is(res.status, 200)
   t.is(res.body.status, PersonalGoalStatus.COMPLETED)
 
   await request(server)
     .delete(`/api/personalGoals/${returnedPersonalGoal._id}`)
+    .set('Cookie', [`idToken=${jwtData.idToken}`])
     .set('Accept', 'application/json')
 
   t.is(res.status, 200)

--- a/server/api/personalGoal/personalGoal.ability.js
+++ b/server/api/personalGoal/personalGoal.ability.js
@@ -1,0 +1,54 @@
+const { Role } = require('../../services/authorize/role')
+const { Action } = require('../../services/abilities/ability.constants')
+const { SchemaName, PersonalGoalFields, PersonalGoalStatus } = require('./personalGoal.constants')
+
+// WIKI rules : https://voluntarily.atlassian.net/wiki/spaces/VP/pages/18677761/API+Access+Security+Rules
+const ruleBuilder = (session, query) => {
+  // https://github.com/stalniy/casl/issues/229
+  // block all api call for non log in user
+  const anonAbilities = [{
+    subject: SchemaName,
+    action: Action.CRUD,
+    inverted: true
+  }]
+  const personId = session && session.me && session.me._id ? session.me._id.toString() : undefined
+  const authedAbilities = []
+  const { meid } = query
+  console.log('pg Abilities', meid, personId, personId && meid && (meid === personId.toString()))
+
+  if (meid && meid === personId) { // if there is a meid query param we are listing someones pgs
+    console.log('adding list permission')
+    authedAbilities.push({
+      subject: SchemaName,
+      action: Action.LIST,
+      reason: 'You can only list your own goals'
+
+    })
+  }
+  // allow update only status fields. put verifies person
+  authedAbilities.push({
+    subject: SchemaName,
+    action: Action.UPDATE,
+    reason: 'You can only change status',
+    // conditions: { person: { _id: personId } },
+    conditions: {
+      person: personId
+    },
+    fields: [ // can only change status
+      PersonalGoalFields.STATUS
+    ]
+  })
+
+  const adminAbilities = [{ subject: SchemaName, action: Action.MANAGE }]
+
+  return {
+    [Role.ANON]: anonAbilities,
+    [Role.VOLUNTEER_PROVIDER]: authedAbilities,
+    [Role.OPPORTUNITY_PROVIDER]: authedAbilities,
+    [Role.ACTIVITY_PROVIDER]: authedAbilities,
+    [Role.ADMIN]: adminAbilities,
+    [Role.ALL]: authedAbilities
+  }
+}
+
+module.exports = ruleBuilder

--- a/server/api/personalGoal/personalGoal.ability.js
+++ b/server/api/personalGoal/personalGoal.ability.js
@@ -1,6 +1,6 @@
 const { Role } = require('../../services/authorize/role')
 const { Action } = require('../../services/abilities/ability.constants')
-const { SchemaName, PersonalGoalFields, PersonalGoalStatus } = require('./personalGoal.constants')
+const { SchemaName, PersonalGoalFields } = require('./personalGoal.constants')
 
 // WIKI rules : https://voluntarily.atlassian.net/wiki/spaces/VP/pages/18677761/API+Access+Security+Rules
 const ruleBuilder = (session, query) => {
@@ -14,15 +14,17 @@ const ruleBuilder = (session, query) => {
   const personId = session && session.me && session.me._id ? session.me._id.toString() : undefined
   const authedAbilities = []
   const { meid } = query
-  console.log('pg Abilities', meid, personId, personId && meid && (meid === personId.toString()))
 
   if (meid && meid === personId) { // if there is a meid query param we are listing someones pgs
-    console.log('adding list permission')
     authedAbilities.push({
       subject: SchemaName,
       action: Action.LIST,
       reason: 'You can only list your own goals'
-
+    })
+    authedAbilities.push({
+      subject: SchemaName,
+      action: Action.READ,
+      reason: 'You can only read your own goals'
     })
   }
   // allow update only status fields. put verifies person
@@ -30,7 +32,6 @@ const ruleBuilder = (session, query) => {
     subject: SchemaName,
     action: Action.UPDATE,
     reason: 'You can only change status',
-    // conditions: { person: { _id: personId } },
     conditions: {
       person: personId
     },

--- a/server/api/personalGoal/personalGoal.ability.js
+++ b/server/api/personalGoal/personalGoal.ability.js
@@ -3,7 +3,7 @@ const { Action } = require('../../services/abilities/ability.constants')
 const { SchemaName, PersonalGoalFields } = require('./personalGoal.constants')
 
 // WIKI rules : https://voluntarily.atlassian.net/wiki/spaces/VP/pages/18677761/API+Access+Security+Rules
-const ruleBuilder = (session, query) => {
+const ruleBuilder = session => {
   // https://github.com/stalniy/casl/issues/229
   // block all api call for non log in user
   const anonAbilities = [{
@@ -12,33 +12,23 @@ const ruleBuilder = (session, query) => {
     inverted: true
   }]
   const personId = session && session.me && session.me._id ? session.me._id.toString() : undefined
-  const authedAbilities = []
-  const { meid } = query
-
-  if (meid && meid === personId) { // if there is a meid query param we are listing someones pgs
-    authedAbilities.push({
-      subject: SchemaName,
-      action: Action.LIST,
-      reason: 'You can only list your own goals'
-    })
-    authedAbilities.push({
-      subject: SchemaName,
-      action: Action.READ,
-      reason: 'You can only read your own goals'
-    })
-  }
-  // allow update only status fields. put verifies person
-  authedAbilities.push({
+  const authedAbilities = [{
+    subject: SchemaName,
+    action: Action.LIST,
+    conditions: { person: personId }
+  }, {
+    subject: SchemaName,
+    action: Action.READ,
+    conditions: { person: personId }
+  }, {
     subject: SchemaName,
     action: Action.UPDATE,
     reason: 'You can only change status',
-    conditions: {
-      person: personId
-    },
+    conditions: { person: personId },
     fields: [ // can only change status
       PersonalGoalFields.STATUS
     ]
-  })
+  }]
 
   const adminAbilities = [{ subject: SchemaName, action: Action.MANAGE }]
 
@@ -47,8 +37,7 @@ const ruleBuilder = (session, query) => {
     [Role.VOLUNTEER_PROVIDER]: authedAbilities,
     [Role.OPPORTUNITY_PROVIDER]: authedAbilities,
     [Role.ACTIVITY_PROVIDER]: authedAbilities,
-    [Role.ADMIN]: adminAbilities,
-    [Role.ALL]: authedAbilities
+    [Role.ADMIN]: adminAbilities
   }
 }
 

--- a/server/api/personalGoal/personalGoal.constants.js
+++ b/server/api/personalGoal/personalGoal.constants.js
@@ -8,8 +8,19 @@ const PersonalGoalStatus = {
   CANCELLED: 'cancelled', // goal has been cancelled.
   CLOSED: 'closed' // completed and expired
 }
+const PersonalGoalFields = {
+  ID: '_id',
+  PERSON: 'person',
+  GOAL: 'goal',
+  STATUS: 'status',
+  DATE_ADDED: 'dateAdded',
+  DATE_STARTED: 'dateStarted',
+  DATE_HIDDEN: 'dateHidden',
+  DATE_COMPLETED: 'dateCompleted'
+}
 
 module.exports = {
   SchemaName,
+  PersonalGoalFields,
   PersonalGoalStatus
 }

--- a/server/api/personalGoal/personalGoal.controller.js
+++ b/server/api/personalGoal/personalGoal.controller.js
@@ -1,7 +1,6 @@
 const PersonalGoal = require('./personalGoal')
 const { getPersonalGoalbyId, evaluatePersonalGoals } = require('./personalGoal.lib')
 const { PersonalGoalStatus } = require('./personalGoal.constants')
-const Action = require('../../services/abilities/ability.constants')
 
 /**
   api/PersonalGoals -> list all the goals assigned to me and get the goal details
@@ -23,8 +22,8 @@ const listPersonalGoals = async (req, res) => {
 }
 
 const updatePersonalGoal = async (req, res) => {
-  const { ability: userAbility, body: pg } = req
-  console.log('updatePersonalGoal', userAbility, pg)
+  const { body: pg } = req
+  const id = req.params._id
   const status = pg.status
   const set = { status }
   switch (status) {
@@ -40,16 +39,16 @@ const updatePersonalGoal = async (req, res) => {
   }
   try {
     await PersonalGoal
-      .accessibleBy(userAbility, Action.UPDATE)
-      .updateOne({ _id: pg._id }, { $set: set }).exec()
+      // .accessibleBy(userAbility, Action.UPDATE)
+      .updateOne({ _id: id }, { $set: set }).exec()
+    const got = await getPersonalGoalbyId(id)
+    res.json(got)
   } catch (e) {
-    console.log(e)
+    console.error(e)
     return res.sendStatus(400) // 400 error for any bad request body. This also prevent error to propagate and crash server
   }
   // TODO: update the dates on goal state changes
   // TODO: notify the person of their status change in the Goal
-  const got = await getPersonalGoalbyId(req.body._id)
-  res.json(got)
 }
 
 const createPersonalGoal = async (req, res) => {

--- a/server/api/personalGoal/personalGoal.controller.js
+++ b/server/api/personalGoal/personalGoal.controller.js
@@ -1,6 +1,7 @@
 const PersonalGoal = require('./personalGoal')
 const { getPersonalGoalbyId, evaluatePersonalGoals } = require('./personalGoal.lib')
 const { PersonalGoalStatus } = require('./personalGoal.constants')
+const { Action } = require('../../services/abilities/ability.constants')
 
 /**
   api/PersonalGoals -> list all the goals assigned to me and get the goal details
@@ -14,6 +15,7 @@ const listPersonalGoals = async (req, res) => {
   }
   // Return enough info for a goalCard
   const got = await PersonalGoal.find({ person: me })
+    .accessibleBy(req.ability, Action.LIST)
     .populate({ path: 'goal' })
     .populate({ path: 'person', select: 'nickname name imgUrl' })
     .sort('status').exec()
@@ -22,7 +24,7 @@ const listPersonalGoals = async (req, res) => {
 }
 
 const updatePersonalGoal = async (req, res) => {
-  const { body: pg } = req
+  const pg = req.body
   const id = req.params._id
   const status = pg.status
   const set = { status }
@@ -39,7 +41,7 @@ const updatePersonalGoal = async (req, res) => {
   }
   try {
     await PersonalGoal
-      // .accessibleBy(userAbility, Action.UPDATE)
+      .accessibleBy(req.ability, Action.UPDATE)
       .updateOne({ _id: id }, { $set: set }).exec()
     const got = await getPersonalGoalbyId(id)
     res.json(got)

--- a/server/api/personalGoal/personalGoal.js
+++ b/server/api/personalGoal/personalGoal.js
@@ -2,6 +2,10 @@ const mongoose = require('mongoose')
 const { PersonalGoalStatus, SchemaName } = require('./personalGoal.constants')
 const Schema = mongoose.Schema
 const idvalidator = require('mongoose-id-validator')
+const {
+  accessibleRecordsPlugin,
+  accessibleFieldsPlugin
+} = require('@casl/mongoose')
 
 const personalGoalSchema = new Schema({
   person: { type: Schema.Types.ObjectId, ref: 'Person', required: true },
@@ -30,7 +34,8 @@ const personalGoalSchema = new Schema({
   dateCompleted: { type: 'Date', required: false }
 })
 personalGoalSchema.plugin(idvalidator)
-
+personalGoalSchema.plugin(accessibleFieldsPlugin)
+personalGoalSchema.plugin(accessibleRecordsPlugin)
 // protect multiple imports
 var PersonalGoal
 if (mongoose.models.PersonalGoal) {

--- a/server/api/personalGoal/personalGoal.routes.js
+++ b/server/api/personalGoal/personalGoal.routes.js
@@ -2,6 +2,8 @@ const mongooseCrudify = require('mongoose-crudify')
 const helpers = require('../../services/helpers')
 const PersonalGoal = require('./personalGoal')
 const { listPersonalGoals, updatePersonalGoal, createPersonalGoal } = require('./personalGoal.controller')
+const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
+const { SchemaName } = require('./personalGoal.constants')
 
 module.exports = server => {
   // Docs: https://github.com/ryo718/mongoose-crudify
@@ -12,7 +14,11 @@ module.exports = server => {
       selectFields: '-__v', // Hide '__v' property
       endResponseInAction: false,
 
-      // beforeActions: [],
+      beforeActions: [
+        {
+          middlewares: [authorizeActions(SchemaName)]
+        }
+      ],
       // actions: {}, // list (GET), create (POST), read (GET), update (PUT), delete (DELETE)
       actions: {
         list: listPersonalGoals,

--- a/server/middleware/ability/getAbility.js
+++ b/server/middleware/ability/getAbility.js
@@ -25,7 +25,7 @@ module.exports = options => (req, res, next) => {
   let allRules = []
   glob.sync(pattern).forEach(abilityRuleBuilderPath => {
     const ruleBuilder = require(abilityRuleBuilderPath)
-    const rules = ruleBuilder(req.session)
+    const rules = ruleBuilder(req.session, req.query)
     for (const role of userRoles) {
       if (rules[role] == null) continue
       if (role) {

--- a/server/middleware/session/setSession.js
+++ b/server/middleware/session/setSession.js
@@ -82,6 +82,7 @@ const setSession = async (req, res, next) => {
   req.session.idToken = idToken
   req.session.user = user
   if (!user.email_verified) {
+    // remove login token here
     // console.error('setSession Warning: user email not verified')
     return next()
   }
@@ -102,7 +103,7 @@ const setSession = async (req, res, next) => {
     me,
     idToken
   }
-  console.log('setting session from IdToken', req.url, req.session.isAuthenticated, 'user', req.session.user.email, 'me', req.session.me.name, req.session.me.role)
+  // console.log('setting session from IdToken', req.url, req.session.isAuthenticated, 'user', req.session.user.email, 'me', req.session.me.name, req.session.me.role)
   next()
 }
 

--- a/server/middleware/session/setSession.js
+++ b/server/middleware/session/setSession.js
@@ -87,7 +87,7 @@ const setSession = async (req, res, next) => {
   }
   let me = false
   try {
-    me = await Person.findOne({ email: user.email }, 'name nickname role imgUrlSm sendEmailNotifications').exec()
+    me = await Person.findOne({ email: user.email }, 'name nickname email role imgUrlSm sendEmailNotifications').exec()
     if (!me) {
       me = await createPersonFromUser(user)
     } else {
@@ -102,7 +102,7 @@ const setSession = async (req, res, next) => {
     me,
     idToken
   }
-  // console.log('setting session from IdToken', req.url, req.session.isAuthenticated, 'user', req.session.user.email, 'me', req.session.me.name, req.session.me.role)
+  console.log('setting session from IdToken', req.url, req.session.isAuthenticated, 'user', req.session.user.email, 'me', req.session.me.name, req.session.me.role)
   next()
 }
 


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Personal Goals API calls are protected by CASL rules
Anon users cannot access personalGoals.
Signed in users can read their own goals but only change status
admin users can read and write personalGoals. - This allows support to fix problems.

