### PR TITLE
VP-1350 Clear idToken cookie on JWT expiry

### DIFF
--- a/server/middleware/session/__tests__/setSession.fixture.js
+++ b/server/middleware/session/__tests__/setSession.fixture.js
@@ -104,6 +104,25 @@ const jwtDataCharles = {
 }
 jwtDataCharles.idToken = jwt.sign(jwtDataCharles.idTokenPayload, 'secret')
 
+const jwtDataExpired = {
+  accessToken: 'IGs4bjO5WLjsulmjKiW2-VLeetlgykUP',
+  idTokenPayload: {
+    name: 'Expired Person',
+    nickname: 'Expired',
+    email: 'expired@voluntarily.nz',
+    email_verified: true,
+    exp: Math.floor(Date.now() / 1000) - (60 * 60),
+    iat: Math.floor(Date.now() / 1000) - (2 * 60 * 60)
+  },
+  refreshToken: null,
+  state: 'Nz_CgRTnYPO5CbD4ueKmkdCiuk2z3psk',
+  expiresIn: 3600,
+  tokenType: 'Bearer',
+  scope: null
+}
+
+jwtDataExpired.idToken = jwt.sign(jwtDataExpired.idTokenPayload, 'secret')
+
 const DEFAULT_SESSION = {
   isAuthenticated: false,
   user: null,
@@ -118,5 +137,6 @@ module.exports = {
   jwtDataAlice, // represents Alice a teacher
   jwtDataBob, // represents someone with non validated email
   jwtDataCharles, // represents a new sign up
+  jwtDataExpired, // represents an expired session
   DEFAULT_SESSION
 }

--- a/server/middleware/session/setSession.js
+++ b/server/middleware/session/setSession.js
@@ -74,6 +74,11 @@ const setSession = async (req, res, next) => {
     user = await jwtVerify(idToken)
   } catch (e) {
     // console.error('Jwt Verify failed', e)
+
+    if (e.name === 'TokenExpiredError') {
+      res.clearCookie('idToken')
+    }
+
     user = false
   }
   if (!user) {


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Clear the idToken cookie if the JWT is found to be expired

## Additional Info.🧐

I've been finding that when I start work in the mornings on Voluntarily my JWT is always expired and I have been having to jump through hoops to sign back in (usually either clicking the "Sign out" button and then signing in again, or clearing my cookies before attempting to sign in). If I don't do this and just click "Sign in" straight away the first page I viewed would appear to be signed in successfully but as soon as I navigate to a different page I was ending up back in the signed out state.

This change removes that frustration - the first request after the JWT expires will now clear the idToken cookie and clicking on "Sign in" will sign you in as expected.