### PR TITLE
VP-1789 ensure people data have role included

### DIFF
--- a/components/VTheme/AvatarProfileLink.js
+++ b/components/VTheme/AvatarProfileLink.js
@@ -16,7 +16,7 @@ export function AvatarProfile ({ person }) {
           icon='user'
         />&nbsp;&nbsp;
         <span>{person.nickname}</span>
-        <PersonRoleIcons roles={person.role} />
+        {person.role && <PersonRoleIcons roles={person.role} />}
       </a>
     </Link>
   )

--- a/server/api/interest/interest.lib.js
+++ b/server/api/interest/interest.lib.js
@@ -18,7 +18,7 @@ const personInterestCountA = InterestSchema => (personId) => {
 const personInterestCount = personInterestCountA(Interest)
 const personInterestArchiveCount = personInterestCountA(InterestArchive)
 
-const personFields = 'name nickname email imgUrl pronoun sendEmailNotifications'
+const personFields = 'name nickname email role imgUrl pronoun sendEmailNotifications'
 
 const getInterestDetailA = InterestSchema => async (interestID) => {
   // Get the interest and populate out key information needed for emailing

--- a/server/api/member/member.controller.js
+++ b/server/api/member/member.controller.js
@@ -19,7 +19,7 @@ const listMembers = async (req, res) => {
 
     if (req.query.orgid) {
       find.organisation = req.query.orgid
-      populateList.push({ path: 'person', select: 'nickname name imgUrl email phone sendEmailNotifications' })
+      populateList.push({ path: 'person', select: 'nickname name imgUrl role email phone sendEmailNotifications' })
       populateList.push({ path: 'organisation', select: 'name imgUrl groups role' })
     }
 

--- a/server/api/member/member.lib.js
+++ b/server/api/member/member.lib.js
@@ -8,7 +8,7 @@ const { OrganisationRole } = require('../organisation/organisation.constants')
 /* get a single member record with org and person populated out */
 const getMemberbyId = id => {
   return Member.findOne({ _id: id })
-    .populate({ path: 'person', select: 'nickname name imgUrl email sendEmailNotifications' })
+    .populate({ path: 'person', select: 'nickname name imgUrl role email sendEmailNotifications' })
     .populate({ path: 'organisation', select: 'name imgUrl role' })
     .exec()
 }


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. The updated PersonAvatar now uses the role value to illustrate the volunteer status of a person. This role needs to be in the data obtained for both interests and membership lists.  the populate sections of these controllers did not include role so the component fails to display. 

2. also the component now checks if role is present before using it.

2. 
3. 

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
