### PR TITLE
VP-1655 default to asks tab for volunteers, offers tab otherwise.

### DIFF
--- a/components/Act/ActTabs.js
+++ b/components/Act/ActTabs.js
@@ -21,8 +21,8 @@ const actAboutTab =
 
 const actRequestsTab =
   <FormattedMessage
-    id='actTabs.requests'
-    defaultMessage='Requests'
+    id='actTabs.asks'
+    defaultMessage='Asks'
     description='Tab label on ActTabs'
   />
 
@@ -74,10 +74,10 @@ export const ActTabs = ({ act, onChange, canManage, canEdit, defaultTab }) => (
     <TabPane tab={actAboutTab} key='about'>
       <ActAboutPanel act={act} />
     </TabPane>
-    <TabPane tab={actRequestsTab} key='requests'>
+    <TabPane tab={actRequestsTab} key='ask'>
       <ActOpsPanel act={act} type={ASK} />
     </TabPane>
-    <TabPane tab={actOffersTab} key='offers'>
+    <TabPane tab={actOffersTab} key='offer'>
       <ActOpsPanel act={act} type={OFFER} />
 
     </TabPane>

--- a/pages/act/actdetailpage.js
+++ b/pages/act/actdetailpage.js
@@ -37,8 +37,13 @@ export const ActDetailPage = ({
   tags
 }) => {
   const router = useRouter()
-  const [tab, setTab] = useState(isNew ? 'edit' : router.query.tab)
-
+  const [tab, setTab] = useState(
+    isNew
+      ? 'edit'
+      : (router.query.tab
+        ? router.query.tab
+        : me.role.includes(Role.VOLUNTEER) ? 'ask' : 'offer')
+  )
   const updateTab = (key, top) => {
     setTab(key)
     if (top) window.scrollTo(0, 0)


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
on the Activity Detail Page
If person.role.includes(Role.VOLUNTEER) the default tab is asks. 
else default tab is offers.

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
Normal person sees
<img width="924" alt="image" src="https://user-images.githubusercontent.com/1596437/78087905-0088e080-741f-11ea-9e7b-d7eecb001579.png">

volunteer sees
<img width="917" alt="image" src="https://user-images.githubusercontent.com/1596437/78087918-0b437580-741f-11ea-8fe5-db795a250966.png">
