### PR TITLE
remove org.category after creating org.role

### DIFF
--- a/x/db/copy-org-category-to-role.js
+++ b/x/db/copy-org-category-to-role.js
@@ -31,8 +31,10 @@ async function main () {
       .cursor()
       .on('data', function (doc) {
         console.log(doc.name, doc.category, doc.role)
-        if (doc.category && !doc.role) {
+        if (doc.category) {
+          console.log('updating role')
           doc.role = doc.category
+          doc.category = undefined
           doc.save()
         }
       })


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Update the script x/db/copy-category-to-role.js to remove the category field once the role field has been created and copied.
