### PR TITLE
VP-1323 Volunteer interest update

### DIFF
--- a/server/api/interest/__tests__/interest.ability.fixture.js
+++ b/server/api/interest/__tests__/interest.ability.fixture.js
@@ -117,6 +117,18 @@ const opportunities = [
     status: OpportunityStatus.ACTIVE,
     requestor: people[5]._id,
     offerOrg: organisations[1]._id
+  },
+  {
+    _id: generateObjectId(),
+    status: OpportunityStatus.ACTIVE,
+    requestor: people[1]._id,
+    offerOrg: organisations[0]._id
+  },
+  {
+    _id: generateObjectId(),
+    status: OpportunityStatus.ACTIVE,
+    requestor: people[1]._id,
+    offerOrg: organisations[0]._id
   }
 ]
 
@@ -124,32 +136,44 @@ const interests = [
   {
     person: people[2]._id,
     opportunity: opportunities[0]._id,
-    message: [{ body: 'Test comment', author: generateObjectId() }],
+    message: [{ body: 'Test comment', author: people[2]._id }],
     status: InterestStatus.INTERESTED
   },
   {
     person: people[3]._id,
     opportunity: opportunities[0]._id,
-    message: [{ body: 'Test comment', author: generateObjectId() }],
+    message: [{ body: 'Test comment', author: people[3]._id }],
     status: InterestStatus.INTERESTED
   },
   {
     person: people[3]._id,
     opportunity: opportunities[1]._id,
-    message: [{ body: 'Test comment 2', author: generateObjectId() }],
+    message: [{ body: 'Test comment 2', author: people[3]._id }],
     status: InterestStatus.INTERESTED
   },
   {
     person: people[6]._id,
     opportunity: opportunities[0]._id,
-    message: [{ body: 'Test comment 1', author: generateObjectId() }],
+    message: [{ body: 'Test comment 1', author: people[6]._id }],
     status: InterestStatus.INTERESTED
   },
   {
     person: people[6]._id,
     opportunity: opportunities[1]._id,
-    message: [{ body: 'Test comment 2', author: generateObjectId() }],
+    message: [{ body: 'Test comment 2', author: people[6]._id }],
     status: InterestStatus.INTERESTED
+  },
+  {
+    person: people[2]._id,
+    opportunity: opportunities[2]._id,
+    message: [{ body: 'Test comment', author: people[2]._id }],
+    status: InterestStatus.INVITED
+  },
+  {
+    person: people[2]._id,
+    opportunity: opportunities[3]._id,
+    message: [{ body: 'Test comment', author: people[2]._id }],
+    status: InterestStatus.COMMITTED
   }
 ]
 

--- a/server/api/interest/__tests__/interest.ability.spec.js
+++ b/server/api/interest/__tests__/interest.ability.spec.js
@@ -4,9 +4,6 @@ import { server, appReady } from '../../../server'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import { loadInterestFixtures, clearInterestFixtures, sessions } from './interest.ability.fixture'
 import { InterestStatus } from '../interest.constants'
-import mongoose from 'mongoose'
-
-const ObjectId = mongoose.Types.ObjectId
 
 test.before('setup database and app', async (t) => {
   t.context.memMongo = new MemoryMongo()
@@ -208,7 +205,7 @@ const testScenarios = [
         .send({
           messages: {
             body: 'Updated message',
-            author: ObjectId()
+            author: context.fixtures.people[2]
           },
           type: 'accept'
         })
@@ -249,7 +246,7 @@ const testScenarios = [
         .put(`/api/interests/${context.fixtures.interests[6]._id}`)
         .set('Cookie', [`idToken=${sessions[2].idToken}`])
         .send({
-          status: InterestStatus.COMMITTED,
+          status: InterestStatus.INTERESTED,
           messages: {
             body: 'Committed message',
             author: context.fixtures.people[2]

--- a/server/api/interest/interest.controller.js
+++ b/server/api/interest/interest.controller.js
@@ -131,7 +131,10 @@ const updateInterest = async (req, res) => {
     }
 
     if (interestUpdateData.messages) {
-      existingInterest.messages.push(interestUpdateData.messages)
+      interestUpdateData.messages = Array.isArray(interestUpdateData.messages)
+        ? interestUpdateData.messages : [interestUpdateData.messages]
+
+      existingInterest.messages = existingInterest.messages.concat(interestUpdateData.messages)
     }
 
     if (!req.ability.can(Action.UPDATE, existingInterest)) {


### PR DESCRIPTION
## I do solemnly swear that I have:

- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔

Implement permissions around interest status transitions for the interest API. Primarily this applies to people with the "volunteer" role who should only be able to update status from:
- "invited" -> "committed"
- "committed" -> "interested"
