### PR TITLE
VP-1753 change support links from jira to zendesk

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a Vulnerability
 
 To report a vulnerability that may affect continued operations, denial of service, loss of data etc 
-please file an issue at https://voluntarily.atlassian.net/servicedesk/customer/portal/2
+please file an issue at https://support.voluntarily.nz/hc/en-nz/requests/new?ticket_form_id=360003338734
 
 and follow up with an email to andrew@voluntarily.nz
 

--- a/components/Act/ActCardSuggest.js
+++ b/components/Act/ActCardSuggest.js
@@ -8,7 +8,7 @@ import { Card } from '../VTheme/VTheme'
 const ActCardSuggest = () => {
   return (
     <Card>
-      <a href='https://voluntarily.atlassian.net/servicedesk/customer/portal/2/group/3/create/17' target='_blank' rel='noreferrer noopener'>
+      <a href='https://support.voluntarily.nz/hc/en-nz/requests/new?ticket_form_id=360003338774' target='_blank' rel='noreferrer noopener'>
         <div>
           <img src='/static/img/activity/addActivity.png' />
         </div>

--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -136,7 +136,7 @@ const Footer = () => (
           <MenuWrapper>
 
             <MenuItem><a href='https://blog.voluntarily.nz/get-involved' target='_blank' rel='noopener noreferrer'>Join the build</a></MenuItem>
-            <MenuItem><a href='https://voluntarily.atlassian.net/servicedesk/customer/portal/2/group/3/create/17' target='_blank' rel='noreferrer noopener'>Suggest a Topic</a></MenuItem>
+            <MenuItem><a href='https://support.voluntarily.nz/hc/en-nz/requests/new?ticket_form_id=360003338774' target='_blank' rel='noreferrer noopener'>Suggest a Topic</a></MenuItem>
             <MenuItem>
               <a
                 href='https://voluntarily.statuspage.io'

--- a/components/Header/HeaderMenu.js
+++ b/components/Header/HeaderMenu.js
@@ -73,7 +73,7 @@ const menuItems = [
     key: 'help',
     show: [ANON, AUTH, VOLUNTEER, ADMIN],
     text: 'Support 🙋🏽‍♀️',
-    href: 'https://voluntarily.atlassian.net/servicedesk/customer/portals'
+    href: 'https://support.voluntarily.nz/hc/en-nz'
   },
   {
     key: 'hsignin',

--- a/components/Interest/RegisterInterestMessageForm.js
+++ b/components/Interest/RegisterInterestMessageForm.js
@@ -15,7 +15,7 @@ import { useState } from 'react'
 const showStaySafe = true
 const maxMessageLength = 400
 
-const staySafeUrl = 'https://voluntarily.atlassian.net/servicedesk/customer/portal/2/article/236486718'
+const staySafeUrl = 'https://support.voluntarily.nz/hc/en-nz/articles/360045883573-Keeping-your-info-safe-from-Scammers'
 export const RegisterInterestMessageForm = ({
   visible,
   onSubmit,

--- a/config/clientConfig.js
+++ b/config/clientConfig.js
@@ -23,7 +23,7 @@ const completeConfig = {
       AUTH0_CLIENT_DOMAIN: process.env.AUTH0_CLIENT_DOMAIN || 'voluntarily.au.auth0.com'
     },
     apiVersion: 'v1',
-    knowledgebaseURL: 'https://voluntarily.atlassian.net/servicedesk/customer/portals?q='
+    knowledgebaseURL: 'https://support.voluntarily.nz/hc/en-nz/search?query='
   },
 
   development: {


### PR DESCRIPTION
## I do solemnly swear that I have:
- [ ] Run `npm test` and all the tests pass.
- [ ] Run `npm run lint` and there are no warnings.
- [ ] Not decreased the overall test coverage?
- [ ] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Header menu help link now links to support.voluntarily.nz - zendesk rather than jira.
2. various links to knowledge base pages updated similarly.

3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
