### PR TITLE
Add OpType and test

### DIFF
--- a/components/Op/OpType.js
+++ b/components/Op/OpType.js
@@ -1,0 +1,32 @@
+import { OpportunityType } from '../../server/api/opportunity/opportunity.constants'
+import { FormattedMessage, useIntl, defineMessages } from 'react-intl'
+import { Stamp } from '../../components/VTheme/Stamp'
+const { ASK, OFFER } = OpportunityType
+export const OpTypeMessages = defineMessages({
+  [ASK]: {
+    id: 'OpportunityType.ASK',
+    defaultMessage: 'Ask',
+    description: 'Asking for help'
+  },
+  [OFFER]: {
+    id: 'OpportunityType.OFFER',
+    defaultMessage: 'Offer',
+    description: 'Offering help'
+  }
+})
+
+/** Converts an opportunity type to a translated display string */
+export const OpType = ({ type }) => {
+  if (!type || ![ASK, OFFER].includes(type)) return null
+  return (<FormattedMessage {...OpTypeMessages[type]} />)
+}
+
+/** Converts an opportunity type to a Stamp - except for Active */
+export const OpTypeStamp = ({ type }) => {
+  if (!type || ![ASK, OFFER].includes(type)) return null
+  const intl = useIntl()
+  return (
+    <Stamp>
+      {intl.formatMessage(OpTypeMessages[type])}
+    </Stamp>)
+}

--- a/components/Op/__tests__/OpType.spec.js
+++ b/components/Op/__tests__/OpType.spec.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import test from 'ava'
+import { mountWithIntl } from '../../../lib/react-intl-test-helper'
+import { OpTypeStamp, OpType } from '../OpType'
+import { OpportunityType } from '../../../server/api/opportunity/opportunity.constants'
+
+test('render OpTypeStamp for ask op', t => {
+  const wrapper = mountWithIntl(
+    <OpTypeStamp
+      type={OpportunityType.ASK}
+    />
+  )
+  t.is(wrapper.find('span').length, 1)
+  t.is(wrapper.find('span').text(), 'Ask')
+})
+
+test('render OpTypeStamp for offer op', t => {
+  const wrapper = mountWithIntl(
+    <OpTypeStamp
+      type={OpportunityType.OFFER}
+    />
+  )
+  t.is(wrapper.find('span').length, 1)
+})
+test('render OpTypeStamp for no type', t => {
+  const wrapper = mountWithIntl(
+    <OpTypeStamp />
+  )
+  t.is(wrapper.find('span').length, 0)
+})
+test('render OpTypeStamp for invalid type', t => {
+  const wrapper = mountWithIntl(
+    <OpTypeStamp type='INVALID' />
+  )
+  t.is(wrapper.find('span').length, 0)
+})
+test('render OpType for offer op', t => {
+  const wrapper = mountWithIntl(
+    <OpType
+      type={OpportunityType.OFFER}
+    />
+  )
+  t.is(wrapper.text(), 'Offer')
+})  
+
+test('render OpType with no type', t => {
+  const wrapper = mountWithIntl(
+    <OpType />
+  )
+  t.is(wrapper.text(), '')
+})

--- a/components/Op/__tests__/OpType.spec.js
+++ b/components/Op/__tests__/OpType.spec.js
@@ -41,7 +41,7 @@ test('render OpType for offer op', t => {
     />
   )
   t.is(wrapper.text(), 'Offer')
-})  
+})
 
 test('render OpType with no type', t => {
   const wrapper = mountWithIntl(

--- a/lang/en.json
+++ b/lang/en.json
@@ -213,6 +213,8 @@
   "OpportunityStatus.active": "Active",
   "OpportunityStatus.completed": "Completed",
   "OpportunityStatus.draft": "Draft",
+  "OpportunityType.ASK": "Ask",
+  "OpportunityType.OFFER": "Offer",
   "opStartDate": "Start Date",
   "opSubtitle": "Subtitle",
   "opTabs.about": "About",


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Adds components <OpType type={op.type} > that will write Ask or Offer text on the page.
Also OpTypeStamp which will place a large stamp over the picture - as per Draft.  this might not be needed. 
