### PR TITLE
VP-1767 if no type param default to ask

### DIFF
--- a/pages/act/actlistpage.js
+++ b/pages/act/actlistpage.js
@@ -38,7 +38,7 @@ const ActListSubTitleMessages = defineMessages({
 
 export const ActListPage = () => {
   const router = useRouter()
-  const type = router.query.type
+  const type = router.query.type || 'ask'
 
   return (
     <FullPage>


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. visiting /asks results in a 500 error. this is the activities page visited with no specific /ask or /offer parameter.  In this case, we should default to asks.
