### PR TITLE
Vp 1421 show volunteers organiser and offer org of the opportunity

### DIFF
--- a/components/Op/OpAboutPanel.js
+++ b/components/Op/OpAboutPanel.js
@@ -47,6 +47,7 @@ export function OpAboutPanel ({ op }) {
         <ProfileSection>
           <ul>
             <ItemIdLine item={op.requestor} path='people' />
+            <ItemIdLine item={op.offerOrg} path='orgs' />
           </ul>
         </ProfileSection>
       </OpSectionGrid>

--- a/server/api/archivedOpportunity/__tests__/archivedOpportunity.ability.spec.js
+++ b/server/api/archivedOpportunity/__tests__/archivedOpportunity.ability.spec.js
@@ -7,7 +7,7 @@ import people from '../../person/__tests__/person.fixture'
 import { jwtData, jwtDataAlice, jwtDataDali } from '../../../middleware/session/__tests__/setSession.fixture'
 import archivedOps from './archivedOpportunity.fixture'
 import ArchivedOpportunity from '../archivedOpportunity'
-import { OpportunityStatus, OpportunityFields, OpportunitySummaryFields } from '../../opportunity/opportunity.constants'
+import { OpportunityStatus, OpportunityFields, OpportunityListFields } from '../../opportunity/opportunity.constants'
 
 test.before('before connect to database', async (t) => {
   t.context.memMongo = new MemoryMongo()
@@ -50,7 +50,7 @@ const testDataByRole = [
     roleName: 'anon',
     cookie: null,
     getExpectedArchivedOps: getCompletedOps,
-    listExpectedFields: OpportunitySummaryFields,
+    listExpectedFields: OpportunityListFields,
     readExpectedFields: Object.values(OpportunityFields),
     expectedPostStatus: 403,
     expectedPutStatus: 403,
@@ -60,7 +60,7 @@ const testDataByRole = [
     roleName: 'admin',
     cookie: `idToken=${jwtData.idToken}`,
     getExpectedArchivedOps: (archivedOps) => archivedOps,
-    listExpectedFields: OpportunitySummaryFields, // admins see all fields
+    listExpectedFields: OpportunityListFields, // admins see all fields
     readExpectedFields: Object.values(OpportunityFields),
     expectedPostStatus: 200,
     expectedPutStatus: 200,
@@ -70,7 +70,7 @@ const testDataByRole = [
     roleName: 'ap',
     cookie: `idToken=${jwtDataDali.idToken}`,
     getExpectedArchivedOps: getCompletedOps,
-    listExpectedFields: OpportunitySummaryFields,
+    listExpectedFields: OpportunityListFields,
     readExpectedFields: Object.values(OpportunityFields),
     expectedPostStatus: 403,
     expectedPutStatus: 403,
@@ -80,7 +80,7 @@ const testDataByRole = [
     roleName: 'op',
     cookie: `idToken=${jwtDataAlice.idToken}`,
     getExpectedArchivedOps: (archivedOps) => archivedOps,
-    listExpectedFields: OpportunitySummaryFields,
+    listExpectedFields: OpportunityListFields,
     readExpectedFields: Object.values(OpportunityFields),
     expectedPostStatus: 403,
     expectedPutStatus: 403,

--- a/server/api/archivedOpportunity/archivedOpportunity.ability.js
+++ b/server/api/archivedOpportunity/archivedOpportunity.ability.js
@@ -1,14 +1,14 @@
 const { Role } = require('../../services/authorize/role')
 const { Action } = require('../../services/abilities/ability.constants')
 const { SchemaName } = require('./archivedOpportunity.constants')
-const { OpportunityStatus, OpportunityFields, OpportunitySummaryFields } = require('../opportunity/opportunity.constants')
+const { OpportunityStatus, OpportunityFields, OpportunityListFields } = require('../opportunity/opportunity.constants')
 
 const ruleBuilder = session => {
   const anonAbilities = [{
     subject: SchemaName,
     action: Action.LIST,
     conditions: { status: { $in: [OpportunityStatus.COMPLETED] } },
-    fields: Object.values(OpportunitySummaryFields)
+    fields: Object.values(OpportunityListFields)
   }, {
     subject: SchemaName,
     action: Action.READ,
@@ -33,7 +33,7 @@ const ruleBuilder = session => {
       subject: SchemaName,
       action: Action.LIST,
       conditions: { requestor: session.me && session.me._id },
-      fields: Object.values(OpportunitySummaryFields)
+      fields: Object.values(OpportunityListFields)
     }, {
       subject: SchemaName,
       action: Action.READ,
@@ -62,7 +62,7 @@ const ruleBuilder = session => {
     {
       subject: SchemaName,
       action: Action.LIST,
-      fields: Object.values(OpportunitySummaryFields)
+      fields: Object.values(OpportunityListFields)
     }, {
       subject: SchemaName,
       action: Action.READ,
@@ -84,7 +84,7 @@ const ruleBuilder = session => {
     {
       subject: SchemaName,
       action: Action.LIST,
-      fields: Object.values(OpportunitySummaryFields)
+      fields: Object.values(OpportunityListFields)
     }, {
       subject: SchemaName,
       action: Action.READ,

--- a/server/api/opportunity/__tests__/opportunity.ability.spec.js
+++ b/server/api/opportunity/__tests__/opportunity.ability.spec.js
@@ -4,7 +4,7 @@ import { server, appReady } from '../../../server'
 import MemoryMongo from '../../../util/test-memory-mongo'
 import Tag from '../../tag/tag'
 import Opportunity from '../opportunity'
-import { OpportunityStatus, OpportunityFields, OpportunityPublishedStatus } from '../opportunity.constants'
+import { OpportunityStatus, OpportunityPublicFields, OpportunityPublishedStatus } from '../opportunity.constants'
 import Person from '../../person/person'
 import people from '../../person/__tests__/person.fixture'
 import Activity from '../../activity/activity'
@@ -50,17 +50,9 @@ const createPersonAndGetToken = async (roles) => {
   }
 }
 
-const assertContainsOnlyAnonymousFields = (test, obj) => {
-  const permittedFields = [
-    OpportunityFields.ID,
-    OpportunityFields.NAME,
-    OpportunityFields.SUBTITLE,
-    OpportunityFields.IMG_URL,
-    OpportunityFields.DURATION,
-    OpportunityFields.DATE
-  ]
+const assertContainsOnlyPublicFields = (test, obj) => {
   for (const key of Object.keys(obj)) {
-    test.true(permittedFields.includes(key), `The response contained an invalid field: '${key}'`)
+    test.true(OpportunityPublicFields.includes(key), `The response contained an invalid field: '${key}'`)
   }
 }
 
@@ -83,7 +75,7 @@ test.serial('Anonymous - READ by id', async t => {
     .set('Accept', 'application/json')
 
   t.is(200, res.status)
-  assertContainsOnlyAnonymousFields(t, res.body)
+  assertContainsOnlyPublicFields(t, res.body)
 })
 
 test.serial('Anonymous users should receive 404 from GET by ID endpoint if draft', async t => {
@@ -100,7 +92,7 @@ test.serial('Anonymous - LIST', async t => {
 
   t.is(200, res.status)
   for (const op of res.body) {
-    assertContainsOnlyAnonymousFields(t, op)
+    assertContainsOnlyPublicFields(t, op)
   }
 })
 
@@ -190,7 +182,7 @@ for (const role of [Role.VOLUNTEER_PROVIDER, Role.OPPORTUNITY_PROVIDER, Role.ORG
       .set('Cookie', [`idToken=${await createPersonAndGetToken([Role.VOLUNTEER_PROVIDER])}`])
 
     t.is(200, res.status)
-    t.is(3, res.body.length) // There are 2 ACTIVE ops in the fixture file
+    t.is(3, res.body.length) // There are 3 ACTIVE ops in the fixture file
     t.truthy(res.body.find(op => op.name === '1 Mentor a year 12 business Impact Project'))
     t.truthy(res.body.find(op => op.name === '2 Self driving model cars'))
     // DRAFT ops will have been trimmed from the response

--- a/server/api/opportunity/opportunity.ability.js
+++ b/server/api/opportunity/opportunity.ability.js
@@ -1,4 +1,10 @@
-const { SchemaName, OpportunityStatus, OpportunityFields, OpportunityPublishedStatus } = require('./opportunity.constants')
+const {
+  SchemaName,
+  OpportunityStatus,
+  OpportunityListFields,
+  OpportunityPublicFields,
+  OpportunityPublishedStatus
+} = require('./opportunity.constants')
 const { Role } = require('../../services/authorize/role')
 const { Action } = require('../../services/abilities/ability.constants')
 
@@ -19,12 +25,12 @@ const ruleBuilder = session => {
     subject: SchemaName,
     action: Action.READ,
     conditions: { status: OpportunityStatus.ACTIVE },
-    fields: [OpportunityFields.ID, OpportunityFields.NAME, OpportunityFields.SUBTITLE, OpportunityFields.IMG_URL, OpportunityFields.DURATION, OpportunityFields.DATE]
+    fields: OpportunityPublicFields
   }, {
     subject: SchemaName,
     action: Action.LIST,
     conditions: { status: OpportunityStatus.ACTIVE },
-    fields: [OpportunityFields.ID, OpportunityFields.NAME, OpportunityFields.SUBTITLE, OpportunityFields.IMG_URL, OpportunityFields.DURATION, OpportunityFields.DATE]
+    fields: OpportunityListFields
   }, {
     subject: SchemaName,
     action: Action.UPDATE,

--- a/server/api/opportunity/opportunity.constants.js
+++ b/server/api/opportunity/opportunity.constants.js
@@ -38,7 +38,11 @@ const OpportunityFields = {
   DATE_ADDED: 'dateAdded',
   TAGS: 'tags'
 }
-const OpportunitySummaryFields = [
+
+/* This list is currently used for requests returning a LIST
+of opportunities, it contains fields required for the OpCard.
+*/
+const OpportunityListFields = [
   OpportunityFields.ID,
   OpportunityFields.NAME,
   OpportunityFields.SUBTITLE,
@@ -48,11 +52,25 @@ const OpportunitySummaryFields = [
   OpportunityFields.LOCATION,
   OpportunityFields.DURATION
 ]
+
+/* This list is currently used for both anon and signed in people
+  all are required to make the OpDetailsPage work correctly.
+*/
+const OpportunityPublicFields = [
+  ...OpportunityListFields,
+  OpportunityFields.TAGS,
+  OpportunityFields.REQUESTOR,
+  OpportunityFields.OFFER_ORG,
+  OpportunityFields.FROM_ACTIVITY,
+  OpportunityFields.DATE_ADDED
+]
+
 module.exports = {
   SchemaName: 'Opportunity',
   OpportunityStatus,
   OpportunityPublishedStatus,
   OpportunityFields,
-  OpportunitySummaryFields,
+  OpportunityListFields,
+  OpportunityPublicFields,
   OpportunityRoutes
 }


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
API security filter was removing the requestor and offerOrg from an opportunity when being obtained for a VP or anon person.  This prevents the page from displaying correctly and does not tell the potential volunteer crucial information for their decision.  (Feedback from testing).

This change makes the list of fields made public clearer by placing them once in the constants file and using consistently.

