### PR TITLE
VP-1805: Expose mongo port, name containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,30 @@
 version: '3.4'
 services:
-  web:
+  voluntarily-web:
+    container_name: voluntarily-web
     build:
       context: ./
       # dockerfile: x/docker/Dockerfile
       target: development
     depends_on:
-      - db
+      - voluntarily-mongodb
     ports:
       - "${WEB_PORT:-3122}:3122"
     volumes:
       - .:/usr/src/app
     environment:
       NODE_ENV: development
-      MONGODB_URI: mongodb://db:27017/vly-dev
+      MONGODB_URI: mongodb://voluntarily-mongodb:27017/vly-dev
     stdin_open: true
     tty: true
-  db:
+
+  voluntarily-mongodb:
+    container_name: voluntarily-mongodb
     image: mongo:latest
     volumes:
       - dbdata:/data/db
+    ports:
+      - 27017:27017
+
 volumes:
   dbdata:


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Exposes the default mongo port, allowing scripts and external browsers to connect.
2. Names `web` and `db` to something a bit more specific, in case devs have multiple docker containers to content with!