### PR TITLE
VP-1608: Basic reporting page with activity,interest, person and opportunity counts

### DIFF
--- a/__tests__/api/reports/summary.spec.js
+++ b/__tests__/api/reports/summary.spec.js
@@ -1,0 +1,39 @@
+import test from 'ava'
+import MockExpressRequest from 'mock-express-request'
+import MockExpressResponse from 'mock-express-response'
+import MemoryMongo from '../../../server/util/test-memory-mongo'
+import { OpportunityType } from '../../../server/api/opportunity/opportunity.constants'
+
+import summary from '../../../pages/api/reports/summary'
+import sinon from 'sinon'
+
+test.before('start in memory mongo and create fake server', async (t) => {
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
+})
+
+test.after.always(async (t) => {
+  t.context.memMongo && (await t.context.memMongo.stop())
+})
+
+test('Should respond with summary data for an admin', async t => {
+  const req = new MockExpressRequest()
+  const res = new MockExpressResponse()
+  req.ability = { can: sinon.fake.returns(true) }
+  await summary(req, res)
+  t.deepEqual(res._getJSON(), {
+    Person: 0,
+    Activity: 0,
+    Interest: 0,
+    Opportunity: { [OpportunityType.ASK]: 0, [OpportunityType.OFFER]: 0 }
+  })
+  t.is(200, res.statusCode, 'OK Response')
+})
+
+test('Should require the logged in user is an admin', async t => {
+  const req = new MockExpressRequest()
+  const res = new MockExpressResponse()
+  req.ability = { can: sinon.fake.returns(false) }
+  await summary(req, res)
+  t.is(401, res.statusCode, 'Authorisation required')
+})

--- a/__tests__/api/reports/summary.spec.js
+++ b/__tests__/api/reports/summary.spec.js
@@ -5,7 +5,6 @@ import MemoryMongo from '../../../server/util/test-memory-mongo'
 import { OpportunityType } from '../../../server/api/opportunity/opportunity.constants'
 
 import summary from '../../../pages/api/reports/summary'
