### PR TITLE
VP-1500 add group tags to org schema

### DIFF
--- a/server/api/activity/activity.routes.js
+++ b/server/api/activity/activity.routes.js
@@ -3,7 +3,7 @@ const helpers = require('../../services/helpers')
 const Activity = require('./activity')
 const { getActivities, getActivity, putActivity, createActivity } = require('./activity.controller')
 const { findActivity } = require('./findActivity')
-const initializeTags = require('../../util/initTags')
+const { initializeTags } = require('../../util/initTags')
 const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
 const { SchemaName } = require('./activity.constants')
 

--- a/server/api/opportunity/opportunity.routes.js
+++ b/server/api/opportunity/opportunity.routes.js
@@ -12,7 +12,7 @@ const {
 } = require('./opportunity.controller')
 const { SchemaName } = require('./opportunity.constants')
 const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
-const initializeTags = require('../../util/initTags')
+const { initializeTags } = require('../../util/initTags')
 const removeUnauthorizedFields = require('../../services/authorize/removeUnauthorizedFields')
 
 module.exports = (server) => {

--- a/server/api/organisation/organisation.constants.js
+++ b/server/api/organisation/organisation.constants.js
@@ -5,10 +5,40 @@ const Category = {
   AGENCY: 'admin',
   OTHER: 'other'
 }
+const OrganisationFields = {
+  NAME: 'name',
+  SLUG: 'slug',
+  IMGURL: 'imgUrl',
+  WEBSITE: 'website',
+  FACEBOOK: 'facebook',
+  DOMAINNAME: 'domainName',
+  TWITTER: 'twitter',
+  CATEGORY: 'category',
+  GROUPS: 'groups',
+  INFO: 'info',
+  DATEADDED: 'dateAdded',
+  AGERANGE: 'ageRange',
+  DECILE: 'decile',
+  CONTACTNAME: 'contactName',
+  CONTACTEMAIL: 'contactEmail',
+  CONTACTPHONENUMBER: 'contactPhoneNumber',
+  ADDRESS: 'address'
+}
+
+const OrganisationListFields = [
+  OrganisationFields.ID,
+  OrganisationFields.NAME,
+  OrganisationFields.SLUG,
+  OrganisationFields.IMG_URL,
+  OrganisationFields.CATEGORY,
+  OrganisationFields.GROUPS
+]
 
 const SchemaName = 'Organisation'
 
 module.exports = {
   Category,
+  OrganisationFields,
+  OrganisationListFields,
   SchemaName
 }

--- a/server/api/organisation/organisation.controller.js
+++ b/server/api/organisation/organisation.controller.js
@@ -1,6 +1,7 @@
 const Organisation = require('./organisation')
 const { Role } = require('../../services/authorize/role')
 const { validationRules } = require('../../../lib/fieldValidation')
+const { OrganisationListFields } = require('./organisation.constants')
 /**
  * Get all orgs
  * @param req
@@ -8,14 +9,15 @@ const { validationRules } = require('../../../lib/fieldValidation')
  * @returns void
  */
 
-const getOrganisations = async (req, res) => {
+const listOrganisations = async (req, res) => {
   let query = {}
   let sort = 'name'
-  let select = null
+  let select = OrganisationListFields.join(' ')
+
   try {
     query = req.query.q ? JSON.parse(req.query.q) : query
     sort = req.query.s ? JSON.parse(req.query.s) : sort
-    select = req.query.p ? req.query.p : null
+    select = req.query.p ? req.query.p : select
   } catch (e) {
     // if there is something wrong with the query return a Bad Query
     return res.status(400).send(e)
@@ -75,7 +77,7 @@ const deleteOrganisation = async (req, res) => {
 }
 
 module.exports = {
-  getOrganisations,
+  listOrganisations,
   putOrganisation,
   postOrganisation,
   deleteOrganisation

--- a/server/api/organisation/organisation.js
+++ b/server/api/organisation/organisation.js
@@ -19,6 +19,7 @@ const organisationSchema = new Schema({
     enum: ['admin', 'vp', 'op', 'ap', 'other']
     // TODO: [VP-905] replace category strings with constants in ./organisation.constants.js
   },
+  groups: [String], // which groups does this org belong to - business, school, individual
   info: {
     about: String,
     instructions: String,

--- a/server/api/organisation/organisation.routes.js
+++ b/server/api/organisation/organisation.routes.js
@@ -1,9 +1,10 @@
 const mongooseCrudify = require('mongoose-crudify')
 const helpers = require('../../services/helpers')
 const Organisation = require('./organisation')
-const { getOrganisations, putOrganisation, postOrganisation, deleteOrganisation } = require('./organisation.controller')
+const { listOrganisations, putOrganisation, postOrganisation, deleteOrganisation } = require('./organisation.controller')
 const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
 const { SchemaName } = require('./organisation.constants')
+const { initializeGroups } = require('../../util/initTags')
 
 module.exports = function (server) {
   // Docs: https://github.com/ryo718/mongoose-crudify
@@ -17,10 +18,13 @@ module.exports = function (server) {
       beforeActions: [
         {
           middlewares: [authorizeActions(SchemaName)]
+        }, {
+          middlewares: [initializeGroups],
+          only: ['create', 'update']
         }],
       // actions: {}, // list (GET), create (POST), read (GET), update (PUT), delete (DELETE)
       actions: {
-        list: getOrganisations,
+        list: listOrganisations,
         update: putOrganisation,
         create: postOrganisation,
         delete: deleteOrganisation

--- a/server/api/person/person.routes.js
+++ b/server/api/person/person.routes.js
@@ -6,7 +6,7 @@ const { SchemaName } = require('./person.constants')
 const removeUnauthorizedFields = require('../../services/authorize/removeUnauthorizedFields')
 const { authorizeActions } = require('../../middleware/authorize/authorizeRequest')
 const { publishCreate } = require('../../services/pubsub/publishTopic')
-const initializeTags = require('../../util/initTags')
+const { initializeTags } = require('../../util/initTags')
 
 module.exports = function (server) {
   // Docs: https://github.com/ryo718/mongoose-crudify

--- a/server/api/tag/tag.constants.js
+++ b/server/api/tag/tag.constants.js
@@ -1,5 +1,6 @@
 
 module.exports = {
   SchemaName: 'TagList',
-  DefaultTagList: 'default'
+  DefaultTagList: 'default',
+  GroupTagList: 'groups'
 }

--- a/server/util/__tests__/initTags.spec.js
+++ b/server/util/__tests__/initTags.spec.js
@@ -2,10 +2,11 @@ import test from 'ava'
 import MockExpressRequest from 'mock-express-request'
 import MockResponse from 'mock-res'
 import sinon from 'sinon'
-import initializeTags from '../initTags'
+import { initializeTags, initializeGroups } from '../initTags'
 import MemoryMongo from '../test-memory-mongo'
 import { appReady } from '../../server'
 import Tag from '../../api/tag/tag'
+const { DefaultTagList, GroupTagList } = require('../../api/tag/tag.constants')
 
 test.before('before connect to database', async (t) => {
   await appReady
@@ -17,14 +18,13 @@ test.after.always(async (t) => {
   await t.context.memMongo.stop()
 })
 
-test.serial('Add tags to DB if needed', async t => {
-  t.plan(4)
+test('Add tags to DB if needed', async t => {
   const p1 = {
     name: 'Testy McTestFace',
     nickname: 'Testy',
     phone: '123 456789',
     // email: 'Testy555@voluntarily.nz', <- explicity remove email
-    role: ['tester'],
+    role: ['opportunityProvider'],
     tags: ['taga', 'tagb']
   }
 
@@ -33,7 +33,7 @@ test.serial('Add tags to DB if needed', async t => {
     nickname: 'Testy',
     phone: '123 456789',
     // email: 'Testy555@voluntarily.nz', <- explicity remove email
-    role: ['tester'],
+    role: ['opportunityProvider'],
     tags: ['taga', 'tagc']
   }
 
@@ -51,10 +51,49 @@ test.serial('Add tags to DB if needed', async t => {
     await initializeTags(request2, response, next)
     t.is(next.callCount, 2)
 
-    await Tag.find().then(tags => {
-      t.is(tags.length, 1)
-      t.deepEqual(Array.from(tags[0].tags), ['taga', 'tagb', 'tagc'])
-    })
+    const tags = await Tag.findOne({ name: DefaultTagList })
+    t.is(tags.tags.length, 3)
+    t.deepEqual(Array.from(tags.tags), ['taga', 'tagb', 'tagc'])
+  } catch (err) {
+    console.error('api/people err', err, err.stack)
+  }
+})
+
+test('Add tags to groups list if needed', async t => {
+  const p1 = {
+    name: 'Testy McTestFace',
+    nickname: 'Testy',
+    phone: '123 456789',
+    // email: 'Testy555@voluntarily.nz', <- explicity remove email
+    role: ['opportunityProvider'],
+    tags: ['groupa', 'groupb']
+  }
+
+  const p2 = {
+    name: 'Testy McTestFace',
+    nickname: 'Testy',
+    phone: '123 456789',
+    // email: 'Testy555@voluntarily.nz', <- explicity remove email
+    role: ['opportunityProvider'],
+    tags: ['groupa', 'groupc']
+  }
+
+  const request1 = new MockExpressRequest()
+  request1.body = p1
+  const request2 = new MockExpressRequest()
+  request2.body = p2
+
+  const response = new MockResponse()
+  const next = sinon.fake()
+
+  try {
+    await initializeGroups(request1, response, next)
+    t.true(next.calledOnce)
+    await initializeGroups(request2, response, next)
+    t.is(next.callCount, 2)
+
+    const groups = await Tag.findOne({ name: GroupTagList })
+    t.deepEqual(Array.from(groups.tags), ['groupa', 'groupb', 'groupc'])
   } catch (err) {
     console.error('api/people err', err, err.stack)
   }

--- a/server/util/initTags.js
+++ b/server/util/initTags.js
@@ -1,12 +1,12 @@
 const Tag = require('../api/tag/tag')
-const { DefaultTagList } = require('../api/tag/tag.constants')
+const { DefaultTagList, GroupTagList } = require('../api/tag/tag.constants')
 
-const initializeTags = async (req, res, next) => {
+const initializeTagsA = taglist => async (req, res, next) => {
   try {
     const { tags } = req.body
     if (tags) {
       try {
-        const tagset = await Tag.findOne({ name: DefaultTagList }).exec()
+        const tagset = await Tag.findOne({ name: taglist }).exec()
         if (tagset) {
           const currentTags = new Set(tagset.tags)
           tags.forEach(x => {
@@ -17,7 +17,7 @@ const initializeTags = async (req, res, next) => {
           })
           await tagset.save()
         } else {
-          await Tag.create({ name: DefaultTagList, tags: tags })
+          await Tag.create({ name: taglist, tags: tags })
         }
       } catch (error) {
         console.error('Failed to fetch tags to append to', error)
@@ -30,4 +30,11 @@ const initializeTags = async (req, res, next) => {
   }
 }
 
-module.exports = initializeTags
+const initializeTags = initializeTagsA(DefaultTagList)
+// console.log(initializeTags)
+const initializeGroups = initializeTagsA(GroupTagList)
+
+module.exports = {
+  initializeTags,
+  initializeGroups
+}


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
To InitTags we add a second named tag list for Groups.  This will hold tags used by orgs to group topics together for searching.

To organisation.js we add a new groups [string] that will hold one or more groups. usually just one. e.g. Business, School, Personal

To the controller we update any incoming group tags into the taglist. 

The getOrganisation call is renamed listOrganisation and a default select is used to limit the size of the result to those fields used in OrgCards.  The fields are now in constants. 

