### PR TITLE
VP-1375 Only send applicable roles when saving a profile

### DIFF
--- a/components/Person/PersonDetailForm.js
+++ b/components/Person/PersonDetailForm.js
@@ -728,9 +728,9 @@ export const permissionTrimFields = (person, roles) => {
   }
 
   delete person.dateAdded
-  
+
   const applicableRoles = [Role.ACTIVITY_PROVIDER, Role.ADMIN, Role.OPPORTUNITY_PROVIDER, Role.RESOURCE_PROVIDER, Role.TESTER, Role.VOLUNTEER_PROVIDER]
   if (person.role) {
-    person.role = person.role.filter(role => applicableRoles.includes(role));
+    person.role = person.role.filter(role => applicableRoles.includes(role))
   }
 }

--- a/components/Person/PersonDetailForm.js
+++ b/components/Person/PersonDetailForm.js
@@ -726,5 +726,11 @@ export const permissionTrimFields = (person, roles) => {
   if (!roles.includes(Role.ADMIN) && !roles.includes(Role.TESTER)) {
     delete person.email
   }
+
   delete person.dateAdded
+  
+  const applicableRoles = [Role.ACTIVITY_PROVIDER, Role.ADMIN, Role.OPPORTUNITY_PROVIDER, Role.RESOURCE_PROVIDER, Role.TESTER, Role.VOLUNTEER_PROVIDER]
+  if (person.role) {
+    person.role = person.role.filter(role => applicableRoles.includes(role));
+  }
 }


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. If the frontend has a role which the API does not allow, then the user cannot save their profile. 

e.g. If the current user is an org admin, then their person object will have the orgAdmin role, but this cannot be sent to the server so it needs to be trimmed before sending
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
