### PR TITLE
VP-1312 - Avoid duplicating the organisation if school-invite used twice.

### DIFF
--- a/server/api/activity/__tests__/activity.spec.js
+++ b/server/api/activity/__tests__/activity.spec.js
@@ -15,6 +15,9 @@ import acts from './activity.fixture.js'
 test.before('before connect to database', async (t) => {
   t.context.memMongo = new MemoryMongo()
   await t.context.memMongo.start()
+  t.context.people = await Person.create(people).catch((err) => `Unable to create people: ${err}`)
+  t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create organisations: ${err}`)
+
   await appReady
 })
 
@@ -24,8 +27,6 @@ test.after.always(async (t) => {
 
 test.beforeEach('connect and add two activity entries', async (t) => {
   // connect each activity to an owner and org
-  t.context.people = await Person.create(people).catch((err) => `Unable to create people: ${err}`)
-  t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create organisations: ${err}`)
   acts.map((act, index) => {
     act.owner = t.context.people[index]._id
     act.offerOrg = t.context.orgs[index]._id
@@ -38,7 +39,6 @@ test.beforeEach('connect and add two activity entries', async (t) => {
 
 test.afterEach.always(async () => {
   await Activity.deleteMany()
-  await Person.deleteMany()
 })
 
 test.serial('verify fixture database has acts', async t => {

--- a/server/api/opportunity/__tests__/opportunity.spec.js
+++ b/server/api/opportunity/__tests__/opportunity.spec.js
@@ -23,6 +23,8 @@ import { jwtData } from '../../../middleware/session/__tests__/setSession.fixtur
 test.before('before connect to database', async (t) => {
   t.context.memMongo = new MemoryMongo()
   await t.context.memMongo.start()
+  t.context.people = await Person.create(people).catch((err) => `Unable to create people: ${err}`)
+  t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create orgs: ${err}`)
   await appReady
 })
 
@@ -32,8 +34,6 @@ test.after.always(async (t) => {
 
 test.beforeEach('connect and add two oppo entries', async (t) => {
   // connect each oppo to a requestor.
-  t.context.people = await Person.create(people).catch((err) => `Unable to create people: ${err}`)
-  t.context.orgs = await Organisation.create(orgs).catch((err) => `Unable to create orgs: ${err}`)
   ops.map((op, index) => {
     op.requestor = t.context.people[index]._id
     op.offerOrg = t.context.orgs[1]._id
@@ -44,7 +44,6 @@ test.beforeEach('connect and add two oppo entries', async (t) => {
 
 test.afterEach.always(async () => {
   await Opportunity.deleteMany()
-  await Person.deleteMany()
 })
 
 test.serial('verify fixture database has ops', async t => {

--- a/server/api/organisation/__tests__/organisation.fixture.js
+++ b/server/api/organisation/__tests__/organisation.fixture.js
@@ -1,7 +1,7 @@
 const orgList = [
   {
     name: 'Voluntarily Administrators',
-    slug: 'vly-admin',
+    slug: 'voluntarily-administrators',
     category: ['admin'],
     imgUrl: 'https://example.com/image1',
     info: {
@@ -45,14 +45,14 @@ const orgList = [
   },
   {
     name: 'Spark Ltd',
-    slug: 'spark',
+    slug: 'spark-ltd',
     category: ['vp'],
     imgUrl: 'https://example.com/image4',
     info: { about: 'more of our most loyal helpers' }
   },
   {
     name: 'Westpac Ltd',
-    slug: 'westpac',
+    slug: 'westpac-ltd',
     category: ['vp'],
     info: { about: 'even more of our most loyal helpers' }
   },

--- a/server/api/organisation/__tests__/organisation.spec.js
+++ b/server/api/organisation/__tests__/organisation.spec.js
@@ -172,7 +172,7 @@ test.serial('Should correctly give reverse sorted orgs of category', async t => 
     .expect('Content-Type', /json/)
   const got = res.body
   t.is(got.length, 3)
-  t.is(got[0].slug, 'westpac')
+  t.is(got[0].slug, 'westpac-ltd')
 })
 
 // Searching for something in the subtitle (case insensitive)

--- a/server/api/organisation/organisation.js
+++ b/server/api/organisation/organisation.js
@@ -3,8 +3,8 @@ const { accessibleRecordsPlugin } = require('@casl/mongoose')
 const Schema = mongoose.Schema
 
 const organisationSchema = new Schema({
-  name: { type: 'String', required: true },
-  slug: { type: 'String', required: true },
+  name: { type: 'String', required: true, unique: true },
+  slug: { type: 'String', required: true, unique: true },
   about: { type: 'String' },
   // TODO: [VP-146] make required and provide a default image in the static folder.  imgUrl: String,
   imgUrl: { type: 'String', default: '/static/img/organisation/organisation.png' },

--- a/server/api/school-invite/__tests__/school-invite.controller.spec.js
+++ b/server/api/school-invite/__tests__/school-invite.controller.spec.js
@@ -185,6 +185,10 @@ test.serial('Create organisation from school', async (t) => {
   t.is(organisation.website, schoolData.website)
   t.is(organisation.address, schoolData.address)
   t.is(organisation.decile, schoolData.decile)
+
+  // try a second time - should get the same organisation back.
+  const org2 = await SchoolInvite.createOrganisationFromSchool(schoolData.schoolId)
+  t.deepEqual(organisation._id, org2._id)
 })
 
 test.serial('Create organisation from non-existent school', async (t) => {
@@ -212,4 +216,8 @@ test.serial('Link person to organisation as admin', async (t) => {
   t.is(member.validation, 'orgAdmin from school-invite controller')
   t.is(member.status, MemberStatus.ORGADMIN)
   t.true(spy.calledOnce)
+
+  // check second record is not created.
+  const dupMember = await SchoolInvite.linkPersonToOrganisationAsAdmin(organisation._id, person._id)
+  t.deepEqual(member._id, dupMember._id)
 })

--- a/server/api/school-invite/school-invite.controller.js
+++ b/server/api/school-invite/school-invite.controller.js
@@ -51,7 +51,7 @@ class SchoolInvite {
         schoolId: school.schoolId
       },
       action: 'join',
-      expiresIn: '2d'
+      expiresIn: '2w' // invite is valid for 2 weeks
     }
 
     const tokenUrl = makeURLToken(payload)
@@ -178,7 +178,9 @@ class SchoolInvite {
 
     initialOrganisationData.category = ['op']
     initialOrganisationData.slug = slug(initialOrganisationData.name)
-
+    // check whether org already exists. - match slug.
+    const existingOrg = await Organisation.findOne({ slug: initialOrganisationData.slug })
+    if (existingOrg) return existingOrg
     return Organisation.create(initialOrganisationData)
   }
 


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
A school-invite email contains a token that when used creates a new organisation based on the school id and adds the person as an admin. 

The handler did not check whether the invite had already been used and the organisation created, as none of the fields is required to be unique the second create succeeds and we get two schools with the same name but different ids.  Thus each user of the token gets their own school.

This change uses the slug field to check whether the school already exists. if so it returns the original school. 

The schema is changed so that two organisations cannot have the same name or slug. attempts to create an organisation with the same name as an existing one, or to edit the name of an organisation to be the same should fail.


