### PR TITLE
VP-1095 School lookup API permissions

### DIFF
--- a/__tests__/admin/invite-school.fixture.js
+++ b/__tests__/admin/invite-school.fixture.js
@@ -1,0 +1,105 @@
+import Person from '../../server/api/person/person'
+import SchoolLookUp from '../../server/api/school-lookup/school-lookup'
+import { Role } from '../../server/services/authorize/role'
+import jwt from 'jsonwebtoken'
+import mongoose from 'mongoose'
+
+const generateObjectId = mongoose.Types.ObjectId
+
+const people = [
+  {
+    _id: generateObjectId(),
+    name: 'Admin',
+    email: 'admin@example.com',
+    role: [Role.ADMIN]
+  },
+  {
+    _id: generateObjectId(),
+    name: 'Volunteer',
+    email: 'volunteer@example.com',
+    role: [Role.VOLUNTEER_PROVIDER]
+  }
+]
+
+const schools = [
+  {
+    schoolId: 1,
+    name: 'Test School',
+    telephone: '123 456 789',
+    emailDomain: 'test.school.nz',
+    website: 'https://www.test.school.nz',
+    address: '1 Test St\nTesturb\nTestington',
+    schoolType: 'Full Primary',
+    decile: 5
+  },
+  {
+    schoolId: 2,
+    name: 'Test School 2',
+    telephone: '123 456 788',
+    emailDomain: 'test2.school.nz',
+    website: 'https://www.test2.school.nz',
+    address: '2 Test St\nTesturb\nTestington',
+    schoolType: 'Full Primary',
+    decile: 5
+  },
+  {
+    schoolId: 3,
+    name: 'Test School 3',
+    telephone: '123 456 787',
+    emailDomain: 'test3.school.nz',
+    website: 'https://www.test3.school.nz',
+    address: '3 Test St\nTesturb\nTestington',
+    schoolType: 'Full Primary',
+    decile: 5
+  }
+]
+
+const sessions = []
+
+for (const person of people) {
+  const session = {
+    accessToken: 'IGs4bjO5WLjsulmjKiW2-VLeetlgykUP',
+    idTokenPayload: {
+      email: person.email,
+      email_verified: true,
+      exp: Math.floor(Date.now() / 1000) + (60 * 60),
+      iat: Math.floor(Date.now() / 1000),
+      name: person.name,
+      nickname: '',
+      picture: ''
+    },
+    refreshToken: null,
+    state: 'Nz_CgRTnYPO5CbD4ueKmkdCiuk2z3psk',
+    expiresIn: 3600,
+    tokenType: 'Bearer',
+    scope: null
+  }
+
+  session.idToken = jwt.sign(session.idTokenPayload, 'secret')
+
+  sessions.push(session)
+}
+
+const loadInterestFixtures = async () => {
+  const loadedFixtures = {};
+
+  [loadedFixtures.people, loadedFixtures.schools] = await Promise.all([
+    Person.create(people),
+    SchoolLookUp.create(schools)
+  ])
+
+  return loadedFixtures
+}
+
+const clearInterestFixtures = async () => {
+  await Promise.all([
+    Person.deleteMany(),
+    SchoolLookUp.deleteMany()
+  ])
+}
+
+module.exports = {
+  sessions,
+  loadInterestFixtures,
+  clearInterestFixtures
+}

