### PR TITLE
VP-1365 Add test for volunteer with no interests

### DIFF
--- a/server/api/interest/__tests__/interest.ability.fixture.js
+++ b/server/api/interest/__tests__/interest.ability.fixture.js
@@ -54,6 +54,12 @@ const people = [
     name: 'Volunteer + Opportunity Provider 1',
     email: 'volunteer.opportunity.provider.1@example.com',
     role: [Role.VOLUNTEER_PROVIDER, Role.OPPORTUNITY_PROVIDER]
+  },
+  {
+    _id: generateObjectId(),
+    name: 'Volunteer 3',
+    email: 'volunteer.3@example.com',
+    role: [Role.VOLUNTEER_PROVIDER]
   }
 ]
 

--- a/server/api/interest/__tests__/interest.ability.fixture.js
+++ b/server/api/interest/__tests__/interest.ability.fixture.js
@@ -59,7 +59,7 @@ const people = [
     _id: generateObjectId(),
     name: 'Volunteer 3',
     email: 'volunteer.3@example.com',
-    role: [Role.VOLUNTEER_PROVIDER]
+    role: [Role.VOLUNTEER_PROVIDER, Role.ACTIVITY_PROVIDER]
   }
 ]
 

--- a/server/api/interest/__tests__/interest.ability.spec.js
+++ b/server/api/interest/__tests__/interest.ability.spec.js
@@ -102,6 +102,19 @@ const testScenarios = [
   },
   {
     role: 'volunteer',
+    action: 'list (no interests)',
+    makeRequest: async () => {
+      return request(server)
+        .get('/api/interests')
+        .set('Cookie', [`idToken=${sessions[7].idToken}`])
+    },
+    assertions: (t, response) => {
+      t.is(response.statusCode, 200)
+      t.is(response.body.length, 0)
+    }
+  },
+  {
+    role: 'volunteer',
     action: 'read (own interest)',
     makeRequest: async (context) => {
       return request(server)

--- a/server/api/interest/interest.ability.js
+++ b/server/api/interest/interest.ability.js
@@ -26,8 +26,6 @@ const ruleBuilder = async (session) => {
     inverted: true
   }]
 
-  // const allRules = anonRules.slice(0)
-
   const volunteerRules = []
 
   if (session.me && session.me._id) {

--- a/server/api/interest/interest.ability.js
+++ b/server/api/interest/interest.ability.js
@@ -26,7 +26,7 @@ const ruleBuilder = async (session) => {
     inverted: true
   }]
 
-  const allRules = anonRules.slice(0)
+  // const allRules = anonRules.slice(0)
 
   const volunteerRules = []
 

--- a/server/api/interest/interest.ability.js
+++ b/server/api/interest/interest.ability.js
@@ -120,8 +120,8 @@ const ruleBuilder = async (session) => {
   return {
     [Role.ANON]: anonRules,
     [Role.VOLUNTEER_PROVIDER]: volunteerRules,
+    [Role.ACTIVITY_PROVIDER]: volunteerRules,
     [Role.OPPORTUNITY_PROVIDER]: opportunityProviderRules,
-    [Role.ACTIVITY_PROVIDER]: allRules,
     [Role.ORG_ADMIN]: orgAdminRules,
     [Role.ADMIN]: adminRules
   }


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

1. Add test for interest API - volunteer with no interests receives 200 with empty array