### PR TITLE
VP-1359 Allow use of dev generated idTokens

### DIFF
--- a/server/middleware/session/__tests__/jwtVerify.spec.js
+++ b/server/middleware/session/__tests__/jwtVerify.spec.js
@@ -31,3 +31,13 @@ test('verify JWT against Auth0 Signing key', async t => {
 
   t.pass()
 })
+
+test.serial('Correct signing key for dev tokens', async t => {
+  const originalEnv = process.env.NODE_ENV
+  process.env.NODE_ENV = 'development'
+  getSigningKey({ kid: 'dev' }, (error, key) => {
+    process.env.NODE_ENV = originalEnv
+    t.is(error, null)
+    t.is(key, 'dev')
+  })
+})

--- a/server/middleware/session/jwtVerify.js
+++ b/server/middleware/session/jwtVerify.js
@@ -15,6 +15,9 @@ const client = jwksClient({
 const getSigningKey = (header, callback) => {
   if (process.env.NODE_ENV === 'test') {
     callback(null, 'secret')
+  } else if (process.env.NODE_ENV === 'development' && header.kid === 'dev') {
+    // we are using a dev signed key for testing purposes
+    callback(null, 'dev')
   } else {
     client.getSigningKey(header.kid, (err, key) => {
       if (err) { console.log(err); callback(err, null) }

--- a/x/get-dev-id-token.js
+++ b/x/get-dev-id-token.js
@@ -1,0 +1,57 @@
+const jwt = require('jsonwebtoken')
+
+/**
+ * get-dev-id-token.js
+ *
+ * This script accepts two arguments and generates an idToken based on them.
+ *
+ * Usage: node x/get-dev-id-token.js <email_address> <optional_expiry_in_seconds>
+ *
+ * If the optional expiry argument is not included tokens will be generated with
+ * an expiry 1 hour in the future.
+ *
+ * To use this token create/update a new cookie when viewing Voluntarily in your browser.
+ * The name of the cookie should be "idToken" the value of the cookie should be the token
+ * that this script generates. Once you've set the cookie up, refresh the window and you
+ * should be logged in using the newly generated token.
+ */
+
+async function main () {
+  const email = process.argv[2]
+
+  if (!email) {
+    console.log('Please provide an email address')
+    console.log('e.g. node x/get-dev-id-token.js test@example.com\n')
+    console.log('Note: the email address should match an existing person record for logins to work\n')
+    console.log('You can optional provided a 2nd argument that will set the expiry time on the token.')
+    console.log('e.g. node x/get-dev-id-token.js test@example.com 3600 # create token that expires in 1 hour')
+    console.log('or:  node x/get-dev-id-token.js test@example.com -3600 # create token that expired 1 hour ago\n')
+    process.exit(1)
+  }
+
+  let expires = (60 * 60) // default to expire 1 hour in future
+
+  if (process.argv[3]) {
+    expires = parseInt(process.argv[3])
+  }
+
+  const payload = {
+    email: email,
+    email_verified: true,
+    exp: Math.floor(Date.now() / 1000) + expires,
+    iat: Math.floor(Date.now() / 1000),
+    name: '',
+    nickname: '',
+    picture: ''
+  }
+
+  const idToken = jwt.sign(payload, 'dev', { keyid: 'dev' })
+
+  console.log('Your token is:\n')
+  console.log('-------------------------')
+  console.log(idToken)
+  console.log('-------------------------')
+  process.exit(0)
+}
+
+main()


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. When NODE_ENV is development allow self generated idTokens to be used for authentication, the benefits of allowing this are:
- makes testing expired tokens significantly easier
- makes it easy to test features by imitating logins for certain accounts
- removes the need for Auth0 from the authentication process so could make future automated end-to-end tests easier to write
