### PR TITLE
VP-1403 termsaccepted is not being saved 

### DIFF
--- a/components/Interest/RegisterInterestItem.js
+++ b/components/Interest/RegisterInterestItem.js
@@ -145,7 +145,7 @@ export const RegisterInterestItem = ({
         id='acceptRegisterInterestForm'
         title={options.acceptFormTitle}
         prompt={options.acceptFormPrompt}
-        showTerms={!interest.status}
+        showTerms={!interest.termsAccepted}
         onSubmit={handleAcceptSubmit}
         visible={showAcceptForm}
       />
@@ -153,7 +153,7 @@ export const RegisterInterestItem = ({
         id='rejectRegisterInterestForm'
         title={options.rejectFormTitle}
         prompt={options.rejectFormPrompt}
-        showTerms
+        showTerms={!interest.termsAccepted}
         onSubmit={handleRejectSubmit}
         visible={showRejectForm}
       />
@@ -161,7 +161,7 @@ export const RegisterInterestItem = ({
         id='messageRegisterInterestForm'
         title={messageForm.title}
         prompt={messageForm.prompt}
-        showTerms
+        showTerms={!interest.termsAccepted}
         onSubmit={handleMessageSubmit}
         visible={showMessageForm}
       />

--- a/components/Interest/RegisterInterestSection.js
+++ b/components/Interest/RegisterInterestSection.js
@@ -81,7 +81,8 @@ const RegisterInterestSection = ({ meid, opid }) => {
     const putInterest = {
       ...((status !== newStatus) && { status: newStatus }),
       ...(message && { messages: [{ body: message }] }),
-      type
+      type,
+      termsAccepted: true // can't get here without accepting the terms button.
     }
 
     if (interest._id) {

--- a/components/Interest/__tests__/RegisterInterestSection.spec.js
+++ b/components/Interest/__tests__/RegisterInterestSection.spec.js
@@ -9,6 +9,7 @@ import adapterFetch from 'redux-api/lib/adapters/fetch'
 import { API_URL } from '../../../lib/callApi'
 import people from '../../../server/api/person/__tests__/person.fixture'
 import fetchMock from 'fetch-mock'
+import { InterestStatus } from '../../../server/api/interest/interest.constants'
 
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -51,7 +52,8 @@ const interests = [
     person: people[0],
     opportunity: ops[0],
     messages: [],
-    status: 'interested'
+    status: 'interested',
+    termsAccepted: true
   }
 ]
 
@@ -88,10 +90,16 @@ test.serial('mount RegisterInterestSection with with no existing interest', asyn
   wrapper.find('#sendBtn').first().simulate('click')
   await sleep(1) // allow asynch fetch to complete
   wrapper.update()
-  // t.is(wrapper.find('h4').first().text(), 'Thank you for expressing your interest!')
 
   // press Get Involved! button
   t.truthy(myMock.done())
+
+  // what got Posted.
+  const posted = JSON.parse(myMock.lastCall()[1].body)
+  t.is(posted.person, meid)
+  t.is(posted.opportunity, opid)
+  t.is(posted.status, InterestStatus.INTERESTED)
+  t.true(posted.termsAccepted)
   myMock.restore()
 })
 

--- a/server/api/interest/__tests__/interest.ability.spec.js
+++ b/server/api/interest/__tests__/interest.ability.spec.js
@@ -58,7 +58,8 @@ const testScenarios = [
           person: context.fixtures.people[0]._id,
           opportunity: context.fixtures.opportunities[0]._id,
           message: [{ body: 'Test comment' }],
-          status: InterestStatus.INTERESTED
+          status: InterestStatus.INTERESTED,
+          termsAccepted: true
         })
     },
     assertions: (t, response) => {
@@ -152,7 +153,8 @@ const testScenarios = [
         .set('Cookie', [`idToken=${sessions[PERSON.VP1].idToken}`])
         .send({
           opportunity: context.fixtures.opportunities[0]._id,
-          message: [{ body: 'Test comment' }]
+          message: [{ body: 'Test comment' }],
+          termsAccepted: true
         })
     },
     assertions: (t, response) => {
@@ -169,7 +171,8 @@ const testScenarios = [
         .send({
           opportunity: context.fixtures.opportunities[0]._id,
           message: [{ body: 'Test comment' }],
-          status: InterestStatus.INVITED
+          status: InterestStatus.INVITED,
+          termsAccepted: true
         })
     },
     assertions: (t, response) => {
@@ -186,7 +189,8 @@ const testScenarios = [
         .send({
           person: context.fixtures.people[PERSON.VP2]._id,
           opportunity: context.fixtures.opportunities[0]._id,
-          message: [{ body: 'Test comment' }]
+          message: [{ body: 'Test comment' }],
+          termsAccepted: true
         })
     },
     assertions: (t, response) => {
@@ -361,7 +365,8 @@ const testScenarios = [
         .set('Cookie', [`idToken=${sessions[PERSON.OP1].idToken}`])
         .send({
           opportunity: context.fixtures.opportunities[0]._id,
-          message: [{ body: 'Test comment' }]
+          message: [{ body: 'Test comment' }],
+          termsAccepted: true
         })
     },
     assertions: (t, response) => {
@@ -487,7 +492,8 @@ const testScenarios = [
         .set('Cookie', [`idToken=${sessions[PERSON.ORGADMIN].idToken}`])
         .send({
           opportunity: context.fixtures.opportunities[0]._id,
-          message: [{ body: 'Test comment' }]
+          message: [{ body: 'Test comment' }],
+          termsAccepted: true
         })
     },
     assertions: (t, response) => {
@@ -576,7 +582,8 @@ const testScenarios = [
           person: context.fixtures.people[PERSON.OP1]._id,
           opportunity: context.fixtures.opportunities[0]._id,
           message: [{ body: 'Test comment' }],
-          status: InterestStatus.INVITED
+          status: InterestStatus.INVITED,
+          termsAccepted: true
         })
     },
     assertions: (t, response) => {

--- a/server/api/interest/interest.controller.js
+++ b/server/api/interest/interest.controller.js
@@ -92,6 +92,9 @@ const createInterestA = InterestModel => async (req, res) => {
   if (!interestData.person) {
     interestData.person = (req.session.me && req.session.me._id) ? req.session.me._id : undefined
   }
+  if (!interestData.termsAccepted) {
+    return res.status(403).send('Must accept terms')
+  }
   const interest = new InterestModel(interestData)
   interest.messages = flatAndAuthorMessages([], interestData.messages, req)
 

--- a/server/api/interest/interest.js
+++ b/server/api/interest/interest.js
@@ -28,7 +28,7 @@ const interestSchema = new Schema({
       InterestStatus.DECLINED
     ]
   },
-  termsAccepted: Boolean,
+  termsAccepted: { type: Boolean, default: false },
   dateAdded: { type: Date, default: Date.now, required: true }
 })
 


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
the termsAccepted flag in the interest schema indicates that the person in the record has accepted the terms and conditions.  This now defaults to false internally. 
Any API call to POST new interest must set termsAccepted to true or it will be rejected 403. forbidden. 
The RegisterInterestSection component creates a new interest when the "Get Involved" button is clicked. This shows the popup message editor with the terms message showing, clicking ok accepts the terms.  So the handler now adds termsAccepted: true to the posted request.

Subsequent users of the message editor will hide or show the terms lines depending on the value of termsAccepted.  

## Additional Info.🧐
Note for some previously created interest records this field will be false and the message will show. However the state is not updated on PUT requests so it will show forever. 

Any additional info goes here

## Screenshots 📷
<img width="339" alt="image" src="https://user-images.githubusercontent.com/1596437/76364921-f0836100-638a-11ea-8789-f6f9c32bffcf.png">
