### PR TITLE
VP-1752 remove beta push on alpha build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: V2LY not master
+name: VLY2 test and build
 
 on: [push]
 
@@ -233,14 +233,6 @@ jobs:
         ECR_REPOSITORY: vly-alpha  
       run: |
         aws ecs update-service --service vly-alpha --cluster vly-alpha-ECSCluster --force-new-deployment --desired-count 3 --deployment-configuration maximumPercent=100,minimumHealthyPercent=50
-
-    - name: Deploy Beta to ECS
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: vly-beta  
-      run: |
-        aws ecs update-service --service voluntarily-beta-service --cluster vly-beta --force-new-deployment --desired-count 3 --deployment-configuration maximumPercent=100,minimumHealthyPercent=50
-  
 
   build-and-deploy-beta:
     name: Build to ECR, deploy to ECS


### PR DESCRIPTION
each merge branch should only deploy its own version. 
i.e merge to beta deploys beta.

so remove the deploy to beta from the alpha build