### PR TITLE
VP-465 setup storybook deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docker-test:build": "docker build -t vly-test:latest -f Dockerfile-test . ",
     "docker-test": "npm run docker-test:build && docker run vly-test:latest ",
     "remote": "APP_URL=http://$(ifconfig | grep -A 1 ‘en0’ | tail -1 | cut -d ' ' -f 2):3122 nodemon -w server -w package.json server/server.js",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -s ./public -p 6006",
     "build-storybook": "build-storybook",
     "mongo": "mongod --dbpath ./data",
     "pretest": "rimraf .test",


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Remove ProjectDemo.wiki as it was breaking the storybook deploy
2. Change start script to allow static imports from public directory
3. This PR is required to enable component library deployment
