### PR TITLE
VP-1659  CSS clean up on Activity and Op cards

### DIFF
--- a/components/Act/ActAboutPanel.js
+++ b/components/Act/ActAboutPanel.js
@@ -52,7 +52,7 @@ export const ActActivityGuideSection = ({ act }) =>
       </p>
       <ActReadMore act={act} />
       <Link href={`/acts/${act._id}?tab=resources`}>
-        <Button block shape='round' size='large'>
+        <Button shape='round' size='large'>
           <FormattedMessage
             id='ActAboutPanel.button.guide'
             defaultMessage='See all resources'

--- a/components/Act/ActCard.js
+++ b/components/Act/ActCard.js
@@ -14,7 +14,7 @@ const { ASK, OFFER } = OpportunityType
 const ActCard = ({ act, onPress, ...props }) => {
   const cardImage = act.imgUrl ? act.imgUrl : '/static/missingimage.svg'
   return (
-    <Card style={{ minHeight: '22rem' }}>
+    <Card style={{ height: '23rem', overflow: 'auto' }}>
       <Link href={`/acts/${act._id}`}>
         <a>
           <div>
@@ -27,9 +27,11 @@ const ActCard = ({ act, onPress, ...props }) => {
               {act.name}
             </h1>
             <p>{act.subtitle}</p>
-            <p><OpTypeCount counts={act.opCounts} type={ASK} /></p>
-            <p><OpTypeCount counts={act.opCounts} type={OFFER} /></p>
-            <p><OpCommitment duration={act.duration} /></p>
+            <ul>
+              <li><OpTypeCount counts={act.opCounts} type={ASK} /></li>
+              <li><OpTypeCount counts={act.opCounts} type={OFFER} /></li>
+              <li><OpCommitment duration={act.duration} /></li>
+            </ul>
           </figcaption>
         </a>
       </Link>

--- a/components/Act/ActOpsPanel.js
+++ b/components/Act/ActOpsPanel.js
@@ -48,7 +48,7 @@ export const ActOpsPanel = ({ act, type, limit }) => {
           <OpListSmall ops={ops} />
           {showMore &&
             <Link href={`/acts/${act._id}?tab=${type}`}>
-              <Button block shape='round' size='large' style={{ marginTop: '1rem', float: 'right' }}>
+              <Button shape='round' size='large' style={{ marginTop: '1rem', float: 'right' }}>
                 <FormattedMessage
                   id='ActOpsPanel.button.showAll'
                   defaultMessage='See all'

--- a/components/Act/__tests__/ActCard.spec.js
+++ b/components/Act/__tests__/ActCard.spec.js
@@ -26,8 +26,8 @@ test('shallow the card with act', t => {
   t.is((wrapper.find('Link').first().props().href), '/acts/' + act._id)
   t.is(wrapper.find('h1').text(), `<OpStatus />${act.name}`)
   t.is(wrapper.find('img').prop('src'), act.imgUrl)
-  t.is(wrapper.find('figcaption').find('p').at(3).text(), '<OpCommitment />')
-  t.is(wrapper.find('figcaption').find('p').first().text(), `${act.subtitle}`)
+  t.is(wrapper.find('figcaption').find('li').at(0).text(), '<OpTypeCount />')
+  t.is(wrapper.find('figcaption').find('li').at(2).text(), '<OpCommitment />')
 })
 
 test('shallow the card with no pic', t => {

--- a/components/Op/OpAdd.js
+++ b/components/Op/OpAdd.js
@@ -25,7 +25,7 @@ export const OpAddNewBtn = () => {
 
   return (
     <Link href={href}>
-      <Button type='primary' block shape='round' size='large'>
+      <Button type='primary' shape='round' size='large'>
         <FormattedMessage
           id='OpAdd.newAskOffer'
           defaultMessage='New request or offering'
@@ -42,7 +42,7 @@ export const OpAddAskBtn = ({ actid }) => {
   }
   return (
     <Link href={href}>
-      <Button type='primary' block shape='round' size='large'>
+      <Button type='primary' shape='round' size='large'>
         <FormattedMessage
           id='OpAdd.newAsk'
           defaultMessage='Ask for help'
@@ -59,7 +59,7 @@ export const OpAddOfferBtn = ({ actid }) => {
   }
   return (
     <Link href={href}>
-      <Button type='primary' block shape='round' size='large'>
+      <Button type='primary' shape='round' size='large'>
         <FormattedMessage
           id='OpAdd.newOffer'
           defaultMessage='Offer to help'

--- a/components/Op/OpCardSmall.js
+++ b/components/Op/OpCardSmall.js
@@ -19,11 +19,13 @@ const getOpPageURL = (isArchived, opid) => {
 
 const StyledIcon = styled(Icon)`
   font-size: 1rem;
-  margin-right: 0.5rem;
-
- 
+  margin-right: 0.5rem; 
 `
-
+const SingleLineTitle = styled('h2')`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
 // todo if image is not present then use a fallback.
 const OpCardSmall = ({ op }) => {
   const isArchived = op.status === 'completed' || op.status === 'cancelled'
@@ -48,25 +50,23 @@ const OpCardSmall = ({ op }) => {
   // }
 
   return (
-    <SmallCard>
+    <SmallCard style={{ height: '10rem' }}>
       <Link href={getOpPageURL(isArchived, op._id)}>
         <a>
+          <SingleLineTitle>
+            {op.requestor.nickname} <OpType type={op.type} />
+          </SingleLineTitle>
           <SmallOpGrid>
-
             <img src={op.requestor.imgUrl} />
             <figcaption>
               {/* <p>  {op.subtitle}</p> */}
-              <h2>
-                {op.requestor.nickname} <OpType type={op.type} /> <br />
-
-              </h2>
-
-              <p> {startLocation}</p>
-              <p> {startTime} </p>
-              <p> {startDuration}</p>
-
+              <ul>
+                {startLocation && <li> {startLocation}</li>}
+                {startTime && <li> {startTime} </li>}
+                {startDuration && <li> {startDuration}</li>}
+                {op.createdAt && <li>{op.createdAt}</li>}
+              </ul>
               {interestIcon}
-
             </figcaption>
           </SmallOpGrid>
         </a>

--- a/components/VTheme/VTheme.js
+++ b/components/VTheme/VTheme.js
@@ -235,7 +235,7 @@ align-self: center;
 `
 export const SmallOpGrid = styled.div`
 display: grid;
-grid-template-columns: 3rem 1fr;
+grid-template-columns: 4rem 1fr;
 gap: 0.5rem;
 align-items: center;
 `
@@ -733,6 +733,9 @@ a { text-decoration: none; }
 figcaption {
   -webkit-transition: all 0.2s;
   transition: all 0.2s;
+
+  li { list-style: none }
+  ul { padding-left: 0; }
 }
 
 :hover {
@@ -815,12 +818,14 @@ box-shadow: 1px 1px 12px 2px rgba(10,10,10,0.1);
 padding: 1rem;
 border-radius: 8px;
 margin-bottom: 0;
-
+overflow: auto;
 a { text-decoration: none; }
 
 figcaption {
   -webkit-transition: all 0.2s;
   transition: all 0.2s;
+  li { list-style: none }
+  ul { padding-left: 0; }
 }
 
 :hover {
@@ -844,15 +849,13 @@ h2 {
   text-overflow: ellipsis;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   -webkit-transition: all 0.28s;
   transition: all 0.28s;
   font-weight: 700;
   font-size: 20px;
   line-height: 1.4;
-  -webkit-line-clamp: 3;
-
 }
 
 img {
@@ -860,15 +863,13 @@ img {
   -webkit-transition: all 0.2s;
  
   border-radius: 129px;
-  width: 3rem;
-  height: 3rem;
+  width: 4rem;
+  height: 4rem;
  
   background-color: rgba(0, 0, 0, 0);
   object-fit: cover;
   overflow: hidden;
   object-position: top;
-
-
 }
 
 time {


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
Tidy up CSS on activity and small op card.
fix height and overflow of the cards so that they line up even if the text grows.
- worst case scenario the card will scroll internally.

## Screenshots 📷
 
### Original


### Updated
<img width="706" alt="image" src="https://user-images.githubusercontent.com/1596437/78614296-4ed82c80-78c2-11ea-8a0b-e323b3ba1b35.png">

