### PR TITLE
VP-1785: allow signup modal to be cancelled

### DIFF
--- a/components/Act/ActAboutPanel.js
+++ b/components/Act/ActAboutPanel.js
@@ -67,8 +67,9 @@ export function ActAboutPanel ({ act }) {
   const appUrl = `${config.appUrl}/acts/act._id`
   const me = useSelector(state => state.session.me)
 
-  const vp = me.role.includes(Role.VOLUNTEER)
-  const bp = me.role.includes(Role.BASIC)
+  const isAnon = me.role.includes(Role.ANON)
+  const vp = me.role.includes(Role.VOLUNTEER) || isAnon
+  const bp = me.role.includes(Role.BASIC) || isAnon
   return (
     <ProfilePanel>
       <ActAboutSection act={act} />

--- a/components/SignUp/SignUpInviteModal.js
+++ b/components/SignUp/SignUpInviteModal.js
@@ -30,6 +30,9 @@ export const SignUpInviteModal = ({ children, href }) => {
   const handleClick = () => {
     setShowModal(true)
   }
+  const handleCancel = () => {
+    setShowModal(false)
+  }
   return (
     <>
       <Button type='primary' shape='round' size='large' style={{ width: '10rem' }} onClick={handleClick}>
@@ -43,6 +46,7 @@ export const SignUpInviteModal = ({ children, href }) => {
           <SignUpButton key='sign-up' then='/flow/postSignUp' />,
           <SignInButton key='sign-in' then={href} />
         ]}
+        onCancel={handleCancel}
       >
         <FormattedMessage
           id='SignUpModal.body'


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Add a cancel handler to `SignUpInviteModal`, allowing it to be closed.
2. Show Ask/Offer help buttons if not logged in (per discussion with @avowkind )
