### PR TITLE
VP-973 make org tabs bookmarkable as for op tabs

### DIFF
--- a/__tests__/op/opdetailpage.spec.js
+++ b/__tests__/op/opdetailpage.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import test from 'ava'
-import { OpDetailPageWithOps } from '../../pages/op/opdetailpage'
+import { OpDetailPageWithOps, OpDetailPage } from '../../pages/op/opdetailpage'
 import { mountWithIntl } from '../../lib/react-intl-test-helper'
 import configureStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
@@ -18,9 +18,7 @@ import sinon from 'sinon'
 import * as nextRouter from 'next/router'
 import { MockWindowScrollTo } from '../../server/util/mock-dom-helpers'
 import fetchMock from 'fetch-mock'
-
 const locations = ['Auckland, Wellington, Christchurch']
-
 MockWindowScrollTo.replaceForTest(test, global)
 
 const orginalWarn = console.warn
@@ -75,7 +73,8 @@ test.before('Setup fixtures', (t) => {
     tags,
     acts,
     orgs,
-    orgMembership
+    orgMembership,
+    locations
   }
   t.context.defaultstore = {
     session: {
@@ -146,6 +145,47 @@ function makeFetchMock (opportunityId) {
   myMock.get(API_URL + '/interests/?op=' + opportunityId, { body: { status: 200 } })
   return myMock
 }
+
+test.serial('OpDetailPage GetInitialProps non member', async t => {
+  // first test GetInitialProps
+  const ctx = {
+    store: t.context.mockStore,
+    query: {
+      id: t.context.op._id
+    }
+  }
+  const myMock = fetchMock.sandbox()
+  reduxApi.use('fetch', adapterFetch(myMock))
+  myMock
+    .get(`path:/api/opportunities/${t.context.op._id}`, { body: { status: 200 } })
+    .get('path:/api/locations', { body: t.context.locations })
+    .get('path:/api/tags/', { body: t.context.tags })
+    .get('path:/api/members/', { body: t.context.members })
+  const props = await OpDetailPage.getInitialProps(ctx)
+  t.falsy(props.isNew)
+  t.true(props.opExists)
+})
+
+test.serial('OpDetailPage GetInitialProps new', async t => {
+  // first test GetInitialProps
+  const ctx = {
+    store: t.context.mockStore,
+    query: {
+      new: 'new'
+    }
+  }
+  const myMock = fetchMock.sandbox()
+  reduxApi.use('fetch', adapterFetch(myMock))
+  myMock
+    .get(`path:/api/opportunities/${t.context.op._id}`, { body: { status: 200 } })
+    .get('path:/api/locations', { body: t.context.locations })
+    .get('path:/api/tags/', { body: t.context.tags })
+    .get('path:/api/members/', { body: t.context.members })
+
+  const props = await OpDetailPage.getInitialProps(ctx)
+  t.true(props.isNew)
+  t.falsy(props.opExists)
+})
 
 test('send "PUT" request to redux-api when opportunity is canceled and confirmed on OpDetailPage', t => {
   const opportunityToCancel = t.context.op

--- a/__tests__/org/orgdetailpage.spec.js
+++ b/__tests__/org/orgdetailpage.spec.js
@@ -12,8 +12,28 @@ import withMockRoute from '../../server/util/mockRouter'
 import { MockWindowScrollTo } from '../../server/util/mock-dom-helpers'
 import fetchMock from 'fetch-mock'
 import { Provider } from 'react-redux'
+import sinon from 'sinon'
+import * as nextRouter from 'next/router'
 
 MockWindowScrollTo.replaceForTest(test, global)
+test.before('Setup Route', (t) => {
+  const router = () => {
+    return ({
+      pathname: '/orgs',
+      route: '/orgs',
+      asPath: '/orgs',
+      query: '',
+      initialProps: {},
+      pageLoader: sinon.fake(),
+      App: sinon.fake(),
+      Component: sinon.fake(),
+      replace: sinon.fake(),
+      push: sinon.fake(),
+      back: sinon.fake()
+    })
+  }
+  sinon.replace(nextRouter, 'useRouter', router)
+})
 
 test.before('Setup fixtures', (t) => {
   // This gives all the people fake ids to better represent a fake mongo db
@@ -233,7 +253,6 @@ test('render OrgDetailPage OrgAdmin ', async t => {
   t.is(wrapper.find('title').text(), 'OMGTech - Voluntarily')
   t.true(wrapper.exists('OrgBanner'))
   t.true(wrapper.exists('OrgTabs'))
-  t.true(wrapper.exists('OrgEditButton'))
 })
 
 test('OrgUnknown', t => {
@@ -268,25 +287,19 @@ test('edit and save existing org', async t => {
       <OrgDetailPage {...props} />
     </Provider>
   )
-  let editButton = wrapper.find('button').at(2)
-  t.is(editButton.text(), 'Edit')
-  editButton.simulate('click')
-  wrapper.update()
+  // click on edit tab
+  wrapper.find('.ant-tabs-tab').at(4).simulate('click')
+
   t.true(wrapper.exists('OrgDetailForm'))
   const cancelButton = wrapper.find('button').at(1)
   t.is(cancelButton.text(), 'Cancel')
   cancelButton.simulate('click')
   wrapper.update()
-  editButton = wrapper.find('button').at(2)
-  t.is(editButton.text(), 'Edit')
-  editButton.simulate('click')
-  wrapper.update()
+  wrapper.find('.ant-tabs-tab').at(4).simulate('click')
   const saveButton = wrapper.find('button').first()
   t.is(saveButton.text(), 'Save')
-  await wrapper.find('Form').first().simulate('submit')
+  wrapper.find('Form').first().simulate('submit')
   wrapper.update()
-  editButton = wrapper.find('button').at(2)
-  t.is(editButton.text(), 'Edit')
 })
 
 test('edit and save new org', async t => {
@@ -316,32 +329,27 @@ test('edit and save new org', async t => {
       <RoutedOrgDetailPage {...props} />
     </Provider>
   )
-  let editButton = wrapper.find('button').at(2)
-  t.is(editButton.text(), 'Edit')
-  editButton.simulate('click')
-  wrapper.update()
-  t.true(wrapper.exists('OrgDetailForm'))
+  // new starts in edit mode
   const cancelButton = wrapper.find('button').at(1)
   t.is(cancelButton.text(), 'Cancel')
   cancelButton.simulate('click')
   wrapper.update()
-  editButton = wrapper.find('button').at(2)
-  t.is(editButton.text(), 'Edit')
-  editButton.simulate('click')
-  wrapper.update()
+  t.true(wrapper.exists('OrgBanner'))
+  t.true(wrapper.exists('VTabs'))
+  t.is(wrapper.find('VTabs').props().defaultActiveKey, 'about')
+  wrapper.find('.ant-tabs-tab').at(4).simulate('click')
+  t.true(wrapper.exists('OrgDetailForm'))
   const saveButton = wrapper.find('button').first()
   t.is(saveButton.text(), 'Save')
-  await wrapper.find('Form').first().simulate('submit')
+  wrapper.find('Form').first().simulate('submit')
   wrapper.update()
-  editButton = wrapper.find('button').at(2)
-  t.is(editButton.text(), 'Edit')
 })
 
 test('render OrgDetailPage Unknown ', async t => {
   // first test GetInitialProps
   const props = {
     isNew: false,
-    orgid: t.context.orgs[0],
+    orgid: '12345678',
     organisations: {
       sync: true,
       syncing: false,
@@ -351,213 +359,6 @@ test('render OrgDetailPage Unknown ', async t => {
     },
     me: t.context.people[1]
   }
-
-  const wrapper = shallowWithIntl(
-    <OrgDetailPage {...props} />
-  )
+  const wrapper = shallowWithIntl(<OrgDetailPage {...props} />)
   t.true(wrapper.exists('OrgUnknown'))
 })
-
-// function makeFetchMock (organisationId) {
-//   const myMock = fetchMock.sandbox()
-//   myMock.get(API_URL + '/interests/?op=' + organisationId, { body: { status: 200 } })
-//   return myMock
-// }
-
-// test('send "PUT" request to redux-api when organisation is canceled and confirmed on OrgDetailPage', t => {
-//   const organisationToCancel = t.context.op
-//   const myMock = makeFetchMock(organisationToCancel._id)
-//   myMock.put(API_URL + '/organisations/' + organisationToCancel._id, { body: { status: 200 } })
-//   reduxApi.use('fetch', adapterFetch(myMock))
-//   const props = {
-//     me: t.context.me,
-//     dispatch: t.context.mockStore.dispatch
-//   }
-//   const RoutedOrgDetailPage = withMockRoute(OrgDetailPageWithOrgs)
-//   const wrapper = mountWithIntl(
-//     <Provider store={t.context.mockStore}>
-//       <RoutedOrgDetailPage {...props} />
-//     </Provider>
-//   )
-//   t.context.mockStore.clearActions()
-//   wrapper.find('Popconfirm').filter('#cancelOrgPopConfirm').props().onConfirm({})
-//   t.is(t.context.mockStore.getActions()[0].type, '@@redux-api@organisations')
-//   t.is(t.context.mockStore.getActions()[0].request.params.method, 'PUT')
-//   t.is(t.context.mockStore.getActions()[0].request.pathvars.id, t.context.op._id)
-// })
-
-// test('can Edit the Org', t => {
-//   const organisationToEdit = t.context.op
-//   const myMock = makeFetchMock(organisationToEdit._id)
-//   myMock.post(API_URL + '/tags/', { body: { status: 200 } })
-//   myMock.put(API_URL + '/organisations/' + organisationToEdit._id, { body: { status: 200 } })
-//   reduxApi.use('fetch', adapterFetch(myMock))
-
-//   const props = {
-//     me: t.context.me,
-//     dispatch: t.context.mockStore.dispatch
-//   }
-//   const RoutedOrgDetailPage = withMockRoute(OrgDetailPageWithOrgs)
-//   const wrapper = mountWithIntl(
-//     <Provider store={t.context.mockStore}>
-//       <RoutedOrgDetailPage {...props} />
-//     </Provider>
-//   )
-//   let editButton = wrapper.find('#editOrgBtn').first()
-//   t.is(editButton.text(), 'Edit')
-//   editButton.simulate('click')
-
-//   // should switch into edit mode
-//   const cancelButton = wrapper.find('#cancelOrgBtn').first()
-//   t.is(cancelButton.text(), 'Cancel')
-//   cancelButton.simulate('click')
-//   editButton = wrapper.find('#editOrgBtn').first()
-//   t.is(editButton.text(), 'Edit')
-//   t.is(wrapper.find('h1').first().text(), organisationToEdit.name)
-//   editButton.simulate('click')
-//   const saveButton = wrapper.find('#saveOrgBtn').first()
-//   t.is(saveButton.text(), 'Save as draft')
-//   saveButton.simulate('click')
-// })
-
-// test('display unavailable organisation message when organisation id is invalid on OrgDetailPage', t => {
-//   const props = {
-//     me: t.context.me
-//   }
-//   const mockStore = configureStore([thunk])(
-//     {
-//       session: {
-//         isAuthenticated: false
-//       },
-//       organisations: {
-//         sync: true,
-//         loading: false,
-//         data: []
-//       }
-//     }
-//   )
-
-//   const RoutedOrgDetailPage = withMockRoute(OrgDetailPageWithOrgs)
-//   const wrapper = mountWithIntl(
-//     <Provider store={mockStore}>
-//       <RoutedOrgDetailPage {...props} />
-//     </Provider>
-//   )
-//   t.is(wrapper.find('h2').first().text(), 'Sorry, this organisation is not available')
-// })
-
-// test('display loading organisation message when organisation is loading', t => {
-//   const props = {
-//     me: t.context.me
-//   }
-//   const mockStore = configureStore([thunk])(
-//     {
-//       session: {
-//         isAuthenticated: false
-//       },
-//       organisations: {
-//         loading: true,
-//         data: []
-//       }
-//     }
-//   )
-
-//   const RoutedOrgDetailPage = withMockRoute(OrgDetailPageWithOrgs)
-//   const wrapper = mountWithIntl(
-//     <Provider store={mockStore}>
-//       <RoutedOrgDetailPage {...props} />
-//     </Provider>
-//   )
-//   t.is(wrapper.find('img').prop('src'), '/static/loading.svg')
-// })
-
-// test('can create new Org from blank', t => {
-//   const organisationToEdit = t.context.org
-//   const myMock = makeFetchMock(organisationToEdit._id)
-//   myMock.put(API_URL + '/organisations/' + organisationToEdit._id, { body: { status: 200 } })
-//   reduxApi.use('fetch', adapterFetch(myMock))
-
-//   const props = {
-//     isNew: true,
-//     me: t.context.me,
-//     dispatch: t.context.mockStore.dispatch
-//   }
-//   const RoutedOrgDetailPage = withMockRoute(OrgDetailPageWithOrgs)
-//   const wrapper = mountWithIntl(
-//     <Provider store={t.context.mockStore}>
-//       <RoutedOrgDetailPage {...props} />
-//     </Provider>
-//   )
-
-//   const saveButton = wrapper.find('#saveOrgBtn').first()
-//   t.is(saveButton.text(), 'Save as draft')
-//   // saveButton.simulate('click')
-// })
-
-// test('can cancel new Org from blank', t => {
-//   const organisationToEdit = t.context.op
-//   const myMock = makeFetchMock(organisationToEdit._id)
-//   myMock.post(API_URL + '/tags/', { body: { status: 200 } })
-//   myMock.put(API_URL + '/organisations/' + organisationToEdit._id, { body: { status: 200 } })
-//   reduxApi.use('fetch', adapterFetch(myMock))
-
-//   const props = {
-//     isNew: true,
-//     me: t.context.me,
-//     dispatch: t.context.mockStore.dispatch
-//   }
-//   const RoutedOrgDetailPage = withMockRoute(OrgDetailPageWithOrgs)
-//   const wrapper = mountWithIntl(
-//     <Provider store={t.context.mockStore}>
-//       <RoutedOrgDetailPage {...props} />
-//     </Provider>
-//   )
-//   const saveButton = wrapper.find('#saveOrgBtn').first()
-//   t.is(saveButton.text(), 'Save as draft')
-//   const cancelButton = wrapper.find('#cancelOrgBtn').first()
-//   t.is(cancelButton.text(), 'Cancel')
-//   cancelButton.simulate('click')
-// })
-
-// test('can create new Org from Activity', t => {
-//   const organisationToEdit = t.context.op
-//   const fromActivity = t.context.acts[0]
-//   const myMock = makeFetchMock(organisationToEdit._id)
-//   myMock.post(API_URL + '/tags/', { body: { status: 200 } })
-//   myMock.put(API_URL + '/organisations/' + organisationToEdit._id, { body: { status: 200 } })
-//   reduxApi.use('fetch', adapterFetch(myMock))
-
-//   const props = {
-//     isNew: true,
-//     me: t.context.me,
-//     dispatch: t.context.mockStore.dispatch,
-//     actid: fromActivity._id
-//   }
-//   const RoutedOrgDetailPage = withMockRoute(OrgDetailPageWithOrgs)
-//   const wrapper = mountWithIntl(
-//     <Provider store={t.context.mockStore}>
-//       <RoutedOrgDetailPage {...props} />
-//     </Provider>
-//   )
-//   // check fields are initialised
-//   t.is(wrapper.find('#organisation_detail_form_name').first().prop('value'), fromActivity.name)
-//   t.is(wrapper.find('#organisation_detail_form_subtitle').first().prop('value'), fromActivity.subtitle)
-//   t.is(wrapper.find('#organisation_detail_form_imgUrl').first().prop('value'), fromActivity.imgUrl)
-//   const saveButton = wrapper.find('#saveOrgBtn').first()
-//   t.is(saveButton.text(), 'Save as draft')
-// })
-
-// test('page loads when user is not signed in but does not show edit VP-499', t => {
-//   const props = {
-//     me: '',
-//     dispatch: t.context.mockStore.dispatch
-//   }
-//   const RoutedOrgDetailPage = withMockRoute(OrgDetailPageWithOrgs)
-//   const wrapper = mountWithIntl(
-//     <Provider store={t.context.mockStore}>
-//       <RoutedOrgDetailPage {...props} />
-//     </Provider>
-//   )
-
-//   t.falsy(wrapper.find('#editOrgBtn').length)
-// })

--- a/components/Member/RegisterMemberItem.js
+++ b/components/Member/RegisterMemberItem.js
@@ -19,10 +19,6 @@ class RegisterMemberItem extends Component {
     }
   }
 
-  componentDidMount () {
-    this.props.form.validateFields()
-  }
-
   handleMemberButton (action) {
     const member = this.props.member
     member.validation = this.props.form.getFieldValue('validation')
@@ -101,7 +97,6 @@ class RegisterMemberItem extends Component {
 
   render () {
     const { getFieldDecorator } = this.props.form
-
     // Options to configure the controls on this page based on the state of the member.
     const options = this.getOptions(this.props.member)
 
@@ -115,13 +110,7 @@ class RegisterMemberItem extends Component {
               md={{ span: 12 }}
             >
               <Form.Item label='Enter your organisations validation code'>
-                {getFieldDecorator('validation', {
-                  // rules: [
-                  //   { required: true, message: 'Validation is required' }
-                  // ]
-                })(
-                  <Input />
-                )}
+                {getFieldDecorator('validation')(<Input />)}
               </Form.Item>
             </Col>
           </Row>}
@@ -130,11 +119,10 @@ class RegisterMemberItem extends Component {
         <Row>
           {options.btns.map((btn, index) => {
             return (
-              <span key={index}>
-                <Button type={btn.type} shape='round' onClick={this.handleMemberButton.bind(this, btn.action)}>
-                  {btn.text}
-                </Button>
-              </span>)
+              <Button key={index} type={btn.type} shape='round' onClick={this.handleMemberButton.bind(this, btn.action)}>
+                {btn.text}
+              </Button>
+            )
           })}
         </Row>
       </Form>
@@ -156,9 +144,6 @@ RegisterMemberItem.propTypes = {
 // Adds form logic to this component
 export default Form.create({
   name: 'register_member_form',
-  onFieldsChange (props, changedFields) {
-    // props.onChange(changedFields);
-  },
   mapPropsToFields (props) {
     return {
       validation: Form.createFormField({ ...props.member.validation, value: props.member.validation })

--- a/components/Member/RegisterMemberSection.js
+++ b/components/Member/RegisterMemberSection.js
@@ -14,6 +14,7 @@ import styled from 'styled-components'
 import reduxApi, { withMembers } from '../../lib/redux/reduxApi'
 import { MemberStatus } from '../../server/api/member/member.constants'
 import RegisterMemberItem from './RegisterMemberItem'
+import Loading from '../../components/Loading'
 
 // Helper function to generate a blank member.
 const getNewMember = (me, org) => {
@@ -92,29 +93,28 @@ class RegisterMemberSection extends Component {
   // Render the component depending on whether we've completed the initial api call, and what information is contained in the store.
   render () {
     // If we haven't finished making the API request to the server yet...
-    if (this.props.members.sync) {
-      // If we have access to the members section of the Redux store...
-      // Get the member out of the store, if any.
-      let member = null
-
-      if (this.props.members.data.length > 0) {
-        const matches = this.props.members.data.filter(m => m.person._id === this.props.meid)
-        member = matches.length && matches[0]
-      }
-      if (!member) {
-        member = getNewMember(this.props.meid, this.props.orgid)
-      }
-      return (
-        <RegisterButtonBox>
-          <RegisterMemberItem
-            member={member}
-            onChangeStatus={this.handleChangeStatus.bind(this)}
-          />
-        </RegisterButtonBox>
-      )
-    } else {
-      return (<br />)
+    if (!this.props.members.sync) {
+      return <Loading label='activity' entity={this.props.members} />
     }
+    // If we have access to the members section of the Redux store...
+    // Get the member out of the store, if any.
+    let member = null
+
+    if (this.props.members.data.length > 0) {
+      const matches = this.props.members.data.filter(m => m.person._id === this.props.meid)
+      member = matches.length && matches[0]
+    }
+    if (!member) {
+      member = getNewMember(this.props.meid, this.props.orgid)
+    }
+    return (
+      <RegisterButtonBox>
+        <RegisterMemberItem
+          member={member}
+          onChangeStatus={this.handleChangeStatus.bind(this)}
+        />
+      </RegisterButtonBox>
+    )
   }
 }
 

--- a/components/Member/__tests__/MemberSection.spec.js
+++ b/components/Member/__tests__/MemberSection.spec.js
@@ -49,7 +49,7 @@ test.serial('followers can become members and then be removed', async t => {
 
   const wrapper = await mountWithIntl(
     <Provider store={t.context.store}>
-      <MemberSection org={org} />
+      <MemberSection org={org} isAdmin />
     </Provider>
   )
   await sleep(1) // allow asynch fetch to complete
@@ -129,7 +129,7 @@ test.serial('joiners can become members ', async t => {
 
   const wrapper = await mountWithIntl(
     <Provider store={t.context.store}>
-      <MemberSection org={org} />
+      <MemberSection org={org} isAdmin />
     </Provider>
   )
   await sleep(1) // allow asynch fetch to complete
@@ -210,7 +210,7 @@ test.serial('members can become admins ', async t => {
 
   const wrapper = await mountWithIntl(
     <Provider store={t.context.store}>
-      <MemberSection org={org} />
+      <MemberSection org={org} isAdmin />
     </Provider>
   )
   await sleep(1) // allow asynch fetch to complete
@@ -257,7 +257,7 @@ test.serial('admins can see exportMembers button', async t => {
 
   const wrapper = await mountWithIntl(
     <Provider store={t.context.store}>
-      <MemberSection org={org} />
+      <MemberSection org={org} isAdmin />
     </Provider>
   )
   await sleep(1) // allow asynch fetch to complete
@@ -270,5 +270,3 @@ test.serial('admins can see exportMembers button', async t => {
 
   t.is(exportMembersButton.text(), 'Export Members')
 })
-
-// TODO: [VP-448] Add Separate set of tests for when logged in user is a joiner, member, follower etc

--- a/components/Org/OrgTabs.js
+++ b/components/Org/OrgTabs.js
@@ -37,32 +37,39 @@ const orgOffersTab =
     description='show opportunities list on volunteer home page'
   />
 
-// const orgSettingsTab =
-//   <FormattedMessage
-//     id='orgSettings'
-//     defaultMessage='Settings'
-//     description='show opportunities list on volunteer home page'
-//   />
+const orgEditTab =
+  <FormattedMessage
+    id='orgTabs.edit'
+    defaultMessage='Edit'
+    description='Tab label for org Editor panel on organisation page'
+  />
 
-export const OrgTabs = ({ org, onChange }) => (
-  <VTabs defaultActiveKey='1' onChange={onChange}>
-    <TabPane tab={orgTab} key='1'>
+// Warning do not try to group tabs under an isFlag TabPanes must be direct Children of Tabs.
+export const OrgTabs = ({ org, onChange, canManage, defaultTab, isAuthenticated }) => (
+  <VTabs defaultActiveKey={defaultTab} onChange={onChange}>
+    <TabPane tab={orgTab} key='about'>
       <OrgAboutPanel org={org} />
     </TabPane>
-    {/* <TabPane tab={orgResourcesTab} key='2' /> */}
-    {/* // TODO: [VP-554] move the OpList for this org from the parent page to a tab  */}
-    <TabPane tab={orgInstructionTab} key='3'>
-      <ProfilePanel>
-        <Html>
-          {(org.info && org.info.instructions) || ''}
-        </Html>
-      </ProfilePanel>
+    <TabPane tab={orgOffersTab} key='offers'>
+      {/* // TODO: [VP-554] move the OpList for this org from the parent page to a tab  */}
     </TabPane>
-    <TabPane tab={orgMemberTab} key='4'>
-      <MemberSection org={org} />
-    </TabPane>
-    <TabPane tab={orgOffersTab} key='5' />
-    {/* <TabPane tab={orgSettingsTab} key='6' /> */}
+    {isAuthenticated && (
+      <TabPane tab={orgInstructionTab} key='instructions'>
+        <ProfilePanel>
+          <Html>
+            {(org.info && org.info.instructions) || ''}
+          </Html>
+        </ProfilePanel>
+      </TabPane>)}
+    {isAuthenticated && (
+      <TabPane tab={orgMemberTab} key='members'>
+        <MemberSection org={org} />
+      </TabPane>)}
+
+    {canManage && (
+      <TabPane tab={orgEditTab} key='edit' />
+    )}
+
   </VTabs>
 )
 

--- a/components/Org/__tests__/OrgTabs.spec.js
+++ b/components/Org/__tests__/OrgTabs.spec.js
@@ -4,11 +4,29 @@ import { shallow } from 'enzyme'
 import OrgTabs from '../OrgTabs'
 import orgs from './Org.fixture'
 
-test('shallows the tabs', t => {
+test('shallows the tabs anon', t => {
   const org = orgs[0]
   const wrapper = shallow(
     <OrgTabs org={org} onChange={() => {}} />
   )
+  t.is(wrapper.find('TabPane').length, 2)
+  t.true(wrapper.exists('OrgAboutPanel'))
+})
+
+test('shallows the tabs authed', t => {
+  const org = orgs[0]
+  const wrapper = shallow(
+    <OrgTabs org={org} onChange={() => {}} isAuthenticated />
+  )
   t.is(wrapper.find('TabPane').length, 4)
+  t.true(wrapper.exists('OrgAboutPanel'))
+})
+
+test('shallows the tabs admin', t => {
+  const org = orgs[0]
+  const wrapper = shallow(
+    <OrgTabs org={org} onChange={() => {}} canManage isAuthenticated />
+  )
+  t.is(wrapper.find('TabPane').length, 5)
   t.true(wrapper.exists('OrgAboutPanel'))
 })

--- a/pages/op/opdetailpage.js
+++ b/pages/op/opdetailpage.js
@@ -162,7 +162,7 @@ export const OpDetailPage = ({
     return (
       <FullPage>
         <Helmet>
-          <title>Edit {op.name}  - Voluntarily</title>
+          <title>Edit {op.name} - Voluntarily</title>
         </Helmet>
         <OpDetailForm
           op={op}

--- a/pages/org/orgdetailpage.js
+++ b/pages/org/orgdetailpage.js
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import { Button, message } from 'antd'
 import Link from 'next/link'
-import Router from 'next/router'
+import { useRouter } from 'next/router'
 import { FormattedMessage } from 'react-intl'
 import Loading from '../../components/Loading'
 import OrgBanner from '../../components/Org/OrgBanner'
@@ -74,22 +74,33 @@ export const OrgUnknown = () =>
     </Link>
   </>
 
-export const OrgDetailPage = ({ members, me, organisations, isNew, dispatch, isAuthenticated }) => {
-  const [editing, setEditing] = useState(false)
+export const OrgDetailPage = ({
+  members,
+  me,
+  organisations,
+  isNew,
+  dispatch,
+  isAuthenticated
+}) => {
+  const router = useRouter()
   const [saved, setSaved] = useState(false)
+  const [tab, setTab] = useState(isNew ? 'edit' : router.query.tab)
 
-  const setEditingOfPage = (editing) => {
-    setEditing(editing)
-    window.scrollTo({
-      top: 0
-    })
+  const updateTab = (key, top) => {
+    setTab(key)
+    if (top) window.scrollTo(0, 0)
+    //  else { window.scrollTo(0, 400) }
+    const newpath = `/orgs/${org._id}?tab=${key}`
+    router.replace(router.pathname, newpath, { shallow: true })
   }
-
+  const handleTabChange = (key, e) => {
+    updateTab(key, key === 'edit')
+  }
   const handleCancel = useCallback(
     () => {
-      setEditing(false)
+      updateTab('about', true)
       if (isNew) { // return to previous
-        Router.back()
+        router.back()
       }
     },
     [isNew]
@@ -112,10 +123,10 @@ export const OrgDetailPage = ({ members, me, organisations, isNew, dispatch, isA
           reduxApi.actions.organisations.post({}, { body: JSON.stringify(org) })
         )
         org = res[0]
-        Router.replace(`/orgs/${org._id}`)
+        router.replace(`/orgs/${org._id}`)
       }
-      setEditing(false)
       setSaved(true)
+      updateTab('about', true)
       message.success('Saved.')
     }, [])
 
@@ -129,14 +140,19 @@ export const OrgDetailPage = ({ members, me, organisations, isNew, dispatch, isA
   }
   const org = isNew ? blankOrg : orgs[0]
 
+  // Who can edit?
+  const isAdmin = me && me.role.includes('admin')
   const isOrgAdmin =
     members.data.length &&
     members.data[0].status === MemberStatus.ORGADMIN
-  const isAdmin = me && me.role.includes('admin')
-  const canEdit = isAuthenticated && (isOrgAdmin || isAdmin)
-  if (editing) {
+  const canManage = isAuthenticated && (isOrgAdmin || isAdmin)
+
+  if (tab === 'edit') {
     return (
       <FullPage>
+        <Helmet>
+          <title>Edit {org.name} - Voluntarily</title>
+        </Helmet>
         <OrgDetailForm
           org={org}
           isAdmin={isAdmin}
@@ -153,11 +169,10 @@ export const OrgDetailPage = ({ members, me, organisations, isNew, dispatch, isA
       </Helmet>
 
       <OrgBanner org={org}>
-        {isAuthenticated && <RegisterMemberSection orgid={org._id} meid={me._id} />}
+        {isAuthenticated && <RegisterMemberSection orgid={org._id} meid={me._id.toString()} />}
         {saved && <HomeButton />}
-        {canEdit && <OrgEditButton onClick={() => setEditingOfPage(true)} />}
       </OrgBanner>
-      <OrgTabs org={org} />
+      <OrgTabs org={org} canManage={canManage} isAuthenticated={isAuthenticated} defaultTab={tab} onChange={handleTabChange} />
     </FullPage>)
 }
 
@@ -187,48 +202,3 @@ OrgDetailPage.getInitialProps = async ({ store, query }) => {
 
 export const OrgDetailPageWithOrgs = withOrgs(OrgDetailPage)
 export default publicPage(OrgDetailPageWithOrgs)
-
-/* //TODO: this commented out code will likely go in the new settings tab
-          <Divider />
-
-          <h2>
-            <FormattedMessage
-              id='getInvolved'
-              defaultMessage='Get involved'
-              description='Header for org activities'
-            />
-          </h2>
-          <h5>Volunteer with {org.name}</h5>
-          <OpListSection org={org._id} />
-          <div style={{ float: 'right' }}>
-            <Button shape='round'>
-              <Link href='/orgs'>
-                <a>
-                  <FormattedMessage
-                    id='showOrgs'
-                    defaultMessage='Show All'
-                    description='Button to show all organisations'
-                  />
-                </a>
-              </Link>
-            </Button>
-
-            {canRemove && (
-              <Popconfirm
-                title='Confirm removal of this organisation.'
-                onConfirm={this.handleDelete.bind(this, org)}
-                onCancel={this.handleDeleteCancel.bind(this)}
-                okText='Yes'
-                cancelText='No'
-              >
-                <Button style={{ float: 'right' }} type='danger' shape='round'>
-                  <FormattedMessage
-                    id='deleteOrg'
-                    defaultMessage='Remove Organisation'
-                    description='Button to remove an Organisatino on OrgDetails page'
-                  />
-                </Button>
-              </Popconfirm>
-            )}
-          </div>
-*/

--- a/pages/org/orgdetailpage.js
+++ b/pages/org/orgdetailpage.js
@@ -130,7 +130,7 @@ export const OrgDetailPage = ({
       message.success('Saved.')
     }, [])
 
-  if (!organisations.sync) {
+  if (!organisations.sync && !isNew) {
     return <Loading label='organisation' entity={organisations} />
   }
 

--- a/pages/org/orgdetailpage.js
+++ b/pages/org/orgdetailpage.js
@@ -26,20 +26,6 @@ const blankOrg = {
   category: ['vp']
 }
 
-export const OrgEditButton = ({ onClick }) =>
-  <Button
-    type='primary'
-    shape='round'
-    onClick={onClick}
-    style={{ float: 'right' }}
-  >
-    <FormattedMessage
-      id='orgDetailPage.button.edit'
-      defaultMessage='Edit'
-      description='Button to edit an organisation on orgDetailPage'
-    />
-  </Button>
-
 export const HomeButton = () =>
   <Button
     type='secondary'


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. The organisation details page was already factored into  OrgTabs, OrgBanner etc. However, it did not set the current tab in the URL making it bookmarkable.  This change captures tab changes and updates the url.  
2. The edit button is moved from the banner to an edit tab and only shown to admins
3. Anon people only see the about tab.
4. fixed flash of unwanted buttons on page load.  VP-1336 by correcting the type of me._id from object to string when comparing membership.

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
### Anon Person
<img width="869" alt="image" src="https://user-images.githubusercontent.com/1596437/75290275-e76f9b80-5884-11ea-8675-2da54b848688.png">

### Signed in non member
<img width="608" alt="image" src="https://user-images.githubusercontent.com/1596437/75290312-f9e9d500-5884-11ea-83cd-a2f5a76974ad.png">

### OrgAdmin
<img width="809" alt="image" src="https://user-images.githubusercontent.com/1596437/75290365-0ec66880-5885-11ea-9b81-c2e2f307ce90.png">