-import sinon from 'sinon'
 
 test.before('start in memory mongo and create fake server', async (t) => {
   t.context.memMongo = new MemoryMongo()
@@ -21,7 +20,7 @@ test('Should respond with summary data for an admin', async t => {
   const res = new MockExpressResponse()
   req.session = {
     isAuthenticated: true,
-    me: { role: ["admin"] }
+    me: { role: ['admin'] }
   }
 
   await summary(req, res)

--- a/__tests__/api/reports/summary.spec.js
+++ b/__tests__/api/reports/summary.spec.js
@@ -19,7 +19,11 @@ test.after.always(async (t) => {
 test('Should respond with summary data for an admin', async t => {
   const req = new MockExpressRequest()
   const res = new MockExpressResponse()
-  req.ability = { can: sinon.fake.returns(true) }
+  req.session = {
+    isAuthenticated: true,
+    me: { role: ["admin"] }
+  }
+
   await summary(req, res)
   t.deepEqual(res._getJSON(), {
     Person: 0,
@@ -33,7 +37,7 @@ test('Should respond with summary data for an admin', async t => {
 test('Should require the logged in user is an admin', async t => {
   const req = new MockExpressRequest()
   const res = new MockExpressResponse()
-  req.ability = { can: sinon.fake.returns(false) }
+  req.session = {}
   await summary(req, res)
   t.is(401, res.statusCode, 'Authorisation required')
 })

--- a/pages/api/reports/summary.js
+++ b/pages/api/reports/summary.js
@@ -17,8 +17,8 @@ export default async (req, res) => {
     Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.OFFER }).exec(),
     Person.countDocuments({ }).exec(),
     Interest.countDocuments({ }).exec(),
-    Activity.countDocuments({status: ActivityStatus.ACTIVE}).exec()
-  ];
+    Activity.countDocuments({ status: ActivityStatus.ACTIVE }).exec()
+  ]
 
   return Promise.all(operations).then(
     ([askCount, offerCount, personCount, interestCount, activityCount]) =>
@@ -28,5 +28,5 @@ export default async (req, res) => {
         Interest: interestCount,
         Activity: activityCount
       })
-  );
+  )
 }

--- a/pages/api/reports/summary.js
+++ b/pages/api/reports/summary.js
@@ -9,7 +9,7 @@ const { ActivityStatus } = require('../../../server/api/activity/activity.consta
 
 export default async (req, res) => {
   res.setHeader('Content-Type', 'application/json')
-  if (!req.session.me.role.includes(Role.ADMIN)) { // Not an admin
+  if ( !(req.session.me && req.session.me.role.includes(Role.ADMIN))) { // Not an admin
     return res.status(401).json('Authorisation required')
   }
 

--- a/pages/api/reports/summary.js
+++ b/pages/api/reports/summary.js
@@ -1,16 +1,28 @@
-const Opportunity = require('../../../server/api/opportunity/opportunity')
-const { OpportunityType, OpportunityStatus } = require('../../../server/api/opportunity/opportunity.constants')
 const Person = require('../../../server/api/person/person')
+const Activity = require('../../../server/api/activity/activity')
+const { Interest } = require('../../../server/api/interest/interest')
+const Opportunity = require('../../../server/api/opportunity/opportunity')
+
+const { OpportunityType, OpportunityStatus } = require('../../../server/api/opportunity/opportunity.constants')
+const { ActivityStatus } = require('../../../server/api/activity/activity.constants')
 
 export default async (req, res) => {
   res.setHeader('Content-Type', 'application/json')
-  const opAskCount = await Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.ASK })
-  const opOfferCount = await Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.OFFER })
-  const personCount = await Person.countDocuments({ })
+  const operations = [
+    Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.ASK }).exec(),
+    Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.OFFER }).exec(),
+    Person.countDocuments({ }).exec(),
+    Interest.countDocuments({ }).exec(),
+    Activity.countDocuments({status: ActivityStatus.ACTIVE}).exec()
+  ];
 
-  const result = {
-    Opportunity: { [OpportunityType.ASK]: opAskCount, [OpportunityType.OFFER]: opOfferCount },
-    Person: personCount
-  }
-  res.send(result)
+  return Promise.all(operations).then(
+    ([askCount, offerCount, personCount, interestCount, activityCount]) =>
+      res.send({
+        Person: personCount,
+        Opportunity: { [OpportunityType.ASK]: askCount, [OpportunityType.OFFER]: offerCount },
+        Interest: interestCount,
+        Activity: activityCount
+      })
+  );
 }

--- a/pages/api/reports/summary.js
+++ b/pages/api/reports/summary.js
@@ -1,15 +1,15 @@
+import { Role } from '../../../server/services/authorize/role'
 const Person = require('../../../server/api/person/person')
 const Activity = require('../../../server/api/activity/activity')
 const { Interest } = require('../../../server/api/interest/interest')
 const Opportunity = require('../../../server/api/opportunity/opportunity')
-import { Role } from '../../../server/services/authorize/role'
 
 const { OpportunityType, OpportunityStatus } = require('../../../server/api/opportunity/opportunity.constants')
 const { ActivityStatus } = require('../../../server/api/activity/activity.constants')
 
 export default async (req, res) => {
   res.setHeader('Content-Type', 'application/json')
-  if (!req.session.me.role.includes(Role.ADMIN)){ // Not an admin
+  if (!req.session.me.role.includes(Role.ADMIN)) { // Not an admin
     return res.status(401).json('Authorisation required')
   }
 

--- a/pages/api/reports/summary.js
+++ b/pages/api/reports/summary.js
@@ -1,0 +1,16 @@
+const Opportunity = require('../../../server/api/opportunity/opportunity')
+const { OpportunityType, OpportunityStatus } = require('../../../server/api/opportunity/opportunity.constants')
+const Person = require('../../../server/api/person/person')
+
+export default async (req, res) => {
+  res.setHeader('Content-Type', 'application/json')
+  const opAskCount = await Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.ASK })
+  const opOfferCount = await Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.OFFER })
+  const personCount = await Person.countDocuments({ })
+
+  const result = {
+    Opportunity: { [OpportunityType.ASK]: opAskCount, [OpportunityType.OFFER]: opOfferCount },
+    Person: personCount
+  }
+  res.send(result)
+}

