### PR TITLE
VP-1479 - Add type = ask or offer to opportunity + test

### DIFF
--- a/components/Op/__tests__/Op.fixture.js
+++ b/components/Op/__tests__/Op.fixture.js
@@ -32,6 +32,7 @@ const date = [
 export default [
   {
     _id: objectid().toString(),
+    type: 'ask',
     name: '1 Mentor a year 12 business Impact Project',
     subtitle: 'Help us create a programme connecting business with senior students',
     imgUrl: 'https://www.tvnz.co.nz/content/dam/images/news/2015/01/26/pacific-island-mentors-with-kelston-high-school-students.jpg.hashed.0d58ef7e.desktop.story.share.jpg',
@@ -46,6 +47,7 @@ export default [
   },
   {
     _id: objectid().toString(),
+    type: 'ask',
     name: '2 Self driving model cars',
     subtitle: 'using algorithms to follow lines and avoid obstacles',
     imgUrl: 'http://www.plaz-tech.com/wp-content/plugins/wp-easycart-data/products/pics1/Arduino%20Car%202_8ab5dd38f1e3f6f05ad244f1e5e74529.jpg',
@@ -60,6 +62,7 @@ export default [
   },
   {
     _id: objectid().toString(),
+    type: 'ask',
     name: '3 Growing in the garden',
     subtitle: 'Growing digitally in the garden',
     imgUrl: 'https://c.pxhere.com/photos/84/ac/garden_water_sprinkler_soil_lettuce_grow_agriculture_floral-561591.jpg!d',
@@ -75,6 +78,7 @@ export default [
   },
   {
     _id: objectid().toString(),
+    type: 'ask',
     name: '4 The first 100 metres',
     subtitle: 'Launching into space',
     imgUrl: 'https://images.sunlive.co.nz/images/170705-st-marys-school-rockets1.jpg',
@@ -89,6 +93,7 @@ export default [
   },
   {
     _id: objectid().toString(),
+    type: 'ask',
     name: '5 Going to the moon',
     subtitle: 'Travelling up',
     imgUrl: 'https://images.sunlive.co.nz/images/170705-st-marys-school-rockets1.jpg',

--- a/server/api/archivedOpportunity/__tests__/archivedOpportunity.fixture.js
+++ b/server/api/archivedOpportunity/__tests__/archivedOpportunity.fixture.js
@@ -1,8 +1,9 @@
-const { OpportunityStatus } = require('../../opportunity/opportunity.constants')
+const { OpportunityStatus, OpportunityType } = require('../../opportunity/opportunity.constants')
 const { regions } = require('../../location/locationData')
 
 const OpList = [
   {
+    type: OpportunityType.ASK,
     name: 'a Teach a year 5 business Impact Project',
     subtitle: 'Please Help us create a programme connecting business with senior students',
     imgUrl: 'https://www.tvnz.co.nz/content/dam/images/news/2015/01/26/pacific-island-mentors-with-kelston-high-school-students.jpg.hashed.0d58ef7e.desktop.story.share.jpg',
@@ -20,6 +21,7 @@ const OpList = [
     fromActivity: null
   },
   {
+    type: OpportunityType.ASK,
     name: 'b Self driving destructive cars',
     subtitle: 'using algorithms to follow lines and avoid obstacles',
     imgUrl: 'http://www.plaz-tech.com/wp-content/plugins/wp-easycart-data/products/pics1/Arduino%20Car%202_8ab5dd38f1e3f6f05ad244f1e5e74529.jpg',
@@ -37,6 +39,7 @@ const OpList = [
     fromActivity: null
   },
   {
+    type: OpportunityType.ASK,
     name: 'c Reducing plants in the garden',
     subtitle: 'Growing digitally in the garden',
     imgUrl: 'https://c.pxhere.com/photos/84/ac/garden_water_sprinkler_soil_lettuce_grow_agriculture_floral-561591.jpg!d',
@@ -54,6 +57,7 @@ const OpList = [
     fromActivity: null
   },
   {
+    type: OpportunityType.ASK,
     name: 'd The second 500 metres',
     subtitle: 'Launching into nowhere',
     imgUrl: 'https://images.sunlive.co.nz/images/170705-st-marys-school-rockets1.jpg',
@@ -71,6 +75,7 @@ const OpList = [
     fromActivity: null
   },
   {
+    type: OpportunityType.ASK,
     name: 'e How to travel to the sun',
     subtitle: 'Travelling up',
     imgUrl: 'https://images.sunlive.co.nz/images/170705-st-marys-school-rockets1.jpg',

--- a/server/api/archivedOpportunity/archivedOpportunity.controller.js
+++ b/server/api/archivedOpportunity/archivedOpportunity.controller.js
@@ -1,5 +1,6 @@
 const ArchivedOpportunity = require('./archivedOpportunity')
 const { Action } = require('../../services/abilities/ability.constants')
+const { OpportunityListFields } = require('../opportunity/opportunity.constants')
 
 const getArchivedOpportunity = async (req, res, next) => {
   const got = await ArchivedOpportunity
@@ -20,7 +21,7 @@ const getArchivedOpportunities = async (req, res, next) => {
   // limit to Active ops unless one of the params overrides
   let query = { }
   let sort = 'name'
-  let select = 'name subtitle imgUrl status date location duration'
+  let select = OpportunityListFields.join(' ')
 
   try {
     query = req.query.q ? JSON.parse(req.query.q) : query

--- a/server/api/opportunity/__tests__/opportunity.fixture.js
+++ b/server/api/opportunity/__tests__/opportunity.fixture.js
@@ -1,8 +1,9 @@
-const { OpportunityStatus } = require('../opportunity.constants')
+const { OpportunityStatus, OpportunityType } = require('../opportunity.constants')
 const { regions } = require('../../location/locationData')
 
 const opList = [
   {
+    type: OpportunityType.ASK,
     name: '1 Mentor a year 12 business Impact Project',
     subtitle: 'Help us create a programme connecting business with senior students',
     imgUrl: 'https://www.tvnz.co.nz/content/dam/images/news/2015/01/26/pacific-island-mentors-with-kelston-high-school-students.jpg.hashed.0d58ef7e.desktop.story.share.jpg',
@@ -17,6 +18,7 @@ const opList = [
     ]
   },
   {
+    type: OpportunityType.ASK,
     name: '2 Self driving model cars',
     subtitle: 'using algorithms to follow lines and avoid obstacles',
     imgUrl: 'http://www.plaz-tech.com/wp-content/plugins/wp-easycart-data/products/pics1/Arduino%20Car%202_8ab5dd38f1e3f6f05ad244f1e5e74529.jpg',
@@ -31,6 +33,7 @@ const opList = [
     ]
   },
   {
+    type: OpportunityType.ASK,
     name: '3 Growing in the garden',
     subtitle: 'Growing digitally in the garden',
     imgUrl: 'https://c.pxhere.com/photos/84/ac/garden_water_sprinkler_soil_lettuce_grow_agriculture_floral-561591.jpg!d',
@@ -45,6 +48,7 @@ const opList = [
     ]
   },
   {
+    type: OpportunityType.ASK,
     name: '4 The first 100 metres',
     subtitle: 'Launching into space',
     imgUrl: 'https://images.sunlive.co.nz/images/170705-st-marys-school-rockets1.jpg',
@@ -59,6 +63,7 @@ const opList = [
     ]
   },
   {
+    type: OpportunityType.ASK,
     name: '5 Going to the moon',
     subtitle: 'Travelling up',
     imgUrl: 'https://images.sunlive.co.nz/images/170705-st-marys-school-rockets1.jpg',
@@ -73,10 +78,11 @@ const opList = [
     ]
   },
   {
+    type: OpportunityType.OFFER,
     name: '6 Building a race car',
     subtitle: 'Racecar',
     imgUrl: 'https://images.sunlive.co.nz/images/170705-st-marys-school-rockets1.jpg',
-    description: 'Attempting to go where no man has gone before',
+    description: 'I will help you go where no man has gone before',
     duration: '2000 days',
     location: regions[2].name,
     status: OpportunityStatus.ACTIVE,

--- a/server/api/opportunity/opportunity.constants.js
+++ b/server/api/opportunity/opportunity.constants.js
@@ -14,6 +14,11 @@ const OpportunityStatus = {
   CANCELLED: 'cancelled'
 }
 
+const OpportunityType = {
+  ASK: 'ask',
+  OFFER: 'offer'
+}
+
 /**
  * An Opportunity is considered Published if it has one of these status.
  */
@@ -24,13 +29,14 @@ const OpportunityPublishedStatus = [
 
 const OpportunityFields = {
   ID: '_id',
+  TYPE: 'type',
+  STATUS: 'status',
   NAME: 'name',
   SUBTITLE: 'subtitle',
   IMG_URL: 'imgUrl',
   DESCRIPTION: 'description',
   DURATION: 'duration',
   LOCATION: 'location',
-  STATUS: 'status',
   DATE: 'date',
   OFFER_ORG: 'offerOrg',
   REQUESTOR: 'requestor',
@@ -44,6 +50,7 @@ of opportunities, it contains fields required for the OpCard.
 */
 const OpportunityListFields = [
   OpportunityFields.ID,
+  OpportunityFields.TYPE,
   OpportunityFields.NAME,
   OpportunityFields.SUBTITLE,
   OpportunityFields.IMG_URL,
@@ -72,5 +79,6 @@ module.exports = {
   OpportunityFields,
   OpportunityListFields,
   OpportunityPublicFields,
-  OpportunityRoutes
+  OpportunityRoutes,
+  OpportunityType
 }

--- a/server/api/opportunity/opportunity.controller.js
+++ b/server/api/opportunity/opportunity.controller.js
@@ -4,7 +4,7 @@ const Opportunity = require('./opportunity')
 const { Interest, InterestArchive } = require('./../interest/interest')
 const Person = require('./../person/person')
 const ArchivedOpportunity = require('./../archivedOpportunity/archivedOpportunity')
-const { OpportunityStatus } = require('./opportunity.constants')
+const { OpportunityStatus, OpportunityListFields } = require('./opportunity.constants')
 const { regions } = require('../location/locationData')
 const sanitizeHtml = require('sanitize-html')
 const { getLocationRecommendations, getSkillsRecommendations } = require('./opportunity.util')
@@ -17,12 +17,12 @@ const Member = require('../member/member')
  * @param res
  * @returns void
  */
-const getOpportunities = async (req, res, next) => {
+const listOpportunities = async (req, res, next) => {
   // Default to Active ops unless one of the params overrides
   let query = { status: OpportunityStatus.ACTIVE }
   let sort = 'name'
   // return only the summary needed for an OpCard
-  let select = 'name subtitle imgUrl status date location duration'
+  let select = OpportunityListFields.join(' ')
 
   try {
     query = req.query.q ? JSON.parse(req.query.q) : query
@@ -89,7 +89,7 @@ const getOpportunities = async (req, res, next) => {
       return res.status(404).send(e)
     }
   } catch (e) {
-    console.error('getOpportunities error:', e)
+    console.error('listOpportunities error:', e)
     return res.status(500).send(e)
   }
 }
@@ -287,7 +287,7 @@ function ensureSanitized (req, res, next) {
 
 module.exports = {
   ensureSanitized,
-  getOpportunities,
+  listOpportunities,
   getOpportunity,
   putOpportunity,
   deleteOpportunity,

--- a/server/api/opportunity/opportunity.js
+++ b/server/api/opportunity/opportunity.js
@@ -2,18 +2,19 @@ const mongoose = require('mongoose')
 const Schema = mongoose.Schema
 const idvalidator = require('mongoose-id-validator')
 const { accessibleRecordsPlugin, accessibleFieldsPlugin } = require('@casl/mongoose')
-const { OpportunityStatus } = require('./opportunity.constants')
+const { OpportunityStatus, OpportunityType } = require('./opportunity.constants')
 const { SchemaName } = require('./opportunity.constants')
 
 const opportunitySchema = new Schema({
-  name: String, // "Growing in the garden",
-  title: String, // deprecated - use name instead
-  subtitle: String, // "Growing digitally in the garden",
-  imgUrl: { type: 'String', required: false, default: '/static/img/opportunity/opportunity.png' }, // "https://image.flaticon.com/icons/svg/206/206857.svg",
-  description: String, // "Project to grow something in the garden",
-  duration: String, // "15 Minutes",
-  location: String, // "Newmarket, Auckland",
-  venue: String,
+  type: {
+    type: String,
+    required: true,
+    default: OpportunityType.ASK,
+    enum: [
+      OpportunityType.ASK,
+      OpportunityType.OFFER
+    ]
+  },
   status: {
     type: String,
     required: true,
@@ -25,7 +26,15 @@ const opportunitySchema = new Schema({
       OpportunityStatus.CANCELLED
     ]
   },
-  date: [Date],
+  name: String, // "Growing in the garden",
+  title: String, // deprecated - use name instead
+  subtitle: String, // "Growing digitally in the garden",
+  imgUrl: { type: 'String', required: false, default: '/static/img/opportunity/opportunity.png' }, // "https://image.flaticon.com/icons/svg/206/206857.svg",
+  description: String, // "Project to grow something in the garden",
+  duration: String, // "15 Minutes",
+  location: String, // region or city,
+  venue: String, // actual address
+  date: [Date], // start and optional end dates
   fromActivity: { type: Schema.Types.ObjectId, ref: 'Activity', required: false },
   offerOrg: { type: Schema.Types.ObjectId, ref: 'Organisation', required: false },
   requestor: { type: Schema.Types.ObjectId, ref: 'Person', required: true },

--- a/server/api/opportunity/opportunity.routes.js
+++ b/server/api/opportunity/opportunity.routes.js
@@ -3,7 +3,7 @@ const helpers = require('../../services/helpers')
 const Opportunity = require('./opportunity')
 const {
   ensureSanitized,
-  getOpportunities,
+  listOpportunities,
   getOpportunity,
   putOpportunity,
   deleteOpportunity,
@@ -32,7 +32,7 @@ module.exports = (server) => {
       }],
       // actions: {}, // list (GET), create (POST), read (GET), update (PUT), delete (DELETE)
       actions: {
-        list: getOpportunities,
+        list: listOpportunities,
         read: getOpportunity,
         update: putOpportunity,
         delete: deleteOpportunity,

--- a/x/db/perf/makeOps.js
+++ b/x/db/perf/makeOps.js
@@ -5,7 +5,7 @@ const Opportunity = require('../../../server/api/opportunity/opportunity')
 const { Interest } = require('../../../server/api/interest/interest')
 const { MemberStatus } = require('../../../server/api/member/member.constants')
 const { InterestStatus } = require('../../../server/api/interest/interest.constants')
-const { OpportunityStatus } = require('../../../server/api/opportunity/opportunity.constants')
+const { OpportunityStatus, OpportunityType } = require('../../../server/api/opportunity/opportunity.constants')
 const moment = require('moment')
 
 const makeMessages = (numMessages, a, b, status, op) =>
@@ -65,6 +65,7 @@ const makeOp = async (interestCount, fromActivity) => {
 
   const op = fromActivity
     ? {
+      type: OpportunityType.ASK,
       name: `${fromActivity.name} Opportunity`,
       imgUrl: fromActivity.imgUrl,
       subtitle: fromActivity.subtitle,
@@ -80,6 +81,7 @@ const makeOp = async (interestCount, fromActivity) => {
       tags
     }
     : {
+      type: OpportunityType.ASK,
       name: `${requestor.nickname} ${code} Opportunity`,
       imgUrl: `https://picsum.photos/seed/${requestor.nickname}-${code}/200/200`,
       subtitle: `${requestor.nickname} ${code}`,


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Add a 'type' field to the opportunity schema.  has values of OpportunityType.ASK or OpportunityType.OFFER.  note this is an enum not a bool as we might have other types. 

it is a required field with a default of ASK so this will preseve all existing behaviour.  

Tests update to check we can read and write the types. 
Ability and default list of fields updated to ensure type is always sent out.
fixtures updated.

When writing clients if type is not available then assume it is ASK.
