### PR TITLE
VP-1070 initial sign up email

### DIFF
--- a/emails/theme/footer.pug
+++ b/emails/theme/footer.pug
@@ -9,13 +9,11 @@ table(width="100%")
                 td(align="center" valign="middle" style="font-size: 12px; line-height: 18px; color:#aaaaaa;")
                   span(class="appleFooter")
                     block footer
-                      p Voluntarily is an initiative run by the
-                        a( href="http://www.pamfergusson.co.nz/") Pam Fergusson Charitable Trust
+                      p Voluntarily is an initiative run by the 
+                        a( href="http://www.pamfergusson.co.nz/") 
+                          span Pam Fergusson Charitable Trust. 
                         if (to && to.email && to.href)
                           span This email was sent to #{to.email}. You're receiving this email because you expressed interest in Voluntarily Opportunities.
-                          span If you'd rather not see us in your inbox in the future, please set your
-                            a(href=to.href) profile to inactive.
-
-                    if (unsubscribeLink)
-                      p
-                        a(href=unsubscribeLink) Unsubscribe
+                      p If you'd rather not see us in your inbox in the future, 
+                        if (unsubscribeLink)
+                          a(href=unsubscribeLink) Unsubscribe

--- a/emails/welcome/html.pug
+++ b/emails/welcome/html.pug
@@ -1,0 +1,22 @@
+//- Welcome email sent when person first signs in
+//- expects locals of {
+//-   to: person receiving email
+//-   from: person sending email - the op requestor
+//- }
+extends ../theme/layout.pug
+
+block tagline
+  span Welcome to Voluntarily
+
+block copy
+  p Kia ora #{to.nickname},
+  p Thanks for volunteering to help out. 
+  p We have setup your account and allocated your first set of goals. 
+  p Click the button below to open Voluntarily on your home page, complete your profile and start your training.
+  p Ngā mihi, Voluntarily.nz
+
+block copybutton
+  a(href=to.href class='mobile-button') Lets get things started
+      
+block copyimage
+                                 

--- a/emails/welcome/subject.pug
+++ b/emails/welcome/subject.pug
@@ -1,0 +1,1 @@
+= `Welcome to Voluntarily`

--- a/server/api/person/__tests__/person.subscribe.spec.js
+++ b/server/api/person/__tests__/person.subscribe.spec.js
@@ -1,0 +1,39 @@
+import test from 'ava'
+import express from 'express'
+import PubSub from 'pubsub-js'
+import { TOPIC_PERSON__CREATE, TOPIC_PERSON__EMAIL_SENT } from '../../../services/pubsub/topic.constants'
+import MemoryMongo from '../../../util/test-memory-mongo'
+import Person from '../person'
+import people from './person.fixture'
+import Subscribe from '../person.subscribe.js'
+
+test.before('before connect to database', async (t) => {
+  try {
+    t.context.server = express()
+    Subscribe(t.context.server)
+    t.context.memMongo = new MemoryMongo()
+    await t.context.memMongo.start()
+    t.context.people = await Person.create(people).catch((err) => console.error('Unable to create people:', err))
+    t.context.andrew = t.context.people[0]
+  } catch (e) {
+    console.error('personController.spec.js, before connect to database', e)
+  }
+})
+
+test.after.always(async (t) => {
+  await t.context.memMongo.stop()
+})
+
+test.serial('Trigger TOPIC_PERSON__CREATE', async t => {
+  t.plan(2)
+
+  const newPerson = t.context.people[0]
+  const done = new Promise((resolve, reject) => {
+    PubSub.subscribe(TOPIC_PERSON__EMAIL_SENT, async (msg, info) => {
+      t.is(info.response, 'nodemailer-mock success')
+      resolve(true)
+    })
+  })
+  t.true(PubSub.publish(TOPIC_PERSON__CREATE, newPerson))
+  await done
+})

--- a/server/api/person/person.email.js
+++ b/server/api/person/person.email.js
@@ -12,52 +12,46 @@ module.exports.emailPerson = async (template, to, props, renderOnly = false) => 
   if (to._id && !to.sendEmailNotifications) {
     return null
   }
