### PR TITLE
VP-1607 useWindowSize hook and vertical menu

### DIFF
--- a/components/Navigation/Navigation.js
+++ b/components/Navigation/Navigation.js
@@ -3,21 +3,21 @@ import Link from 'next/link'
 import { withRouter } from 'next/router'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-
+import { useWindowSize } from '../../lib/useWindowSize'
+const { SubMenu, Item } = Menu
 const VMenu = styled(Menu)`
 border-bottom: 2px solid transparent;
-
+border-right: none;
 .ant-menu-item {
   border: none;
   
 }
 
 @media screen and (max-width: 767px) {
-    display: none;
+    // display: none;
   }
 `
-
-const Navigation = ({ items, defaultItem, router, me, ...props }) => {
+export const NavigationH = ({ items, router }) => {
   const activeItem = router.pathname.slice(1)
   return (
     <VMenu
@@ -36,6 +36,39 @@ const Navigation = ({ items, defaultItem, router, me, ...props }) => {
 
     </VMenu>
   )
+}
+export const NavigationV = ({ items, router }) => {
+  const activeItem = router.pathname.slice(1)
+  return (
+    <VMenu
+      theme='light'
+      mode='inline'
+      // style={{ float: 'right' }}
+      selectedKeys={[activeItem]}
+    >
+      <SubMenu
+        key='sub1'
+        title='☰'
+      >
+        {items.map(item => (
+          <Item key={item.key}>
+            <Link key={item.href} href={item.href}>
+              <a>{item.text}</a>
+            </Link>
+          </Item>
+        ))}
+      </SubMenu>
+
+    </VMenu>
+  )
+}
+
+const COLLAPSE_MENU_WIDTH = 767
+const Navigation = (props) => {
+  const [width] = useWindowSize()
+  return (width < COLLAPSE_MENU_WIDTH)
+    ? <NavigationV {...props} />
+    : <NavigationH {...props} />
 }
 
 Navigation.propTypes = {

--- a/lib/useWindowSize.js
+++ b/lib/useWindowSize.js
@@ -1,0 +1,16 @@
+import { useLayoutEffect, useState } from 'react'
+
+export function useWindowSize () {
+  const [size, setSize] = useState([0, 0])
+  useLayoutEffect(() => {
+    function updateSize () {
+      setSize([window.innerWidth, window.innerHeight])
+    }
+    window.addEventListener('resize', updateSize)
+    updateSize()
+    return () => window.removeEventListener('resize', updateSize)
+  }, [])
+  return size
+}
+
+export default useWindowSize


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. When the screen width falls below 765 we switch from the horizontal menu to a vertical submenu with a '☰' 


2. Added a useWindowSize hook to detect size changes.
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 normal
<img width="696" alt="image" src="https://user-images.githubusercontent.com/1596437/77566667-dde05e80-6f2a-11ea-8675-0927c13b675e.png">

### Mobile Closed
<img width="362" alt="image" src="https://user-images.githubusercontent.com/1596437/77566705-e9cc2080-6f2a-11ea-9da2-f3a029401c19.png">

### Mobile Open
<img width="372" alt="image" src="https://user-images.githubusercontent.com/1596437/77566758-fcdef080-6f2a-11ea-9096-16c7407f6e04.png">


