### PR TITLE
VP_1419 - Quick Fix. protect OpStatus from empty state

### DIFF
--- a/components/Op/OpStatus.js
+++ b/components/Op/OpStatus.js
@@ -1,38 +1,41 @@
 import { OpportunityStatus } from '../../server/api/opportunity/opportunity.constants'
 import { FormattedMessage, useIntl, defineMessages } from 'react-intl'
 import { Stamp } from '../../components/VTheme/Stamp'
-
+const { DRAFT, ACTIVE, COMPLETED, CANCELLED } = OpportunityStatus
 export const OpportunityStatusMessages = defineMessages({
-  [OpportunityStatus.DRAFT]: {
+  [DRAFT]: {
     id: 'OpportunityStatus.draft',
     defaultMessage: 'Draft',
     description: 'When an opportunity is being drafted'
   },
-  [OpportunityStatus.ACTIVE]: {
+  [ACTIVE]: {
     id: 'OpportunityStatus.active',
     defaultMessage: 'Active',
     description: 'When an opportunity has been published'
   },
-  [OpportunityStatus.COMPLETED]: {
+  [COMPLETED]: {
     id: 'OpportunityStatus.completed',
     defaultMessage: 'Completed',
     description: 'When an opportunity has been completed'
   },
-  [OpportunityStatus.CANCELLED]: {
-    id: 'OpportunityStatus.cancelled',
+  [CANCELLED]: {
+    id: 'cancelled',
     defaultMessage: 'Cancelled',
     description: 'When an opportunity has been cancelled'
   }
 })
 
 /** Converts an opportunity status to a translated display string */
-export const OpStatus = ({ status }) =>
-  <FormattedMessage {...OpportunityStatusMessages[status]} />
+export const OpStatus = ({ status }) => {
+  if (!status || ![DRAFT, ACTIVE, COMPLETED, CANCELLED].includes(status)) return null
+  return (<FormattedMessage {...OpportunityStatusMessages[status]} />)
+}
 
 /** Converts an opportunity status to a Stamp - except for Active */
 export const OpStatusStamp = ({ status }) => {
+  if (!status) return null
   const intl = useIntl()
-  return status !== OpportunityStatus.ACTIVE
+  return status !== ACTIVE
     ? (
       <Stamp>
         {intl.formatMessage(OpportunityStatusMessages[status])}

--- a/components/Op/__tests__/OpStatus.spec.js
+++ b/components/Op/__tests__/OpStatus.spec.js
@@ -22,7 +22,18 @@ test('render OpStatusStamp for active op', t => {
   )
   t.is(wrapper.find('span').length, 0)
 })
-
+test('render OpStatusStamp for no state', t => {
+  const wrapper = mountWithIntl(
+    <OpStatusStamp />
+  )
+  t.is(wrapper.find('span').length, 0)
+})
+test('render OpStatusStamp for invalid state', t => {
+  const wrapper = mountWithIntl(
+    <OpStatusStamp state='INVALID' />
+  )
+  t.is(wrapper.find('span').length, 0)
+})
 test('render OpStatus for active op', t => {
   const wrapper = mountWithIntl(
     <OpStatus
@@ -30,4 +41,11 @@ test('render OpStatus for active op', t => {
     />
   )
   t.is(wrapper.text(), 'Active')
+})
+
+test('render OpStatus with no status', t => {
+  const wrapper = mountWithIntl(
+    <OpStatus />
+  )
+  t.is(wrapper.text(), '')
 })


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
OpStatus is used to generate a translated string showing the current opportunity status. e.g. Draft, Active etc.  
An instance where this is called with no status causes a 500 error exception on alpha. This change ensures that the line returns null instead of exception when that happens.
