### PR TITLE
VP-1726 add end to end test launcher to admin page

### DIFF
--- a/__tests__/admin/admin.spec.js
+++ b/__tests__/admin/admin.spec.js
@@ -114,3 +114,12 @@ test.serial('Load invite school page as authenticated', async (t) => {
 
   t.truthy(response.text.includes('<h1>Access denied</h1><p>You do not have permission to view this page.</p>'))
 })
+
+// TEST
+test.serial('Load admin/test page as admin', async (t) => {
+  const response = await request(server)
+    .get('/admin/test')
+    .set('Cookie', [`idToken=${sessions[0].idToken}`])
+
+  t.is(response.status, 200, 'Should be allowed to view page')
+})

--- a/lang/en.json
+++ b/lang/en.json
@@ -550,6 +550,7 @@
   "registerTeacher.methods": "You can validate as a teacher using your teacher registration number:",
   "resourceProvider": "Resource Provider",
   "revision": "local-build",
+  "runTestTitle": "End-To-End Testing",
   "savePerson": "Save",
   "schoolInvite.mainHeading": "Invite school",
   "search.title": "Search results for \"{search}\"",

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -16,6 +16,11 @@ export const AdminPage = () =>
           <a>Goal Cards</a>
         </Link>
       </li>
+      <li>
+        <Link href='/admin/test'>
+          <a>E2E Testing Launcher</a>
+        </Link>
+      </li>
     </ul>
 
   </FullPage>

--- a/pages/admin/test.js
+++ b/pages/admin/test.js
@@ -1,0 +1,33 @@
+import { Helmet } from 'react-helmet'
+import { Button, message } from 'antd'
+import { FormattedMessage } from 'react-intl'
+import { FullPage, Section } from '../../components/VTheme/VTheme'
+import adminPage from '../../hocs/adminPage'
+import fetch from 'isomorphic-fetch'
+
+const TestPage = () => {
+  const handleRunTest = async () => {
+    try {
+      await fetch('/api/xadmin/runTest')
+      message.success('done')
+    } catch (e) { console.error('handleRunTest Failed', e) }
+  }
+
+  return (
+    <FullPage>
+      <Helmet>
+        <title>Voluntarily - E2E Testing</title>
+      </Helmet>
+      <h1>
+        <FormattedMessage id='runTestTitle' defaultMessage='End-To-End Testing' description='title on Test index page' />
+      </h1>
+      <Section>
+        <h2>Run Test</h2>
+        <p>Each run creates a result test cycle and can tell you where the test failed.</p>
+        <Button shape='round' type='primary' onClick={handleRunTest}>Run Test</Button>
+      </Section>
+    </FullPage>
+  )
+}
+
+export default adminPage(TestPage)

--- a/pages/api/xadmin/runTest.js
+++ b/pages/api/xadmin/runTest.js
@@ -1,0 +1,20 @@
+import fetch from 'isomorphic-fetch'
+import { Role } from '../../../server/services/authorize/role.js'
+
+export default async (req, res) => {
+  // person must be authenticated administrator
+  if (!req.session ||
+    !req.session.isAuthenticated ||
+    !req.session.me.role.includes(Role.ADMIN)) {
+    return res.status(403).end()
+  }
+
+  const e2eTestUrl = 'https://ci.getskills.co.nz/job/voluntarily-alpha-auto-nimbal/buildWithParameters?token=11807fa12c68f4d8651de26ae1cf54baea&parameters=@signin'
+  try {
+    await fetch(e2eTestUrl)
+    return res.json({ status: 'OK' })
+  } catch (e) {
+    console.error('problem with end to end test:', e)
+    return res.status(400).json(e)
+  }
+}


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Added a test button to the admin page
2. Added a button to the admin/test page to call external url to run automated tests.

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
![image](https://user-images.githubusercontent.com/47195725/82405017-debee800-9ab6-11ea-8cc7-3ce8f5ecd33d.png)
![image](https://user-images.githubusercontent.com/47195725/82405056-f9915c80-9ab6-11ea-8987-29c06b6fd166.png)