--- a/__tests__/admin/invite-school.spec.js
+++ b/__tests__/admin/invite-school.spec.js
@@ -1,0 +1,83 @@
+import test from 'ava'
+import request from 'supertest'
+import { server, appReady } from '../../server/server'
+import MemoryMongo from '../../server/util/test-memory-mongo'
+import { loadInterestFixtures, clearInterestFixtures, sessions } from './invite-school.fixture'
+import fetchMock from 'fetch-mock'
+import SchoolLookUp from '../../server/api/school-lookup/school-lookup'
+
+let originalConsole = null
+
+test.before('setup database and app', async (t) => {
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
+  await appReady
+
+  t.context.mockServer = fetchMock.sandbox()
+  global.fetch = t.context.mockServer
+})
+
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
+})
+
+test.beforeEach('populate database fixtures', async (t) => {
+  originalConsole = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error
+  }
+
+  console.log = () => {}
+  console.warn = () => {}
+  console.error = () => {}
+
+  t.context.fixtures = await loadInterestFixtures()
+})
+
+test.afterEach.always(async (t) => {
+  console.log = originalConsole.log
+  console.warn = originalConsole.warn
+  console.error = originalConsole.error
+
+  t.context.mockServer.reset()
+  await clearInterestFixtures()
+})
+
+test.serial('Load invite school page as admin', async (t) => {
+  t.context.mockServer.get(
+    'end:/api/schools?p=schoolId%20name',
+    { body: await SchoolLookUp.find() }
+  )
+
+  const response = await request(server)
+    .get('/admin/invite-school')
+    .set('Cookie', [`idToken=${sessions[0].idToken}`])
+
+  t.is(response.status, 200, 'Should be allowed to view page')
+})
+
+test.serial('Load invite school page as anon', async (t) => {
+  t.context.mockServer.get(
+    'end:/api/schools?p=schoolId%20name',
+    { status: 403 }
+  )
+
+  const response = await request(server)
+    .get('/admin/invite-school')
+
+  t.is(response.status, 302, 'Should be redirected to login')
+})
+
+test.serial('Load invite school page as authenticated', async (t) => {
+  t.context.mockServer.get(
+    'end:/api/schools?p=schoolId%20name',
+    { status: 403 }
+  )
+
+  const response = await request(server)
+    .get('/admin/invite-school')
+    .set('Cookie', [`idToken=${sessions[1].idToken}`])
+
+  t.truthy(response.text.includes('<h1>Access denied</h1><p>You do not have permission to view this page.</p>'))
+})

