### PR TITLE
VP-1338 Interest archive API permissions

### DIFF
--- a/server/api/interest-archive/__tests__/interestArchive.ability.fixture.js
+++ b/server/api/interest-archive/__tests__/interestArchive.ability.fixture.js
@@ -7,8 +7,8 @@ import { InterestStatus } from '../../interest/interest.constants'
 import { Role } from '../../../services/authorize/role'
 import { MemberStatus } from '../../member/member.constants'
 import { OpportunityStatus } from '../../opportunity/opportunity.constants'
-import jwt from 'jsonwebtoken'
 import mongoose from 'mongoose'
+import { generateTestSession } from '../../../util/test-generate-session'
 
 const generateObjectId = mongoose.Types.ObjectId
 
@@ -126,25 +126,7 @@ const archivedInterests = [
 const sessions = []
 
 for (const person of people) {
-  const session = {
-    accessToken: 'IGs4bjO5WLjsulmjKiW2-VLeetlgykUP',
-    idTokenPayload: {
-      email: person.email,
-      email_verified: true,
-      exp: Math.floor(Date.now() / 1000) + (60 * 60),
-      iat: Math.floor(Date.now() / 1000),
-      name: person.name,
-      nickname: '',
-      picture: ''
-    },
-    refreshToken: null,
-    state: 'Nz_CgRTnYPO5CbD4ueKmkdCiuk2z3psk',
-    expiresIn: 3600,
-    tokenType: 'Bearer',
-    scope: null
-  }
-
-  session.idToken = jwt.sign(session.idTokenPayload, 'secret')
+  const session = generateTestSession(person.name, person.email)
 
   sessions.push(session)
 }

--- a/server/api/interest-archive/__tests__/interestArchive.ability.spec.js
+++ b/server/api/interest-archive/__tests__/interestArchive.ability.spec.js
@@ -88,6 +88,88 @@ const testScenarios = [
     }
   },
   {
+    role: 'volunteer',
+    action: 'list',
+    makeRequest: async () => {
+      return request(server)
+        .get('/api/interestsArchived')
+        .set('Cookie', [`idToken=${sessions[2].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 200)
+      t.is(response.body.length, 1)
+    }
+  },
+  {
+    role: 'volunteer',
+    action: 'read (own interest)',
+    makeRequest: async (context) => {
+      return request(server)
+        .get(`/api/interestsArchived/${context.fixtures.archivedInterests[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[2].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 200)
+    }
+  },
+  {
+    role: 'volunteer',
+    action: 'read (other\'s interest)',
+    makeRequest: async (context) => {
+      return request(server)
+        .get(`/api/interestsArchived/${context.fixtures.archivedInterests[1]._id}`)
+        .set('Cookie', [`idToken=${sessions[2].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 404)
+    }
+  },
+  {
+    role: 'volunteer',
+    action: 'create',
+    makeRequest: async (context) => {
+      return request(server)
+        .post('/api/interestsArchived')
+        .set('Cookie', [`idToken=${sessions[2].idToken}`])
+        .send({
+          person: context.fixtures.people[0]._id,
+          opportunity: context.fixtures.archivedOpportunities[0]._id,
+          comment: 'Test comment',
+          status: InterestStatus.INTERESTED
+        })
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'volunteer',
+    action: 'update',
+    makeRequest: async (context) => {
+      return request(server)
+        .put(`/api/interestsArchived/${context.fixtures.archivedInterests[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[2].idToken}`])
+        .send({
+          comment: 'Updated test comment'
+        })
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
+    role: 'volunteer',
+    action: 'delete',
+    makeRequest: async (context) => {
+      return request(server)
+        .delete(`/api/interestsArchived/${context.fixtures.archivedInterests[0]._id}`)
+        .set('Cookie', [`idToken=${sessions[2].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 403)
+    }
+  },
+  {
     role: 'opportunity provider',
     action: 'list',
     makeRequest: async () => {

--- a/server/api/interest-archive/interestArchive.ability.js
+++ b/server/api/interest-archive/interestArchive.ability.js
@@ -10,7 +10,19 @@ const ruleBuilder = async (session) => {
     inverted: true
   }]
 
-  const allRules = anonRules.slice(0)
+  const allRules = [{
+    subject: SchemaName,
+    action: Action.LIST,
+    conditions: { person: session.me._id }
+  }, {
+    subject: SchemaName,
+    action: Action.READ,
+    conditions: { person: session.me._id }
+  }, {
+    subject: SchemaName,
+    action: [Action.CREATE, Action.UPDATE, Action.DELETE],
+    inverted: true
+  }]
 
   const opportunityProviderRules = []
 


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Update permissions for volunteers (and other authenticated users) when listing/reading from the interest archive API (volunteers can read/list their own archived interests)