--- a/pages/api/reports/summary.js
+++ b/pages/api/reports/summary.js
@@ -2,13 +2,14 @@ const Person = require('../../../server/api/person/person')
 const Activity = require('../../../server/api/activity/activity')
 const { Interest } = require('../../../server/api/interest/interest')
 const Opportunity = require('../../../server/api/opportunity/opportunity')
+import { Role } from '../../../server/services/authorize/role'
 
 const { OpportunityType, OpportunityStatus } = require('../../../server/api/opportunity/opportunity.constants')
 const { ActivityStatus } = require('../../../server/api/activity/activity.constants')
 
 export default async (req, res) => {
   res.setHeader('Content-Type', 'application/json')
-  if (!req.ability.can('manage', 'Person')) { // Not an admin
+  if (!req.session.me.role.includes(Role.ADMIN)){ // Not an admin
     return res.status(401).json('Authorisation required')
   }
 

--- a/pages/api/reports/summary.js
+++ b/pages/api/reports/summary.js
@@ -9,7 +9,7 @@ const { ActivityStatus } = require('../../../server/api/activity/activity.consta
 
 export default async (req, res) => {
   res.setHeader('Content-Type', 'application/json')
-  if ( !(req.session.me && req.session.me.role.includes(Role.ADMIN))) { // Not an admin
+  if (!(req.session.me && req.session.me.role.includes(Role.ADMIN))) { // Not an admin
     return res.status(401).json('Authorisation required')
   }
 

--- a/pages/api/reports/summary.js
+++ b/pages/api/reports/summary.js
@@ -8,6 +8,10 @@ const { ActivityStatus } = require('../../../server/api/activity/activity.consta
 
 export default async (req, res) => {
   res.setHeader('Content-Type', 'application/json')
+  if (!req.ability.can('manage', 'Person')) { // Not an admin
+    return res.status(401).json('Authorisation required')
+  }
+
   const operations = [
     Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.ASK }).exec(),
     Opportunity.countDocuments({ status: OpportunityStatus.ACTIVE, type: OpportunityType.OFFER }).exec(),

--- a/pages/reports/summary.js
+++ b/pages/reports/summary.js
@@ -1,0 +1,56 @@
+import adminPage from '../../hocs/adminPage'
+import { FullPage } from '../../components/VTheme/VTheme'
+import { useState, useEffect } from 'react'
+import callApi from '../../lib/callApi'
+import { Button, List, Statistic } from 'antd'
+import cuid from 'cuid'
+
+const SummaryReport = () => {
+  const initSummary = {
+    Person: 0,
+    Opportunity: { ask: 0, offer: 0 }
+  }
+  const [summary, setSummary] = useState(initSummary)
+  const [resets, setResets] = useState('')
+
+  useEffect(() => {
+    const getSummaryCounts = async () => {
+      const summary = await callApi('reports/summary')
+      setSummary(summary)
+    }
+    getSummaryCounts()
+  }, [resets])
+
+  const stats = [
+    { label: 'People', value: summary.Person },
+    { label: 'Asks', value: summary.Opportunity.ask },
+    { label: 'Offers', value: summary.Opportunity.offer }
+  ]
+
+  return (
+    <FullPage>
+      <h1>Summary Report</h1>
+      {/* <pre>{JSON.stringify(summary, 2)}</pre> */}
+      <List
+        grid={{ gutter: 16, column: 4 }}
+        dataSource={stats}
+        renderItem={item => (
+          <List.Item>
+            <Statistic title={item.label} value={item.value} />
+          </List.Item>
+        )}
+      />
+
+      <Button
+        style={{ marginTop: 16 }}
+        shape='round'
+        type='primary'
+        onClick={() => setResets(cuid())}
+      >
+        Reload
+      </Button>
+    </FullPage>
+  )
+}
+
+export default adminPage(SummaryReport)

--- a/pages/reports/summary.js
+++ b/pages/reports/summary.js
@@ -8,7 +8,9 @@ import cuid from 'cuid'
 const SummaryReport = () => {
   const initSummary = {
     Person: 0,
-    Opportunity: { ask: 0, offer: 0 }
+    Opportunity: { ask: 0, offer: 0 },
+    Interest: 0,
+    Activity: 0
   }
   const [summary, setSummary] = useState(initSummary)
   const [resets, setResets] = useState('')
@@ -24,13 +26,14 @@ const SummaryReport = () => {
   const stats = [
     { label: 'People', value: summary.Person },
     { label: 'Asks', value: summary.Opportunity.ask },
-    { label: 'Offers', value: summary.Opportunity.offer }
+    { label: 'Offers', value: summary.Opportunity.offer },
+    { label: 'Interests', value: summary.Interest },
+    { label: 'Activities', alue: summary.Activity }
   ]
 
   return (
     <FullPage>
       <h1>Summary Report</h1>
-      {/* <pre>{JSON.stringify(summary, 2)}</pre> */}
       <List
         grid={{ gutter: 16, column: 4 }}
         dataSource={stats}


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [?] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Adds `/api/reports/summary` endpoint. This returns MongoDB collection counts for acitvity (scoped by status = active), interest 
2. Adds `/reports/summary` page that consumes the endpoint above to present the summary data in a very simple UI.

## Additional Info.🧐

I have written a unit test for the summary API handler based on the health API. I also attempted to write unit tests for the page, but had trouble figuring out how to convince the test that an administrator was signed in. I attempted to borrow some test setup functions from other tests, which got me into the world of attempting to set up a stub Redux state. It ended up feeling too complicated for the behaviour I was trying to test, but I _would_ like to get this test in if I can have some additional guidance on how to convince the component that an administrator is signed in.

Here is the point I got the test to:

```
import test from 'ava'
import { mountWithIntl } from '../../lib/react-intl-test-helper'
import { act } from 'react-dom/test-utils'
import fetchMock from 'fetch-mock'
import configureStore from 'redux-mock-store'
import withMockRoute from '../../server/util/mockRouter'

import { Provider } from 'react-redux'
import sinon from 'sinon'
import thunk from 'redux-thunk'
import people from '../../server/api/person/__tests__/person.fixture'
import Summary from '../../pages/reports/summary'
import { OpportunityType } from '../../server/api/opportunity/opportunity.constants'

test.before('Setup summary fixture', (t) => {
  const me = people[0]
  t.context.me = me

  t.context.mockStore = configureStore([thunk])(
    {
      session: {
        isAuthenticated: true,
        user: { nickname: me.nickname },
        me
      }
    }
  )

  const summary = {
    Person: 10,
    Opportunity: { [OpportunityType.ASK]: 10, [OpportunityType.OFFER]: 20 },
    Interest: 30,
    Activity: 40
  }

  t.context.summary = summary
})

test.beforeEach(t => {
  t.context.mockServer = fetchMock.sandbox()
  global.fetch = t.context.mockServer
  t.context.cls = console.error
  console.error = sinon.spy()
})

test.afterEach(t => {
  fetchMock.reset()
  console.error = t.context.cls
})

test.serial('render Summary with mocked data', async t => {
  const props = {
    me: t.context.me,
    dispatch: t.context.mockStore.dispatch
  }
  t.context.mockServer.get('end:/api/reports/summary', { body: t.context.summary })
  const RoutedSummaryPage = withMockRoute(Summary)

  const wrapper = mountWithIntl(
    <Provider store={t.context.mockStore}>
      <RoutedSummaryPage {...props} />
    </Provider>
  )

  t.is(wrapper.find('h1').first().text(), 'Summary Report')
  await act() // Wait for hooks to complete
  wrapper.update()

  t.is(wrapper.find('Statistic')[0].prop('label'), 'People')
  t.is(wrapper.find('Statistic')[0].prop('value'), t.context.summary.Person)
  t.is(wrapper.find('Statistic')[1].prop('label'), 'Asks')
  t.is(wrapper.find('Statistic')[1].prop('value'), t.context.summary.Opportunity.ask)
  t.is(wrapper.find('Statistic')[2].prop('label'), 'Offers')
  t.is(wrapper.find('Statistic')[2].prop('value'), t.context.summary.Opportunity.offer)
})
```

## Screenshots 📷
 
![image](https://user-images.githubusercontent.com/292020/77631234-280c2300-6fb1-11ea-97db-5c38aad37695.png)