--- a/pages/admin/invite-school.js
+++ b/pages/admin/invite-school.js
@@ -6,8 +6,14 @@ import fetch from 'isomorphic-fetch'
 import callApi from '../../lib/callApi'
 
 class InviteSchool extends Component {
-  static async getInitialProps () {
-    const schools = await callApi('schools?p=schoolId%20name')
+  static async getInitialProps ({ req }) {
+    let cookies = {}
+
+    if (req) {
+      cookies = req.cookies
+    }
+
+    const schools = await callApi('schools?p=schoolId%20name', 'GET', null, cookies)
 
     return {
       schools: schools

--- a/pages/admin/invite-school.js
+++ b/pages/admin/invite-school.js
@@ -13,7 +13,13 @@ class InviteSchool extends Component {
       cookies = req.cookies
     }
 
-    const schools = await callApi('schools?p=schoolId%20name', 'GET', null, cookies)
+    let schools = []
+
+    try {
+      schools = await callApi('schools?p=schoolId%20name', 'GET', null, cookies)
+    } catch (error) {
+      console.log(error)
+    }
 
     return {
       schools: schools

--- a/server/api/school-lookup/__tests__/school-lookup.ability.fixture.js
+++ b/server/api/school-lookup/__tests__/school-lookup.ability.fixture.js
@@ -1,0 +1,105 @@
+import Person from '../../person/person'
+import SchoolLookUp from '../../school-lookup/school-lookup'
+import { Role } from '../../../services/authorize/role'
+import jwt from 'jsonwebtoken'
+import mongoose from 'mongoose'
+
+const generateObjectId = mongoose.Types.ObjectId
+
+const people = [
+  {
+    _id: generateObjectId(),
+    name: 'Admin',
+    email: 'admin@example.com',
+    role: [Role.ADMIN]
+  },
+  {
+    _id: generateObjectId(),
+    name: 'Volunteer 1',
+    email: 'volunteer.1@example.com',
+    role: [Role.VOLUNTEER_PROVIDER]
+  }
+]
+
+const schools = [
+  {
+    schoolId: 1,
+    name: 'Test School',
+    telephone: '123 456 789',
+    emailDomain: 'test.school.nz',
+    website: 'https://www.test.school.nz',
+    address: '1 Test St\nTesturb\nTestington',
+    schoolType: 'Full Primary',
+    decile: 5
+  },
+  {
+    schoolId: 2,
+    name: 'Test School 2',
+    telephone: '123 456 788',
+    emailDomain: 'test2.school.nz',
+    website: 'https://www.test2.school.nz',
+    address: '2 Test St\nTesturb\nTestington',
+    schoolType: 'Full Primary',
+    decile: 5
+  },
+  {
+    schoolId: 3,
+    name: 'Test School 3',
+    telephone: '123 456 787',
+    emailDomain: 'test3.school.nz',
+    website: 'https://www.test3.school.nz',
+    address: '3 Test St\nTesturb\nTestington',
+    schoolType: 'Full Primary',
+    decile: 5
+  }
+]
+
+const sessions = []
+
+for (const person of people) {
+  const session = {
+    accessToken: 'IGs4bjO5WLjsulmjKiW2-VLeetlgykUP',
+    idTokenPayload: {
+      email: person.email,
+      email_verified: true,
+      exp: Math.floor(Date.now() / 1000) + (60 * 60),
+      iat: Math.floor(Date.now() / 1000),
+      name: person.name,
+      nickname: '',
+      picture: ''
+    },
+    refreshToken: null,
+    state: 'Nz_CgRTnYPO5CbD4ueKmkdCiuk2z3psk',
+    expiresIn: 3600,
+    tokenType: 'Bearer',
+    scope: null
+  }
+
+  session.idToken = jwt.sign(session.idTokenPayload, 'secret')
+
+  sessions.push(session)
+}
+
+const loadInterestFixtures = async () => {
+  const loadedFixtures = {};
+
+  [loadedFixtures.people, loadedFixtures.schools] = await Promise.all([
+    Person.create(people),
+    SchoolLookUp.create(schools)
+  ])
+
+  return loadedFixtures
+}
+
+const clearInterestFixtures = async () => {
+  await Promise.all([
+    Person.deleteMany(),
+    SchoolLookUp.deleteMany()
+  ])
+}
+
+module.exports = {
+  sessions,
+  loadInterestFixtures,
+  clearInterestFixtures
+}

--- a/server/api/school-lookup/__tests__/school-lookup.ability.spec.js
+++ b/server/api/school-lookup/__tests__/school-lookup.ability.spec.js
@@ -1,0 +1,234 @@
+import test from 'ava'
+import request from 'supertest'
+import { server, appReady } from '../../../server'
+import MemoryMongo from '../../../util/test-memory-mongo'
+import { loadInterestFixtures, clearInterestFixtures, sessions } from './school-lookup.ability.fixture'
+import { SCHOOL_TYPES } from '../school-lookup.constants'
+
+test.before('setup database and app', async (t) => {
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
+  await appReady
+})
+
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
+})
+
+test.beforeEach('populate database fixtures', async (t) => {
+  t.context.fixtures = await loadInterestFixtures()
+})
+
+test.afterEach.always(async () => {
+  await clearInterestFixtures()
+})
+
+const testScenarios = [
+  {
+    role: 'anon',
+    action: 'list',
+    makeRequest: async () => {
+      return request(server)
+        .get('/api/schools')
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'anon',
+    action: 'read',
+    makeRequest: async (context) => {
+      return request(server)
+        .get(`/api/schools/${context.fixtures.schools[0]._id}`)
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'anon',
+    action: 'create',
+    makeRequest: async (context) => {
+      return request(server)
+        .post('/api/schools')
+        .send({
+          schoolId: 1234,
+          emailDomain: 'example.com',
+          schoolType: SCHOOL_TYPES.FULL_PRIMARY
+        })
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'anon',
+    action: 'update',
+    makeRequest: async (context) => {
+      return request(server)
+        .put(`/api/schools/${context.fixtures.schools[0]._id}`)
+        .send({
+          name: 'Updated test name'
+        })
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'anon',
+    action: 'delete',
+    makeRequest: async (context) => {
+      return request(server).delete(`/api/schools/${context.fixtures.schools[0]._id}`)
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'authenticated',
+    action: 'list',
+    makeRequest: async () => {
+      return request(server)
+        .get('/api/schools')
+        .set('Cookie', [`idToken=${sessions[1].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'authenticated',
+    action: 'read',
+    makeRequest: async (context) => {
+      return request(server)
+        .get(`/api/schools/${context.fixtures.schools[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[1].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'authenticated',
+    action: 'create',
+    makeRequest: async (context) => {
+      return request(server)
+        .post('/api/schools')
+        .set('Cookie', [`idToken=${sessions[1].idToken}`])
+        .send({
+          schoolId: 1234,
+          emailDomain: 'example.com',
+          schoolType: SCHOOL_TYPES.FULL_PRIMARY
+        })
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'authenticated',
+    action: 'update',
+    makeRequest: async (context) => {
+      return request(server)
+        .put(`/api/schools/${context.fixtures.schools[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[1].idToken}`])
+        .send({
+          name: 'Updated test name'
+        })
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'authenticated',
+    action: 'delete',
+    makeRequest: async (context) => {
+      return request(server)
+        .delete(`/api/schools/${context.fixtures.schools[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[1].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'admin',
+    action: 'list',
+    makeRequest: async () => {
+      return request(server)
+        .get('/api/schools')
+        .set('Cookie', [`idToken=${sessions[0].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 200)
+      t.is(response.body.length, 3)
+    }
+  },
+  {
+    role: 'admin',
+    action: 'read',
+    makeRequest: async (context) => {
+      return request(server)
+        .get(`/api/schools/${context.fixtures.schools[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[0].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'admin',
+    action: 'create',
+    makeRequest: async (context) => {
+      return request(server)
+        .post('/api/schools')
+        .set('Cookie', [`idToken=${sessions[0].idToken}`])
+        .send({
+          schoolId: 1234,
+          emailDomain: 'example.com',
+          schoolType: SCHOOL_TYPES.FULL_PRIMARY
+        })
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'admin',
+    action: 'update',
+    makeRequest: async (context) => {
+      return request(server)
+        .put(`/api/schools/${context.fixtures.schools[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[0].idToken}`])
+        .send({
+          name: 'Updated test name'
+        })
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'admin',
+    action: 'delete',
+    makeRequest: async (context) => {
+      return request(server)
+        .delete(`/api/schools/${context.fixtures.schools[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[0].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  }
+]
+
+for (const { role, action, makeRequest, assertions } of testScenarios) {
+  test.serial(`School API - ${role} - ${action}`, async t => {
+    const response = await makeRequest(t.context)
+
+    assertions(t, response)
+  })
+}

--- a/server/api/school-lookup/school-lookup.ability.js
+++ b/server/api/school-lookup/school-lookup.ability.js
@@ -1,0 +1,29 @@
+const { Role } = require('../../services/authorize/role')
+const { Action } = require('../../services/abilities/ability.constants')
+const { SchemaName } = require('./school-lookup.constants')
+
+const ruleBuilder = async (session) => {
+  const anonRules = [{
+    subject: SchemaName,
+    action: Action.MANAGE,
+    inverted: true
+  }]
+
+  const allRules = anonRules.slice(0)
+
+  const adminRules = [{
+    subject: SchemaName,
+    action: Action.LIST
+  }]
+
+  return {
+    [Role.ANON]: anonRules,
+    [Role.VOLUNTEER_PROVIDER]: allRules,
+    [Role.OPPORTUNITY_PROVIDER]: allRules,
+    [Role.ACTIVITY_PROVIDER]: allRules,
+    [Role.ORG_ADMIN]: allRules,
+    [Role.ADMIN]: adminRules
+  }
+}
+
+module.exports = ruleBuilder

--- a/server/api/school-lookup/school-lookup.constants.js
+++ b/server/api/school-lookup/school-lookup.constants.js
@@ -15,6 +15,9 @@ const SCHOOL_TYPES = {
   TEEN_PARENT_UNIT: 'Teen Parent Unit'
 }
 
+const SchemaName = 'SchoolLookUp'
+
 module.exports = {
-  SCHOOL_TYPES
+  SCHOOL_TYPES,
+  SchemaName
 }

--- a/server/api/school-lookup/school-lookup.routes.js
+++ b/server/api/school-lookup/school-lookup.routes.js
@@ -2,6 +2,8 @@ const mongooseCrudify = require('mongoose-crudify')
 const helpers = require('../../services/helpers')
 const SchoolLookUp = require('./school-lookup')
 const { getSchools } = require('./school-lookup.controller')
+const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
+const { SchemaName } = require('./school-lookup.constants')
 
 module.exports = function (server) {
   server.use(
@@ -10,6 +12,9 @@ module.exports = function (server) {
       Model: SchoolLookUp,
       selectFields: '-__v', // Hide '__v' property
       endResponseInAction: false,
+      beforeActions: [{
+        middlewares: [authorizeActions(SchemaName)]
+      }],
       actions: {
         list: getSchools
       },


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Add permissions for school lookup API
2. Fix bug in school invite page where cookies were not being sent along with API request (when run server side)