### PR TITLE
VP-1321 replace Promise.All with allSettled so we get as much data as possible.

### DIFF
--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -61,7 +61,15 @@ export const PersonHomePage = () => {
     </FullPage>
   )
 }
-
+const allSettled = (promises) => {
+  return Promise.all(promises.map(p => Promise.resolve(p).then(value => ({
+    state: 'fulfilled',
+    value
+  }), reason => ({
+    state: 'rejected',
+    reason
+  }))))
+}
 PersonHomePage.getInitialProps = async ({ store, query }) => {
   try {
     const me = store.getState().session.me
@@ -70,7 +78,7 @@ PersonHomePage.getInitialProps = async ({ store, query }) => {
       q: JSON.stringify({ requestor: meid })
     }
 
-    await Promise.all([
+    await allSettled([
       store.dispatch(reduxApi.actions.people.get({ id: meid })),
       store.dispatch(reduxApi.actions.opportunities.get(myOpportunities)),
       store.dispatch(reduxApi.actions.archivedOpportunities.get(myOpportunities)),


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
home.js getInitialProperties makes eight reduxApi calls to obtain all the data it needs from the database. These are wrapped in Promise.All so they can run in parallel.  When running server side if any call throws an exception then the page response will be sent to the client before all the data is available. 
using allSettled waits for all the calls to resolve whether they fail or not. 
This means that failure to obtain one set of data e.g. the interests list will not block the rest of the page. Coupled with the <Loading > component that shows API call errors makes it easier to see the cause of the problem
 

## Additional Info.🧐
Promise.allSettled is a recent addition to the language 
https://javascript.info/promise-api#promise-allsettled

we should use a polyfill, or babel should be configured to provide the call. But for now I am just using a locally defined function.

## Screenshots 📷
<img width="448" alt="image" src="https://user-images.githubusercontent.com/1596437/75505202-76c0ae80-5a3f-11ea-810e-85aa1b063394.png">
