### PR TITLE
Feature/vp 1380/personal details org invited

### DIFF
--- a/server/api/person/__tests__/person.permissions.spec.js
+++ b/server/api/person/__tests__/person.permissions.spec.js
@@ -8,6 +8,8 @@ import people from '../__tests__/person.fixture'
 import uuid from 'uuid'
 import { Role } from '../../../services/authorize/role'
 import jsonwebtoken from 'jsonwebtoken'
+import Organisation from '../../organisation/organisation'
+import Member from '../../member/member'
 
 const createJwtIdToken = (email) => {
   const jwt = { ...jwtData }
@@ -194,7 +196,7 @@ test('Get person by id - self returns all fields', async t => {
 })
 
 for (const role of [Role.ADMIN, Role.TESTER]) {
-  test(`Get person by id - ${role}`, async t => {
+  test(`Get person by id - ${role} - should return all fields`, async t => {
     const person = t.context.people.find(p => p.email === 'andrew@groat.nz')
 
     const res = await request(server)
@@ -226,6 +228,53 @@ for (const role of [Role.ADMIN, Role.TESTER]) {
     }
   })
 }
+
+test(`Get person by id - requested person is in my organisation`, async t => {
+  const personA = await createPerson([Role.VOLUNTEER_PROVIDER])
+  // Create a new user in the database directly
+  const personB = await Person.create({
+    name: 'name',
+    email: `${uuid()}@test.com`,
+    role: [Role.VOLUNTEER_PROVIDER],
+    status: 'active',
+    language: 'en',
+    website: 'https://reddit.com',
+    // Personal fields
+    phone: 'Phone self',
+    education: 'self university',
+    job: 'Self',
+    location: 'Loc',
+    placeOfWork: 'POW'
+  })
+
+  const org = await Organisation.create({
+    name: `${uuid()}`,
+    slug: `${uuid()}`,
+  })
+
+  // Join person A and B to the same org
+  await Member.create({
+    person: personA,
+    organisation: org
+  })
+  await Member.create({
+    person: personB,
+    organisation: org
+  })
+
+  const res = await request(server)
+    .get(`/api/people/${personB._id}`)
+    .set('Accept', 'application/json')
+    .set('Cookie', [`idToken=${createJwtIdToken([personA.email])}`])
+
+  // Personal fields should be returned
+  t.is(res.status, 200)
+  t.is(res.body.phone, 'Phone self')
+  t.is(res.body.education, 'self university')
+  t.is(res.body.job, 'Self')
+  t.is(res.body.location, 'Loc')
+  t.is(res.body.placeOfWork, 'POW')
+})
 
 for (const role of [undefined, Role.VOLUNTEER_PROVIDER, Role.OPPORTUNITY_PROVIDER, Role.ACTIVITY_PROVIDER, Role.TESTER]) {
   test.serial(`Create a new person - ${role || 'Anonymous'} is denied`, async t => {

--- a/server/api/person/__tests__/person.permissions.spec.js
+++ b/server/api/person/__tests__/person.permissions.spec.js
@@ -232,7 +232,7 @@ for (const role of [Role.ADMIN, Role.TESTER]) {
   })
 }
 
-test(`Get person by id - requested person is in my organisation`, async t => {
+test('Get person by id - requested person is in my organisation', async t => {
   const personA = await createPerson([Role.VOLUNTEER_PROVIDER])
   const personB = await Person.create({
     name: 'name',
@@ -251,7 +251,7 @@ test(`Get person by id - requested person is in my organisation`, async t => {
 
   const org = await Organisation.create({
     name: `${uuid()}`,
-    slug: `${uuid()}`,
+    slug: `${uuid()}`
   })
 
   // Join person A and B to the same org
@@ -278,7 +278,7 @@ test(`Get person by id - requested person is in my organisation`, async t => {
   t.is(res.body.placeOfWork, 'POW')
 })
 
-test(`Get person by id - requested person is invited to an opportunity of mine`, async t => {
+test('Get person by id - requested person is invited to an opportunity of mine', async t => {
   const personA = await createPerson([Role.VOLUNTEER_PROVIDER])
   const personB = await Person.create({
     name: 'name',

--- a/server/api/person/person.controller.js
+++ b/server/api/person/person.controller.js
@@ -9,6 +9,9 @@ const mongoose = require('mongoose')
 const { PersonFields } = require('./person.constants')
 const { mapValues, keyBy } = require('lodash')
 const Member = require('../member/member')
+const Interest = require('../interest/interest')
+const Opportunity = require('../opportunity/opportunity')
+const { InterestStatus } = require('../interest/interest.constants')
 
 /* find a single person by searching for a key field.
 This is a convenience function usually used to call
@@ -52,11 +55,21 @@ async function getPerson (req, res, next) {
     return !!myOrgs.find(myOrg => personOrgs.includes(myOrg))
   }
 
+  const isPersonInvitedToMyOpportunities = async () => {
+    const myOps = await Opportunity.find({ requestor: me._id })
+    return !!(await Interest.findOne({
+      opportunity: { $in: myOps },
+      status: { $ne: InterestStatus.DECLINED },
+      person: personId
+    }))
+  }
+
   const includePersonalFields = (me.role &&
     (
       me.role.includes(Role.ADMIN) ||
       me.role.includes(Role.TESTER) ||
-      (await isPersonInMyOrg())
+      (await isPersonInMyOrg()) ||
+      (await isPersonInvitedToMyOpportunities())
     )) ||
     isSelf
 


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Return 'sensitive' personal details of a user (via /api/people/:id) if;
1.1 the requested user is in the current user's organisation (e.g. we both work for New World)
1.2 or, if the requested user is on an opportunity the current user is running. This fixes the case where someone running an op clicks on a person who has shown interest to see that person's personal details (email, phone number, education, job, location, place of work)
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
