### PR TITLE
VP-1345 Add script to make person an admin

### DIFF
--- a/x/db/make-admin.js
+++ b/x/db/make-admin.js
@@ -1,0 +1,56 @@
+const mongoose = require('mongoose')
+const { config } = require('../../config/serverConfig')
+const Person = require('../../server/api/person/person')
+const { Role } = require('../../server/services/authorize/role')
+
+async function main () {
+  mongoose.Promise = Promise
+
+  try {
+    await mongoose.connect(
+      config.databaseUrl,
+      {
+        useNewUrlParser: true,
+        useCreateIndex: true,
+        useUnifiedTopology: true,
+        useFindAndModify: false
+      }
+    )
+  } catch (error) {
+    console.log(error)
+    process.exit(1)
+  }
+
+  if (!process.argv[2]) {
+    console.log('To make someone an admin run this script and provide an email address')
+    console.log('e.g. node x/db/make-admin.js test@example.com')
+    console.log('Note: the email provided should match an existing person record')
+    process.exit(1)
+  }
+
+  const person = await Person.findOne({ email: process.argv[2] })
+
+  if (person === null) {
+    console.log(`Could not find person record for email: ${process.argv[2]}`)
+    process.exit(1)
+  }
+
+  if (person.role.includes(Role.ADMIN)) {
+    console.log(`${person.name} <${person.email}> is already an admin`)
+    process.exit(0)
+  }
+
+  if (Array.isArray(person.role)) {
+    person.role.push(Role.ADMIN)
+  } else {
+    person.role = [Role.ADMIN]
+  }
+
+  await person.save()
+  console.log(`${person.name} <${person.email}> is now an admin`)
+
+  await mongoose.disconnect()
+  process.exit(0)
+}
+
+main()


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Adds a command line script that takes an email address as an argument and attempts to find that person record and give it the admin role.

This is intended for use in local development environments - at the moment it's quite hard to make yourself an admin (the person API prevents a standard user from setting their role to "admin", so editing roles on your profile does not work).