### PR TITLE
VP-1413 Fix sign in oscillations when token expires

### DIFF
--- a/server/middleware/session/__tests__/setSession.spec.js
+++ b/server/middleware/session/__tests__/setSession.spec.js
@@ -108,7 +108,7 @@ test('Check headers and redirect location for expired session on page request', 
     'Location header should be set to /auth/sign-thru and redirect parameter to the correct page'
   )
 
-  t.is(res.statusCode, 301, 'Status code should be 301 for redirect')
+  t.is(res.statusCode, 302, 'Status code should be 302 for temp redirect')
   t.false(req.session.isAuthenticated)
 })
 

--- a/server/middleware/session/setSession.js
+++ b/server/middleware/session/setSession.js
@@ -101,7 +101,7 @@ const setSession = async (req, res, next) => {
         'Set-Cookie',
         'idToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
       )
-      res.statusCode = 301
+      res.statusCode = 302
       return res.end()
     }
 


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
When setSession on the server detected an expired JWT idToken it responds to the page request with a redirect to the sign-thru page to cause a new sign in to occur.  This was returning a 301 permanent redirect. so when the sign in was completed it would try to reload the original url which would use the cached redirect to sign-thru again.  causing the loop.

changing this to a 302 temporary redirect means that the browser will retry the original page correctly when sign-in completes. 
