### PR TITLE
VP-1432 Remove PDF unicode icon next to each document

### DIFF
--- a/components/Act/ActDetail.js
+++ b/components/Act/ActDetail.js
@@ -25,15 +25,6 @@ import {
 import { Role } from '../../server/services/authorize/role'
 import styled from 'styled-components'
 
-const DocumentLink = styled.a`
-  &::before
-  {
-    content: '🗎';
-    display: inline-block;
-    margin-right: 4px;
-  }
-`
-
 export function ActDetail ({ act, me }) {
   const img = act.imgUrl || '/static/missingimage.svg'
   const isOP = me && me.role.includes(Role.OPPORTUNITY_PROVIDER)
@@ -118,7 +109,7 @@ export function ActDetail ({ act, me }) {
               <ul id='documents'>
                 {act.documents.map(document => (
                   <li key={document.location}>
-                    <DocumentLink href={document.location}>{document.filename}</DocumentLink>
+                    <a href={document.location}>{document.filename}</a>
                   </li>
                 ))}
               </ul>

--- a/components/Act/ActDetail.js
+++ b/components/Act/ActDetail.js
@@ -23,7 +23,6 @@ import {
   ItemImage
 } from '../VTheme/ItemList'
 import { Role } from '../../server/services/authorize/role'
-import styled from 'styled-components'
 
 export function ActDetail ({ act, me }) {
   const img = act.imgUrl || '/static/missingimage.svg'


### PR DESCRIPTION
## I do solemnly swear that I have:
- [ ] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. The document icon next to each document on an activity looks broken on some computers. So for now I'll just remove the icon and we can decide later what or if an icon could go there
2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
