### PR TITLE
add topic group selection to profile

### DIFF
--- a/components/Act/ActDetailForm.js
+++ b/components/Act/ActDetailForm.js
@@ -667,7 +667,7 @@ class ActDetailForm extends Component {
                 })(
                   <Switch
                     checkedChildren={<Icon type='check' />}
-                    unCheckedChildren={<Icon type='cross' />}
+                    unCheckedChildren={<Icon type='close' />}
                   />)}
               </Form.Item>
 

--- a/components/File/FileUpload.js
+++ b/components/File/FileUpload.js
@@ -160,7 +160,7 @@ class FileUpload extends Component {
   }
 }
 
-FileUpload.PropTypes = {
+FileUpload.propTypes = {
   maxFileSize: PropTypes.number,
   maxNumberOfFiles: PropTypes.number,
   allowedFileTypes: PropTypes.arrayOf(PropTypes.string),

--- a/components/Person/PersonDetail.js
+++ b/components/Person/PersonDetail.js
@@ -14,6 +14,7 @@ import { PersonBadgeSection } from './PersonBadge'
 import { VBanner, VBannerImg, ProfileBannerTitle } from '../VTheme/Profile'
 import Verification from '../Verification/Verification'
 import { ParticipationSection } from './ParticipationSection'
+import { TopicGroupSection } from './TopicGroupSection'
 const DetailItem = styled.div`
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
@@ -74,6 +75,13 @@ const PersonDetail = ({ person, panelEdit, personEdit, canEdit }) => (
           <h2><FormattedMessage defaultMessage='Participation' id='PersonDetail.Participation' description='Participation section header for a person profile' /> </h2>
           <div>
             <ParticipationSection person={person} />
+          </div>
+        </ActivityContainer>
+        <Divider />
+        <ActivityContainer>
+          <h2><FormattedMessage defaultMessage='Follow Groups' id='PersonDetail.TopicGroups' description='TopicGroups section header for a person profile' /> </h2>
+          <div>
+            <TopicGroupSection person={person} />
           </div>
         </ActivityContainer>
         <Divider />

--- a/components/Person/TopicGroupSection.js
+++ b/components/Person/TopicGroupSection.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { SelectTopicGroupButtons } from '../SignUp/SelectTopicGroup'
+import callApi from '../../lib/callApi'
+import reduxApi from '../../lib/redux/reduxApi'
+import { Role } from '../../server/services/authorize/role'
+import { OpportunityType } from '../../server/api/opportunity/opportunity.constants'
+const { ASK, OFFER } = OpportunityType
+
+export const setSession = session => {
+  return {
+    type: 'SET_SESSION',
+    ...session
+  }
+}
+
+export const TopicGroupSection = ({ person }) => {
+  const currentTopicGroups = {
+    business: person.topicGroups.includes('business'),
+    community: person.topicGroups.includes('community'),
+    education: person.topicGroups.includes('education')
+  }
+  const [topicGroups, setTopicGroups] = useState(currentTopicGroups)
+  const session = useSelector(state => state.session)
+  const me = session.me
+  const opType = me.role.includes(Role.VOLUNTEER) ? OFFER : ASK
+  const dispatch = useDispatch()
+  const updatePrefs = async prefs => {
+    const res = await callApi('signUp', 'post', prefs)
+    session.me = res
+    dispatch(setSession(session)) // update the session
+    dispatch(reduxApi.actions.people.get({ id: person._id })) // update the redux person
+  }
+  const handleSelectTopicGroup = async update => {
+    const newtgs = { ...topicGroups, ...update }
+    updatePrefs({ topicGroups: Object.keys(newtgs).filter(key => newtgs[key]) })
+    setTopicGroups(newtgs) // remember this is async and updates the page
+  }
+  return (
+    <SelectTopicGroupButtons
+      type={opType}
+      topicGroups={topicGroups}
+      onChange={handleSelectTopicGroup}
+    />
+  )
+}

--- a/components/Person/__tests__/PersonDetail.spec.js
+++ b/components/Person/__tests__/PersonDetail.spec.js
@@ -116,7 +116,7 @@ test('render person details as self', t => {
 
   )
   t.truthy(wrapper.find('Head'))
-  t.is(wrapper.find('h1').length,3)
+  t.is(wrapper.find('h1').length, 3)
   t.is(wrapper.find('h1').first().text(), t.context.me.name)
   t.is(wrapper.find('h1').at(1).text(), 'How do you want to use Voluntarily?')
   t.is(wrapper.find('h1').at(2).text(), 'What would you like to get help with?')

--- a/components/Person/__tests__/PersonDetail.spec.js
+++ b/components/Person/__tests__/PersonDetail.spec.js
@@ -46,6 +46,7 @@ test.before('Setup People fixtures', (t) => {
     }
   ]
   me.education = 'Some College'
+  me.topicGroups = ['business']
 
   t.context = {
     me,
@@ -115,8 +116,10 @@ test('render person details as self', t => {
 
   )
   t.truthy(wrapper.find('Head'))
+  t.is(wrapper.find('h1').length,3)
   t.is(wrapper.find('h1').first().text(), t.context.me.name)
-  t.is(wrapper.find('h1').last().text(), 'How do you want to use Voluntarily?')
+  t.is(wrapper.find('h1').at(1).text(), 'How do you want to use Voluntarily?')
+  t.is(wrapper.find('h1').at(2).text(), 'What would you like to get help with?')
   t.truthy(wrapper.find(ActivityContainer))
   t.truthy(wrapper.find(VBanner))
   t.is(wrapper.find(ProfileBannerTitle).length, 1)

--- a/components/SignUp/ChooseParticipation.js
+++ b/components/SignUp/ChooseParticipation.js
@@ -51,14 +51,14 @@ export const ChooseParticipationButtons = ({ roleAsk, onChangeAsk, roleOffer, on
 /**
  * This page asks the person to select whether they are an asker or offerer
  */
-export const ChooseParticipation = ({ children, roleAsk, onChangeAsk, roleOffer, onChangeOffer }) =>
+export const ChooseParticipation = (props) =>
   <HalfGrid style={{ paddingTop: 0 }}>
     <div id='leftCol'>
       <img style={{ width: '100%' }} src='/static/img/sign-up/chooseparticipation.svg' />
     </div>
     <div id='rightCol'>
-      <ChooseParticipationButtons />
-      {children}
+      <ChooseParticipationButtons {...props} />
+      {props.children}
     </div>
   </HalfGrid>
 

--- a/components/SignUp/SelectTopicGroup.js
+++ b/components/SignUp/SelectTopicGroup.js
@@ -19,62 +19,70 @@ export const topicGroupMessages = {
     [OFFER]: { id: 'SelectTopicGroup.education.OFFER', defaultMessage: 'Offer your skills and time to students and teachers' }
   })
 }
+
 /**
  * This page asks the person to select whether they are an asker or offerer
  */
-export const SelectTopicGroup = ({ children, type, topicGroups, onChange }) =>
+export const SelectTopicGroupButtons = ({ type, topicGroups, onChange }) =>
+  <>
+    <h1>
+      <OpTypeTopicGroup type={type} />
+    </h1>
+    <ToggleUl id='topicGroup_options'>
+      <ToggleLi key='group_business' icon='business' checked={topicGroups.business} onChange={(on) => onChange({ business: on })}>
+        <div>
+          <h2>
+            <FormattedMessage
+              id='SelectTopicGroup.title.business'
+              defaultMessage='Small Businesses'
+            />
+          </h2>
+          <p>
+            <FormattedMessage {...topicGroupMessages.business[type]} />
+          </p>
+        </div>
+      </ToggleLi>
+      <ToggleLi key='group_community' icon='community' checked={topicGroups.community} onChange={(on) => onChange({ community: on })}>
+        <div>
+          <h2>
+            <FormattedMessage
+              id='SelectTopicGroup.title.community'
+              defaultMessage='Communities'
+            />
+          </h2>
+          <p>
+            <FormattedMessage {...topicGroupMessages.community[type]} />
+          </p>
+        </div>
+      </ToggleLi>
+      <ToggleLi key='group_education' icon='school' checked={topicGroups.education} onChange={(on) => onChange({ education: on })}>
+        <div>
+          <h2>
+            <FormattedMessage
+              id='SelectTopicGroup.title.education'
+              defaultMessage='Schools'
+            />
+          </h2>
+          <p>
+            <FormattedMessage {...topicGroupMessages.education[type]} />
+
+          </p>
+        </div>
+      </ToggleLi>
+    </ToggleUl>
+  </>
+
+/**
+ * This page asks the person to select whether they are an asker or offerer
+ */
+export const SelectTopicGroup = (props) =>
   <HalfGrid style={{ paddingTop: 0 }}>
     <div id='leftCol'>
       <img style={{ width: '100%' }} src='/static/img/sign-up/topic.svg' />
     </div>
     <div id='rightCol'>
-      <h1>
-        <OpTypeTopicGroup type={type} />
-      </h1>
-      <ToggleUl id='topicGroup_options'>
-        <ToggleLi key='group_business' icon='business' checked={topicGroups.business} onChange={(on) => onChange({ business: on })}>
-          <div>
-            <h2>
-              <FormattedMessage
-                id='SelectTopicGroup.title.business'
-                defaultMessage='Small Businesses'
-              />
-            </h2>
-            <p>
-              <FormattedMessage {...topicGroupMessages.business[type]} />
-            </p>
-          </div>
-        </ToggleLi>
-        <ToggleLi key='group_community' icon='community' checked={topicGroups.community} onChange={(on) => onChange({ community: on })}>
-          <div>
-            <h2>
-              <FormattedMessage
-                id='SelectTopicGroup.title.community'
-                defaultMessage='Communities'
-              />
-            </h2>
-            <p>
-              <FormattedMessage {...topicGroupMessages.community[type]} />
-            </p>
-          </div>
-        </ToggleLi>
-        <ToggleLi key='group_education' icon='school' checked={topicGroups.education} onChange={(on) => onChange({ education: on })}>
-          <div>
-            <h2>
-              <FormattedMessage
-                id='SelectTopicGroup.title.education'
-                defaultMessage='Schools'
-              />
-            </h2>
-            <p>
-              <FormattedMessage {...topicGroupMessages.education[type]} />
-
-            </p>
-          </div>
-        </ToggleLi>
-      </ToggleUl>
-      {children}
+      <SelectTopicGroupButtons {...props} />
+      {props.children}
     </div>
-
   </HalfGrid>
 export default SelectTopicGroup

--- a/lang/en.json
+++ b/lang/en.json
@@ -475,6 +475,7 @@
   "PersonDetail.subheading.following": "Following",
   "PersonDetail.subheading.member": "Member of",
   "PersonDetail.subheading.membership": "Organisations",
+  "PersonDetail.TopicGroups": "Follow Groups",
   "PersonDetailForm.Label.education": "Education Level",
   "PersonDetailForm.Label.Location": "In what regions do you want to volunteer",
   "PersonDetailForm.Label.Tags": "Skills & Interests",


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Adds the topic group selection choices to the personal profile page.  these can be set without needing to edit the profile. - just click the ones wanted.

## Additional Info.🧐
Next step is to use these settings in the discover tab

Any additional info goes here

## Screenshots 📷

<img width="1267" alt="image" src="https://user-images.githubusercontent.com/1596437/80059084-236e6680-857f-11ea-90d9-c68edf63772d.png">
