### PR TITLE
VP-1687: count only active ops

### DIFF
--- a/server/api/activity/__tests__/activity.lib.spec.js
+++ b/server/api/activity/__tests__/activity.lib.spec.js
@@ -58,7 +58,7 @@ test.before('before connect to database', async (t) => {
   t.context.ops = await Promise.all(t.context.activities.map(act => {
     const activeOps = Array(activeCount).fill({}).map(i => makeActiveOp(act, i))
     const draftOps = Array(draftCount).fill({}).map(i => makeDraftOp(act, i))
-    return Opportunity.create([ ...activeOps, ...draftOps ])
+    return Opportunity.create([...activeOps, ...draftOps])
   }))
 })
 

--- a/server/api/activity/__tests__/activity.lib.spec.js
+++ b/server/api/activity/__tests__/activity.lib.spec.js
@@ -17,6 +17,28 @@ export const gra = (min, max) => { return (Math.round(Math.random() * (max - min
 export const coin = (a, b) => { return gra(0, 1) ? a : b }
 
 const opCount = 10
+const draftCount = 5
+const activeCount = opCount - draftCount
+
+const makeOp = (opStatus) => (fromActivity, index) => {
+  return ({
+    name: `${fromActivity.name} Opportunity ${cuid}`,
+    imgUrl: fromActivity.imgUrl,
+    subtitle: fromActivity.subtitle,
+    description: fromActivity.description,
+    duration: fromActivity.duration,
+    location: 'Northland',
+    type: coin(OpportunityType.ASK, OpportunityType.OFFER),
+    status: opStatus,
+    fromActivity: fromActivity._id,
+    // offerOrg: fromActivity.offerOrg._id,
+    requestor: fromActivity.owner._id,
+    tags: ['one']
+  })
+}
+
+const makeActiveOp = makeOp(OpportunityStatus.ACTIVE)
+const makeDraftOp = makeOp(OpportunityStatus.DRAFT)
 
 test.before('before connect to database', async (t) => {
   t.context.memMongo = new MemoryMongo()
@@ -34,31 +56,15 @@ test.before('before connect to database', async (t) => {
   t.context.activities = await Activity.create(acts)
   // create some ops from the act - we only care about type and fromAct
   t.context.ops = await Promise.all(t.context.activities.map(act => {
-    const ops = Array(opCount).fill({}).map(i => makeOp(act, i))
-    return Opportunity.create(ops)
+    const activeOps = Array(activeCount).fill({}).map(i => makeActiveOp(act, i))
+    const draftOps = Array(draftCount).fill({}).map(i => makeDraftOp(act, i))
+    return Opportunity.create([ ...activeOps, ...draftOps ])
   }))
 })
 
 test.after.always(async (t) => {
   await t.context.memMongo.stop()
 })
-
-const makeOp = (fromActivity, index) => {
-  return ({
-    name: `${fromActivity.name} Opportunity ${cuid}`,
-    imgUrl: fromActivity.imgUrl,
-    subtitle: fromActivity.subtitle,
-    description: fromActivity.description,
-    duration: fromActivity.duration,
-    location: 'Northland',
-    type: coin(OpportunityType.ASK, OpportunityType.OFFER),
-    status: OpportunityStatus.ACTIVE,
-    fromActivity: fromActivity._id,
-    // offerOrg: fromActivity.offerOrg._id,
-    requestor: fromActivity.owner._id,
-    tags: ['one']
-  })
-}
 
 test.serial('verify fixture database has acts and ops', async t => {
   const count = await Activity.countDocuments()
@@ -79,6 +85,6 @@ test.serial('verify fixture database has acts and ops', async t => {
   // can find active ops
   await Promise.all(t.context.activities.map(async act => {
     const counts = await getOpsForActivity(act._id)
-    t.is(counts.ask + counts.offer, opCount)
+    t.is(counts.ask + counts.offer, activeCount)
   }))
 })

--- a/server/api/activity/__tests__/activity.lib.spec.js
+++ b/server/api/activity/__tests__/activity.lib.spec.js
@@ -52,7 +52,7 @@ const makeOp = (fromActivity, index) => {
     duration: fromActivity.duration,
     location: 'Northland',
     type: coin(OpportunityType.ASK, OpportunityType.OFFER),
-    status: coin(OpportunityStatus.DRAFT, OpportunityStatus.ACTIVE),
+    status: OpportunityStatus.ACTIVE,
     fromActivity: fromActivity._id,
     // offerOrg: fromActivity.offerOrg._id,
     requestor: fromActivity.owner._id,
@@ -76,6 +76,7 @@ test.serial('verify fixture database has acts and ops', async t => {
   const countOps = await Opportunity.countDocuments()
   t.is(countOps, opCount * t.context.activities.length)
 
+  // can find active ops
   await Promise.all(t.context.activities.map(async act => {
     const counts = await getOpsForActivity(act._id)
     t.is(counts.ask + counts.offer, opCount)

--- a/server/api/activity/activity.lib.js
+++ b/server/api/activity/activity.lib.js
@@ -1,6 +1,6 @@
 const Activity = require('./activity')
 const Opportunity = require('../opportunity/opportunity')
-const { OpportunityType } = require('../opportunity/opportunity.constants')
+const { OpportunityStatus, OpportunityType } = require('../opportunity/opportunity.constants')
 
 const findActivity = async (req, res) => {
   // filter by role if present  e.g /my/org/vp
@@ -20,8 +20,8 @@ const findActivity = async (req, res) => {
   */
 const getOpsForActivity = async (actid) => {
   const counts = {
-    [OpportunityType.ASK]: await Opportunity.countDocuments({ fromActivity: actid, type: OpportunityType.ASK }),
-    [OpportunityType.OFFER]: await Opportunity.countDocuments({ fromActivity: actid, type: OpportunityType.OFFER })
+    [OpportunityType.ASK]: await Opportunity.countDocuments({ fromActivity: actid, type: OpportunityType.ASK, status: OpportunityStatus.ACTIVE }),
+    [OpportunityType.OFFER]: await Opportunity.countDocuments({ fromActivity: actid, type: OpportunityType.OFFER, status: OpportunityStatus.ACTIVE })
   }
   return counts
 }


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. `getOpsForActivity` should not include DRAFT status ops in its count.
