### PR TITLE
VP-1647 make person VOLUNTEER if they belong to a VOLUNTEER_PROVIDER

### DIFF
--- a/server/api/member/__tests__/member.lib.fixtures.js
+++ b/server/api/member/__tests__/member.lib.fixtures.js
@@ -18,7 +18,12 @@ module.exports = {
     {
       name: 'Member of None',
       email: 'test4@example.com'
+    },
+    {
+      name: 'Classic Volunteer',
+      email: 'test5@example.com'
     }
+
   ],
   organisations: [
     {
@@ -34,13 +39,13 @@ module.exports = {
     {
       name: 'Test organisation 3',
       slug: 'test-org-3',
-      role: 'op'
+      role: OrganisationRole.OPPORTUNITY_PROVIDER
 
     },
     {
       name: 'Test organisation 4',
       slug: 'test-org-4',
-      role: 'admin'
+      role: OrganisationRole.ADMIN
 
     }
   ]

--- a/server/api/member/__tests__/member.lib.spec.js
+++ b/server/api/member/__tests__/member.lib.spec.js
@@ -63,6 +63,12 @@ test.beforeEach('Load fixtures', async (t) => {
       organisation: organisations[3]._id,
       validation: 'orgAdmin',
       status: MemberStatus.ORGADMIN
+    },
+    {
+      person: people[4]._id,
+      organisation: organisations[0]._id,
+      validation: 'member',
+      status: MemberStatus.MEMBER
     }
   ]
 
@@ -166,10 +172,19 @@ test.serial('role of person with various memberships.', async (t) => {
   const person = t.context.people[1]
   const [role, orgAdminFor] = await getPersonRoles(person)
   t.is(role.length, 3) // ["opportunityProvider","orgAdmin","admin"]
-  t.is(role[0], 'opportunityProvider') // because org[2] is OP
-  t.is(role[2], 'admin') // because org[3] is admin role
+  t.is(role[0], Role.OPPORTUNITY_PROVIDER) // because org[2] is OP
+  t.is(role[2], Role.ADMIN) // because org[3] is admin role
   t.is(orgAdminFor.length, 1)
   t.deepEqual(orgAdminFor[0], t.context.organisations[3]._id)
+})
+
+test.serial('role generic volunteer.', async (t) => {
+  const person = t.context.people[4]
+  const [role, orgAdminFor] = await getPersonRoles(person)
+  console.log(role)
+  t.is(role.length, 1) // [VOLUNTEER]
+  t.is(role[0], Role.VOLUNTEER) // because org[2] is OP
+  t.is(orgAdminFor.length, 0)
 })
 
 test.serial('roles are sorted and deduplicated', t => {

--- a/server/api/member/member.lib.js
+++ b/server/api/member/member.lib.js
@@ -64,6 +64,7 @@ const findOrgByPersonIdAndRole = async (personId, role) => {
 }
 
 const orgToRoleTable = {
+  [OrganisationRole.VOLUNTEER_PROVIDER]: Role.VOLUNTEER,
   [OrganisationRole.ADMIN]: Role.ADMIN,
   [OrganisationRole.OPPORTUNITY_PROVIDER]: Role.OPPORTUNITY_PROVIDER,
   [OrganisationRole.ACTIVITY_PROVIDER]: Role.ACTIVITY_PROVIDER,


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
When a person signs in we collect their role from the orgs they are members of.  If an org has VOLUNTEER_PROVIDER role add VOLUNTEER to the person's role.

This means that by default new people are not volunteers and cannot make OFFERS.  To do so they must first join a VP org.  this should happen automatically during onboarding when they are asked if they want to volunteer and for which group.
