### PR TITLE
Tidy up home page buttons

### DIFF
--- a/__tests__/home.spec.js
+++ b/__tests__/home.spec.js
@@ -409,11 +409,11 @@ test.serial('render Edit Profile ', async t => {
     </Provider>)
   wrapper.find('.ant-tabs-tab').at(tabIndex.profile).simulate('click')
   t.is(wrapper.find('.ant-tabs-tab-active').first().text(), 'Profile')
-  t.is(wrapper.find('Button').first().text(), 'Edit')
-  wrapper.find('Button').first().simulate('click')
-  // t.is(wrapper.find('Button').first().text(), 'Cancel')
-  wrapper.find('Button').first().simulate('click') // cancel edit
-  wrapper.find('Button').first().simulate('click') // edit again
-  // t.is(wrapper.find('Button').last().text(), 'Save')
+  const profilePanel = wrapper.find('EditablePersonPanel').first()
+  t.is(profilePanel.find('Button').first().text(), 'Edit')
+  profilePanel.find('EditablePersonPanel Button').first().simulate('click')
+
+  wrapper.find('EditablePersonPanel Button').first().simulate('click') // cancel edit
+  wrapper.find('EditablePersonPanel Button').first().simulate('click') // edit again
   wrapper.find('Form').first().simulate('submit')
 })

--- a/components/Op/OpAdd.js
+++ b/components/Op/OpAdd.js
@@ -20,6 +20,21 @@ const OppAddButtons = styled.div`
     }
 `
 
+export const OpAddNewBtn = () => {
+  const href = '/acts'
+
+  return (
+    <Link href={href}>
+      <Button type='primary' block shape='round' size='large'>
+        <FormattedMessage
+          id='opAdd.newAskOffer'
+          defaultMessage='New request or offering'
+          description='Button to create a new Ask or Offer opportunity used on multiple pages'
+        />
+      </Button>
+    </Link>)
+}
+
 export const OpAddAskBtn = ({ actid }) => {
   let href = `/op/${OpportunityType.ASK}`
   if (actid) {

--- a/lang/en.json
+++ b/lang/en.json
@@ -191,6 +191,7 @@
   "op.SaveInstructions": "Save as Draft will allow you to preview the request while Publish will make it available to everyone to view.",
   "OpAboutPanel.subtitle": "About this activity",
   "opAdd.newAsk": "I can offer this",
+  "opAdd.newAskOffer": "New request or offering",
   "opAdd.newOffer": "I'd like help with this",
   "OpArchivedHeader.Cancelled.message": "This activity was cancelled, but you can still get involved with",
   "OpArchivedHeader.Completed.message": "This activity has already happened, but you can still get involved with",

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -6,7 +6,7 @@ import ActAdd from '../../components/Act/ActAdd'
 import { HomeBanner } from '../../components/Home/HomeBanner.js'
 import { HomeTabs } from '../../components/Home/HomeTabs.js'
 import Loading from '../../components/Loading'
-import OpAdd from '../../components/Op/OpAdd'
+import { OpAddNewBtn } from '../../components/Op/OpAdd'
 import { FullPage, PageBannerButtons } from '../../components/VTheme/VTheme'
 import securePage from '../../hocs/securePage'
 import reduxApi from '../../lib/redux/reduxApi.js'
@@ -49,7 +49,7 @@ export const PersonHomePage = () => {
       </Helmet>
       <HomeBanner person={person}>
         <PageBannerButtons>
-          <OpAdd roles={person.roles} />
+          <OpAddNewBtn />
         </PageBannerButtons>
         <PageBannerButtons>
           <ActAdd roles={person.roles} />


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Home page button now only has one choice - Ask or Offer which leads to the resources page. This means you have to first consider using an existing template before creating a new thing. 

On the templates page we will add placeholder templates for Generic thing.


## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/1596437/77236815-e41ec400-6c26-11ea-9565-438f9b66d318.png">

### Original


### Updated
