### PR TITLE
Vp 1644 show volunteer status

### DIFF
--- a/components/Member/__tests__/MemberSection.spec.js
+++ b/components/Member/__tests__/MemberSection.spec.js
@@ -95,7 +95,7 @@ test.serial('followers can become members and then be removed', async t => {
   membersSection = wrapper.find('section').at(2)
   t.is(membersSection.find('tbody tr').length, 2)
   const member2 = membersSection.find('tbody tr').at(1)
-  t.is(member2.find('td').at(MTF.NAME).text().trim(), firstFollower.person.nickname)
+  t.regex(member2.find('td').at(MTF.NAME).text().trim(), new RegExp(firstFollower.person.nickname))
 
   // test Remove button
   const removeButton = member2.find('button').first()
@@ -167,7 +167,7 @@ test.serial('joiners can become members ', async t => {
   membersSection = wrapper.find('section').at(2)
   t.is(membersSection.find('tbody tr').length, memberCount + 1)
   const member2 = membersSection.find('tbody tr').at(1)
-  t.is(member2.find('td a span').at(MTF.NAME).text(), firstJoiner.person.nickname)
+  t.regex(member2.find('td a span').at(MTF.NAME).text(), new RegExp(firstJoiner.person.nickname))
 
   // one joiner left
   joinersSection = wrapper.find('section').at(1)
@@ -176,7 +176,7 @@ test.serial('joiners can become members ', async t => {
   const orgValidators = orgMembers.filter(member => member.status === MemberStatus.VALIDATOR)
   const firstValidator = orgValidators[0]
 
-  t.is(firstJoinerRow.find('td').at(MTF.NAME).text().trim(), firstValidator.person.nickname)
+  t.regex(firstJoinerRow.find('td').at(MTF.NAME).text().trim(), new RegExp(firstValidator.person.nickname))
   t.is(firstJoinerRow.find('td').at(MTF.STATUS).text(), MemberStatus.VALIDATOR)
 
   // test Reject button

--- a/components/Person/PersonRole.js
+++ b/components/Person/PersonRole.js
@@ -1,19 +1,36 @@
 import { FormattedMessage } from 'react-intl'
 import styled from 'styled-components'
+import { Popover } from 'antd'
 
 // converts a person role to a translated string
 export const PersonRole = ({ role }) => {
   const roleOptions = {
     admin: <FormattedMessage id='admin' defaultMessage='Admin' />,
     orgAdmin: <FormattedMessage id='orgAdmin' defaultMessage='Organisation-Admin' />,
-    opportunityProvider: <FormattedMessage id='opportunityProvider' defaultMessage='Make Requests' />,
-    basic: <FormattedMessage id='basic' defaultMessage='Ask' />,
-    volunteer: <FormattedMessage id='volunteer' defaultMessage='Offer' />,
+    // opportunityProvider: <FormattedMessage id='opportunityProvider' defaultMessage='Make Requests' />,
+    basic: <FormattedMessage id='basic' defaultMessage='Asker' />,
+    volunteer: <FormattedMessage id='volunteer' defaultMessage='Volunteer' />,
     activityProvider: <FormattedMessage id='activityProvider' defaultMessage='Activity Provider' />,
     resourceProvider: <FormattedMessage id='resourceProvider' defaultMessage='Resource Provider' />,
-    support: <FormattedMessage id='test' defaultMessage='Test' />
+    support: <FormattedMessage id='support' defaultMessage='Help Desk' />
   }
-  return roleOptions[role] || role
+  return roleOptions[role] || null
+}
+
+// converts a person role to a translated string
+const roleIcons = {
+  admin: '🌟',
+  orgAdmin: '⭐',
+  support: '💁',
+  activityProvider: '🧑‍💻',
+  resourceProvider: '🧑‍💻',
+  volunteer: '🤙', // 🤝,
+  basic: '🙋'
+  // opportunityProvider: '🤝'
+}
+
+export const PersonRoleIcon = ({ role }) => {
+  return roleIcons[role] || null
 }
 
 const RoleSpan = styled.span`
@@ -27,12 +44,31 @@ const RoleSpan = styled.span`
   }
 `
 
-const PersonRoles = ({ roles }) =>
+export const PersonRoles = ({ roles }) =>
   roles
     ? (
       <>
-        {roles.map(role => <RoleSpan key={role}><PersonRole role={role} /></RoleSpan>)}
+        {roles.map(role =>
+          roleIcons[role] &&
+            <RoleSpan key={role}>
+              <PersonRoleIcon role={role} /><PersonRole role={role} />
+            </RoleSpan>)}
       </>)
     : null
 
+const RoleBadge = styled.span`
+  background-color: #fff;
+  border: solid 1px #a08db8;
+  border-radius: 100%;
+  padding: 0.2rem ;
+  margin-left: 0.5rem;
+`
+export const PersonRoleIcons = ({ roles }) => {
+  const key = Object.keys(roleIcons).find(role => roles.includes(role))
+  return (key &&
+    <Popover content={<PersonRoles roles={roles} />} title='Role' trigger='hover'>
+      <RoleBadge>{roleIcons[key]}</RoleBadge>
+    </Popover>
+  )
+}
 export default PersonRoles

--- a/components/Person/__tests__/PersonRole.spec.js
+++ b/components/Person/__tests__/PersonRole.spec.js
@@ -4,8 +4,8 @@ import PersonRoles, { PersonRole } from '../PersonRole'
 import { renderWithIntl } from '../../../lib/react-intl-test-helper'
 
 test('Person Role renders properly', t => {
-  t.is(renderWithIntl(<PersonRole role='volunteer' />).text(), 'Offer')
-  t.is(renderWithIntl(<PersonRole role='support' />).text(), 'Test')
+  t.is(renderWithIntl(<PersonRole role='volunteer' />).text(), 'Volunteer')
+  t.is(renderWithIntl(<PersonRole role='support' />).text(), 'Help Desk')
 })
 
 test('Person Role list renders properly', t => {
@@ -15,8 +15,8 @@ test('Person Role list renders properly', t => {
     'activityProvider'
   ]
   const wrapper = renderWithIntl(<PersonRoles roles={roles} />)
-  t.is(wrapper.find('span').first().text(), 'Offer')
-  t.is(wrapper.find('span').last().text(), 'Activity Provider')
+  t.regex(wrapper.find('span').first().text(), /Volunteer/)
+  t.regex(wrapper.find('span').last().text(), /Activity Provider/)
 })
 
 test('Person Role list renders blank when given no roles', t => {
@@ -24,10 +24,10 @@ test('Person Role list renders blank when given no roles', t => {
   t.is(wrapper.text(), '')
 })
 
-test('Person Role list renders given role when its an unknown role', t => {
+test('Person Role list renders nothing when its an unknown role', t => {
   const roles = [
     'author'
   ]
   const wrapper = renderWithIntl(<PersonRoles roles={roles} />)
-  t.is(wrapper.text(), 'author')
+  t.is(wrapper.text(), '')
 })

--- a/components/VTheme/AvatarProfileLink.js
+++ b/components/VTheme/AvatarProfileLink.js
@@ -2,7 +2,7 @@ import { Avatar } from 'antd'
 import React from 'react'
 import Link from 'next/link'
 import Router from 'next/router'
-
+import { PersonRoleIcons } from '../Person/PersonRole'
 export function AvatarProfile ({ person }) {
   if (!person) return null
   return (
@@ -12,10 +12,11 @@ export function AvatarProfile ({ person }) {
           size='large'
           shape='round'
           onClick={() => Router.push(`/people/${person._id}`)}
-          src={person.imgUrlSm}
+          src={person.imgUrl}
           icon='user'
         />&nbsp;&nbsp;
         <span>{person.nickname}</span>
+        <PersonRoleIcons roles={person.role} />
       </a>
     </Link>
   )

--- a/lang/en.json
+++ b/lang/en.json
@@ -71,7 +71,7 @@
   "admin-page.access-denied.heading": "Access denied",
   "AllDone.title": "You are ready to go",
   "askforhelp-anon": "Ask for help",
-  "basic": "Ask",
+  "basic": "Asker",
   "Button.AcceptAndContinue": "Accept and Continue",
   "Button.Back": "Back",
   "Button.editSaveDraft": "Save as draft",
@@ -366,7 +366,6 @@
   "OpOfferForm.Tags": "Tags",
   "OpOfferForm.Title": "Title",
   "OpOfferForm.Venue": "Address",
-  "opportunityProvider": "Make Requests",
   "OpportunityStatus.active": "Active",
   "OpportunityStatus.completed": "Completed",
   "OpportunityStatus.draft": "Draft",
@@ -566,13 +565,13 @@
   "storyDescription": "Description",
   "storyName": "Title",
   "storyUpdate": "Check here for updates about this activity",
+  "support": "Help Desk",
   "TakeSupportSection.ask": "See all activities",
   "TeacherRegistrationRecord.Category": "Category",
   "TeacherRegistrationRecord.Expiry": "Expiry",
   "TeacherRegistrationRecord.name": "Name",
   "TeacherRegistrationRecord.registrationNumber": "Registration Number",
   "TeacherRegistrationRecord.title": "Teacher Registration Record",
-  "test": "Test",
   "test-person.notavailable": "Sorry, this person is not available",
   "unverified.button": "Sign out and try again",
   "unverified.message": "\n  <h1>Email not verified</h1>\n  <p>You have signed in as {name} but your email account is not currently verified. </p>\n  <p>Please check your email inbox and spam box for a verification request to complete the registration process. </p>\n  <p>If problems continue please contact technical support.</p>",
@@ -584,5 +583,5 @@
   "verification.trustandsafety.confirmation": "Verify Identity",
   "VerifyButton.label": "Verify Identity",
   "version": "Version",
-  "volunteer": "Offer"
+  "volunteer": "Volunteer"
 }

--- a/server/api/interest/interest.controller.js
+++ b/server/api/interest/interest.controller.js
@@ -35,7 +35,7 @@ const listInterestsA = InterestModel => async (req, res) => {
 
     if (req.query.op) {
       find.opportunity = req.query.op
-      populateList.push({ path: 'person', select: 'nickname name imgUrl email website phone job placeOfWork' })
+      populateList.push({ path: 'person', select: 'nickname name imgUrl role email website phone job placeOfWork' })
     }
 
     if (req.query.me) {


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. When we show a person's avatar (pic + name) this is now followed by an icon indicating their volunteer status (role).  
2. If the person has multiple roles we rank them and show the highest in order
basic, volunteer, orgadmin, help desk, admin
3. on hover a popover shows to list all the roles with icon and labels.

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
basic volunteer
<img width="817" alt="image" src="https://user-images.githubusercontent.com/1596437/80561417-86a54080-8a38-11ea-8cf1-f6213ccd36d6.png">

admin
<img width="370" alt="image" src="https://user-images.githubusercontent.com/1596437/80561426-93299900-8a38-11ea-9dd1-02f63a6fc199.png">

hover detail
<img width="843" alt="image" src="https://user-images.githubusercontent.com/1596437/80561439-9ae93d80-8a38-11ea-9df0-37c9d959aee5.png">
