### PR TITLE
VP-1814 Entered Op address is not held in the op record and is not shown in the editor later

### DIFF
--- a/components/Op/OpShortForm.js
+++ b/components/Op/OpShortForm.js
@@ -45,6 +45,11 @@ class OpShortForm extends Component {
           op.duration = values.duration
           op.locations = [values.city, values.region]
           delete op.location
+          op.address = values.address
+          op.suburb = values.suburb
+          op.city = values.city
+          op.postcode = values.postcode
+          op.region = values.region
           op.offerOrg = values.offerOrg && values.offerOrg.key
           op.description = values.description
           // op.imgUrl = values.imgUrl
@@ -156,7 +161,11 @@ export default Form.create({
       // subtitle: Form.createFormField({ value: op.subtitle }),
       description: Form.createFormField({ value: op.description }),
       duration: Form.createFormField({ value: op.duration }),
-      locations: Form.createFormField({ value: op.locations }),
+      address: Form.createFormField({ value: op.address }),
+      suburb: Form.createFormField({ value: op.suburb }),
+      city: Form.createFormField({ value: op.city }),
+      postcode: Form.createFormField({ value: op.postcode }),
+      region: Form.createFormField({ value: (op.locations)[0] }),
       offerOrg: Form.createFormField({ value: { key: op.offerOrg ? op.offerOrg._id : '' } }),
       // imgUrl: Form.createFormField({ value: op.imgUrl }),
       // status: Form.createFormField({ value: op.status }),

--- a/server/api/opportunity/opportunity.js
+++ b/server/api/opportunity/opportunity.js
@@ -34,6 +34,11 @@ const opportunitySchema = new Schema({
   duration: String, // "15 Minutes",
   location: String, // region or city,  deprecated - use locations array
   locations: { type: [String], default: [] }, // list of places where Op is of interest region or city,
+  address: String,
+  suburb: String,
+  city: String,
+  postcode: String,
+  region: String,
   venue: String, // actual address
   date: [Date], // start and optional end dates
   fromActivity: { type: Schema.Types.ObjectId, ref: 'Activity', required: false },


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Preserved address-related fields into the Opportunity Collection so that they can be reloaded.

## Additional Info.🧐

Any additional info goes here

## Screenshots 📷
 
### Original


### Updated