-  try {
-    const transport = getTransport()
-    const email = new Email({
-      message: {
-        from: 'no-reply@voluntarily.nz'
-      },
-      // uncomment below to send emails in development/test env:
-      send: true,
-      subjectPrefix: config.env === 'production' ? false : `[${config.env.toUpperCase()}] `,
+  const transport = getTransport()
+  const email = new Email({
+    message: {
+      from: 'no-reply@voluntarily.nz'
+    },
+    // uncomment below to send emails in development/test env:
+    send: true,
+    subjectPrefix: config.env === 'production' ? false : `[${config.env.toUpperCase()}] `,
 
-      // Comment the line below to see preview email
-      preview: false,
-      textOnly: config.onlyEmailText, // The value onlyEmailText has a Boolean type not string
-      transport
-    })
+    // Comment the line below to see preview email
+    preview: false,
+    textOnly: config.onlyEmailText, // The value onlyEmailText has a Boolean type not string
+    transport
+  })
 
-    props.appUrl = config.appUrl
+  props.appUrl = config.appUrl
 
-    if (to._id) {
-      props.unsubscribeLink = getUnsubscribeLink(to)
-    }
-
-    if (renderOnly) {
-      return await email.render(
-        template + '/html',
-        {
-          to,
-          ...props
-        }
-      )
-    } else {
-      return await email.send({
-        template: template,
-        message: {
-          to: to.email,
-          attachments: props.attachment ? props.attachment : null
-        },
-        locals: {
-          to,
-          ...props
-        }
-      })
-    }
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error)
+  if (to._id) {
+    props.unsubscribeLink = getUnsubscribeLink(to)
   }
-  return null
+
+  if (renderOnly) {
+    return email.render(
+      template + '/html',
+      {
+        to,
+        ...props
+      }
+    )
+  } else {
+    return email.send({
+      template: template,
+      message: {
+        to: to.email,
+        attachments: props.attachment ? props.attachment : null
+      },
+      locals: {
+        to,
+        ...props
+      }
+    })
+  }
 }

--- a/server/api/person/person.subscribe.js
+++ b/server/api/person/person.subscribe.js
@@ -1,0 +1,27 @@
+const { emailPerson } = require('./person.email')
+const { config } = require('../../../config/clientConfig')
+const PubSub = require('pubsub-js')
+const { TOPIC_PERSON__CREATE, TOPIC_PERSON__EMAIL_SENT } = require('../../services/pubsub/topic.constants')
+
+/**
+ * This will be easier to add more status without having too much if. All we need is add another folder in email template folder and the status will reference to that folder
+ * @param {string} template status will be used to indicate which email template to use
+ * @param {object} to person email is for. (requestor or volunteer) with email populated.
+ * @param {object} props extra properties such as attachment
+ */
+const welcomeFrom = {
+  nickname: 'Welcome',
+  name: 'The team at Voluntarily',
+  email: 'welcome@voluntarily.nz'
+}
+
+module.exports = (server) => {
+  PubSub.subscribe(TOPIC_PERSON__CREATE, async (msg, person) => {
+    person.href = `${config.appUrl}/home`
+    const info = await emailPerson('welcome', person, {
+      send: true,
+      from: welcomeFrom
+    })
+    PubSub.publish(TOPIC_PERSON__EMAIL_SENT, info)
+  })
+}

--- a/server/services/pubsub/topic.constants.js
+++ b/server/services/pubsub/topic.constants.js
@@ -6,7 +6,8 @@ const Topic = {
   TOPIC_API__HEALTH: Symbol('API.HEALTH'), // /api/health called
   TOPIC_PERSON__CREATE: Symbol('PERSON.CREATE'), // new person created via API
   TOPIC_MEMBER__UPDATE: Symbol('MEMBER.UPDATE'), // membership changed via service
-  TOPIC_GOALGROUP__ADD: Symbol('GOALGROUP.ADD') // goal group added to person
+  TOPIC_GOALGROUP__ADD: Symbol('GOALGROUP.ADD'), // goal group added to person
+  TOPIC_PERSON__EMAIL_SENT: Symbol('PERSON.EMAIL_SENT') // email sent to a person
 }
 
 module.exports = Topic


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Send a Welcome email to a new person when they first sign in. 

When a person signs in for the first time a new account is created.  AddPerson publishes a TOPIC_PERSON__CREATE event which is received by person.subscribe. This generates a new email to the person using the Welcome template.
This, in turn, generates a TOPIC_PERSON__EMAIL_SENT event. 

## Screenshots 📷
 
<img width="636" alt="image" src="https://user-images.githubusercontent.com/1596437/75225084-bce2fb80-580e-11ea-9fee-f488ef242c40.png">
