### PR TITLE
[VP-1413] Fixes several issues with client side redirect to sign thru

### DIFF
--- a/lib/auth/__tests__/auth.spec.js
+++ b/lib/auth/__tests__/auth.spec.js
@@ -13,7 +13,6 @@ import {
 import Cookie from 'js-cookie'
 import fetchMock from 'fetch-mock'
 import sinon from 'sinon'
-import Router from 'next/router'
 
 test.beforeEach(t => {
   // t.context.mockServer = fetchMock.sandbox()
@@ -104,31 +103,32 @@ test.serial('getSession redirects to sign-thru when JWT is expired', async t => 
   const store = {
     dispatch: sinon.fake()
   }
-  const routerReplaceFake = sinon.fake()
-  sinon.replace(Router, 'replace', routerReplaceFake)
+  const windowReplaceFake = sinon.fake()
 
   const realWindow = global.window
-  // mock global window object
-  global.window = {
-    location: {
-      pathName: '/home',
-      search: '?tab=history',
-      hash: ''
+  try {
+    global.window = {
+      location: {
+        pathname: '/home',
+        search: '?tab=history',
+        hash: '',
+        replace: windowReplaceFake
+      }
     }
+
+    // set expired jwt token
+    setToken(jwtDataExpired.idToken, 'accessToken5678')
+    await getSession(req, store)
+
+    const expectedRedirectUrl = '/auth/sign-thru?redirect=%2Fhome%3Ftab%3Dhistory'
+
+    const result = windowReplaceFake.calledWith(expectedRedirectUrl)
+    t.true(result)
+  } catch (e) {} finally {
+    // reset global.window
+    global.window = realWindow
+    sinon.restore()
   }
-
-  // set expired jwt token
-  setToken(jwtDataExpired.idToken, 'accessToken5678')
-  await getSession(req, store)
-
-  const expectedRedirectUrl = '/auth/sign-thru?redirect=%2Fhome%3Ftab%3Dhistory'
-
-  const result = routerReplaceFake.calledWith(expectedRedirectUrl)
-  t.true(result)
-
-  // reset global.window
-  global.window = realWindow
-  sinon.restore()
 })
 
 test.serial('isJwtExpValid returns false on expired token', t => {

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -58,7 +58,7 @@ export const getSessionFromCookies = async () => {
   if (!jwtValid) {
     const redirectUrl = encodeURIComponent(getPathAndHash())
     const signThruUrl = `/auth/sign-thru?redirect=${redirectUrl}`
-    Router.replace(signThruUrl)
+    window.location.replace(signThruUrl)
     return DEFAULT_SESSION
   }
 

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -4,7 +4,6 @@ import jwtDecode from 'jwt-decode'
 import callApi from '../callApi'
 import { Role } from '../../server/services/authorize/role'
 import moment from 'moment'
-import Router from 'next/router'
 import { getPathAndHash } from '../urlUtil'
 
 export const DEFAULT_SESSION = {

--- a/lib/urlUtil.js
+++ b/lib/urlUtil.js
@@ -25,7 +25,7 @@ const defaultToHttpScheme = (url) => {
 const getBaseUrl = () => `${window.location.protocol}//${window.location.host}`
 
 const getPathAndHash = () => {
-  const pathName = window.location.pathName
+  const pathName = window.location.pathname
   const search = window.location.search
   const hash = window.location.hash
   return `${pathName}${search}${hash}`

--- a/server/middleware/session/setSession.js
+++ b/server/middleware/session/setSession.js
@@ -82,6 +82,11 @@ const setSession = async (req, res, next) => {
         return res.sendStatus(401)
       }
 
+      // from a client side redirect
+      if (req.url.startsWith('/auth/sign-thru')) {
+        return next()
+      }
+
       const encodedRedirectUrl = encodeURIComponent(req.url)
 
       // Have to set location and set-cookie header manually without nodejs helper functions (res.clearCookie, res.redirect)


### PR DESCRIPTION


## I do solemnly swear that I have:
- [ ] Run `npm test` and all the tests pass.
- [ ] Run `npm run lint` and there are no warnings.
- [ ] Not decreased the overall test coverage?
- [ ] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Client side redirect to sign-thru also triggered the server side setSession redirect, causing several redirects to stack up. Giving the feeling of a 'loop'.
2. The end outcome of the client side redirect wasn't working correctly because of a typo in getPathAndHash
3. Next router Router.replace would crash the browser and cause an infinite loop. window.location.replace worked perfectly.

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
