### PR TITLE
VP-1842: Summary endpoint for the statistics API

### DIFF
--- a/server/api/statistics/__tests__/statistics.fixture.js
+++ b/server/api/statistics/__tests__/statistics.fixture.js
@@ -1,0 +1,239 @@
+import mongoose from "mongoose";
+import moment from "moment";
+
+const generateObjectId = mongoose.Types.ObjectId;
+
+const firstOrgId = generateObjectId();
+
+const organisations = [
+  {
+    _id: firstOrgId,
+    name: "Volunteer Provider 1",
+    slug: "volunteer-provider-1",
+    role: ["vp"],
+  },
+  {
+    _id: generateObjectId(),
+    name: "Volunteer Provider 2",
+    slug: "volunteer-provider-2",
+    role: ["vp"],
+  },
+];
+
+const people = [
+  {
+    // 0
+    _id: generateObjectId(),
+    name: "Volunteer 1",
+    email: "volunteer.1@example.com",
+    role: ["volunteer"],
+  },
+  {
+    // 1
+    _id: generateObjectId(),
+    name: "Volunteer 2",
+    email: "volunteer.2@example.com",
+    role: ["volunteer"],
+  },
+  {
+    // 2
+    _id: generateObjectId(),
+    name: "Volunteer 3",
+    email: "volunteer.3@example.com",
+    role: ["volunteer"],
+  },
+  {
+    // 3
+    _id: generateObjectId(),
+    name: "requestor",
+    email: "requestor@example.com",
+    role: ["volunteer"],
+  },
+];
+
+// Two members from the same organisation and one member in another organisation
+const members = [
+  {
+    _id: generateObjectId(),
+    status: "orgadmin",
+    person: people[0]._id,
+    organisation: firstOrgId,
+  },
+  {
+    _id: generateObjectId(),
+    status: "member",
+    person: people[1]._id,
+    organisation: firstOrgId,
+  },
+  {
+    _id: generateObjectId(),
+    status: "member",
+    person: people[2]._id,
+    organisation: organisations[1]._id,
+  },
+];
+
+const sixMonthsAgo = moment().subtract(6, "months").toDate();
+const threeYearsAgo = moment().subtract(3, "years").toDate();
+
+// Each member has an interest in four opportunities
+const archivedOpportunities = [
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT2H20M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT1H20M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT3H",
+  },
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT25M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT1H50M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "P1DT2H20M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "P1DT1H20M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT3H20M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [sixMonthsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT1H10M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [threeYearsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT5H20M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [threeYearsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT6H20M",
+  },
+  {
+    _id: generateObjectId(),
+    date: [threeYearsAgo, null],
+    requestor: people[3]._id,
+    duration: "PT7H20M",
+  },
+];
+
+// Each member attends 2 opporunities in the last six months, attends 1 in the last three
+// years and 1 not attended
+const interestArchives = [
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[0].person,
+    opportunity: archivedOpportunities[0]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[0].person,
+    opportunity: archivedOpportunities[1]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "not_attended",
+    person: members[0].person,
+    opportunity: archivedOpportunities[2]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[0].person,
+    opportunity: archivedOpportunities[9]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[1].person,
+    opportunity: archivedOpportunities[3]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[1].person,
+    opportunity: archivedOpportunities[4]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "not_attended",
+    person: members[1].person,
+    opportunity: archivedOpportunities[5]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[1].person,
+    opportunity: archivedOpportunities[10]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[2].person,
+    opportunity: archivedOpportunities[6]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[2].person,
+    opportunity: archivedOpportunities[7]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "not_attended",
+    person: members[2].person,
+    opportunity: archivedOpportunities[8]._id,
+  },
+  {
+    _id: generateObjectId(),
+    status: "attended",
+    person: members[2].person,
+    opportunity: archivedOpportunities[11]._id,
+  },
+];
+
+module.exports = {
+  firstOrgId,
+  organisations,
+  people,
+  members,
+  archivedOpportunities,
+  interestArchives,
+};

--- a/server/api/statistics/__tests__/statistics.fixture.js
+++ b/server/api/statistics/__tests__/statistics.fixture.js
@@ -1,80 +1,80 @@
-import mongoose from "mongoose";
-import moment from "moment";
+import mongoose from 'mongoose'
+import moment from 'moment'
 
-const generateObjectId = mongoose.Types.ObjectId;
+const generateObjectId = mongoose.Types.ObjectId
 
-const firstOrgId = generateObjectId();
+const firstOrgId = generateObjectId()
 
 const organisations = [
   {
     _id: firstOrgId,
-    name: "Volunteer Provider 1",
-    slug: "volunteer-provider-1",
-    role: ["vp"],
+    name: 'Volunteer Provider 1',
+    slug: 'volunteer-provider-1',
+    role: ['vp']
   },
   {
     _id: generateObjectId(),
-    name: "Volunteer Provider 2",
-    slug: "volunteer-provider-2",
-    role: ["vp"],
-  },
-];
+    name: 'Volunteer Provider 2',
+    slug: 'volunteer-provider-2',
+    role: ['vp']
+  }
+]
 
 const people = [
   {
     // 0
     _id: generateObjectId(),
-    name: "Volunteer 1",
-    email: "volunteer.1@example.com",
-    role: ["volunteer"],
+    name: 'Volunteer 1',
+    email: 'volunteer.1@example.com',
+    role: ['volunteer']
   },
   {
     // 1
     _id: generateObjectId(),
-    name: "Volunteer 2",
-    email: "volunteer.2@example.com",
-    role: ["volunteer"],
+    name: 'Volunteer 2',
+    email: 'volunteer.2@example.com',
+    role: ['volunteer']
   },
   {
     // 2
     _id: generateObjectId(),
-    name: "Volunteer 3",
-    email: "volunteer.3@example.com",
-    role: ["volunteer"],
+    name: 'Volunteer 3',
+    email: 'volunteer.3@example.com',
+    role: ['volunteer']
   },
   {
     // 3
     _id: generateObjectId(),
-    name: "requestor",
-    email: "requestor@example.com",
-    role: ["volunteer"],
-  },
-];
+    name: 'requestor',
+    email: 'requestor@example.com',
+    role: ['volunteer']
+  }
+]
 
 // Two members from the same organisation and one member in another organisation
 const members = [
   {
     _id: generateObjectId(),
-    status: "orgadmin",
+    status: 'orgadmin',
     person: people[0]._id,
-    organisation: firstOrgId,
+    organisation: firstOrgId
   },
   {
     _id: generateObjectId(),
-    status: "member",
+    status: 'member',
     person: people[1]._id,
-    organisation: firstOrgId,
+    organisation: firstOrgId
   },
   {
     _id: generateObjectId(),
-    status: "member",
+    status: 'member',
     person: people[2]._id,
-    organisation: organisations[1]._id,
-  },
-];
+    organisation: organisations[1]._id
+  }
+]
 
-const sixMonthsAgo = moment().subtract(6, "months").toDate();
-const threeYearsAgo = moment().subtract(3, "years").toDate();
+const sixMonthsAgo = moment().subtract(6, 'months').toDate()
+const threeYearsAgo = moment().subtract(3, 'years').toDate()
 
 // Each member has an interest in four opportunities
 const archivedOpportunities = [
@@ -82,152 +82,152 @@ const archivedOpportunities = [
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "PT2H20M",
+    duration: 'PT2H20M'
   },
   {
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "PT1H20M",
+    duration: 'PT1H20M'
   },
   {
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "PT3H",
+    duration: 'PT3H'
   },
   {
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "PT25M",
+    duration: 'PT25M'
   },
   {
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "PT1H50M",
+    duration: 'PT1H50M'
   },
   {
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "P1DT2H20M",
+    duration: 'P1DT2H20M'
   },
   {
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "P1DT1H20M",
+    duration: 'P1DT1H20M'
   },
   {
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "PT3H20M",
+    duration: 'PT3H20M'
   },
   {
     _id: generateObjectId(),
     date: [sixMonthsAgo, null],
     requestor: people[3]._id,
-    duration: "PT1H10M",
+    duration: 'PT1H10M'
   },
   {
     _id: generateObjectId(),
     date: [threeYearsAgo, null],
     requestor: people[3]._id,
-    duration: "PT5H20M",
+    duration: 'PT5H20M'
   },
   {
     _id: generateObjectId(),
     date: [threeYearsAgo, null],
     requestor: people[3]._id,
-    duration: "PT6H20M",
+    duration: 'PT6H20M'
   },
   {
     _id: generateObjectId(),
     date: [threeYearsAgo, null],
     requestor: people[3]._id,
-    duration: "PT7H20M",
-  },
-];
+    duration: 'PT7H20M'
+  }
+]
 
 // Each member attends 2 opporunities in the last six months, attends 1 in the last three
 // years and 1 not attended
 const interestArchives = [
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[0].person,
-    opportunity: archivedOpportunities[0]._id,
+    opportunity: archivedOpportunities[0]._id
   },
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[0].person,
-    opportunity: archivedOpportunities[1]._id,
+    opportunity: archivedOpportunities[1]._id
   },
   {
     _id: generateObjectId(),
-    status: "not_attended",
+    status: 'not_attended',
     person: members[0].person,
-    opportunity: archivedOpportunities[2]._id,
+    opportunity: archivedOpportunities[2]._id
   },
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[0].person,
-    opportunity: archivedOpportunities[9]._id,
+    opportunity: archivedOpportunities[9]._id
   },
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[1].person,
-    opportunity: archivedOpportunities[3]._id,
+    opportunity: archivedOpportunities[3]._id
   },
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[1].person,
-    opportunity: archivedOpportunities[4]._id,
+    opportunity: archivedOpportunities[4]._id
   },
   {
     _id: generateObjectId(),
-    status: "not_attended",
+    status: 'not_attended',
     person: members[1].person,
-    opportunity: archivedOpportunities[5]._id,
+    opportunity: archivedOpportunities[5]._id
   },
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[1].person,
-    opportunity: archivedOpportunities[10]._id,
+    opportunity: archivedOpportunities[10]._id
   },
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[2].person,
-    opportunity: archivedOpportunities[6]._id,
+    opportunity: archivedOpportunities[6]._id
   },
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[2].person,
-    opportunity: archivedOpportunities[7]._id,
+    opportunity: archivedOpportunities[7]._id
   },
   {
     _id: generateObjectId(),
-    status: "not_attended",
+    status: 'not_attended',
     person: members[2].person,
-    opportunity: archivedOpportunities[8]._id,
+    opportunity: archivedOpportunities[8]._id
   },
   {
     _id: generateObjectId(),
-    status: "attended",
+    status: 'attended',
     person: members[2].person,
-    opportunity: archivedOpportunities[11]._id,
-  },
-];
+    opportunity: archivedOpportunities[11]._id
+  }
+]
 
 module.exports = {
   firstOrgId,
@@ -235,5 +235,5 @@ module.exports = {
   people,
   members,
   archivedOpportunities,
-  interestArchives,
-};
+  interestArchives
+}

--- a/server/api/statistics/__tests__/statistics.spec.js
+++ b/server/api/statistics/__tests__/statistics.spec.js
@@ -32,7 +32,7 @@ test.after.always(async (t) => {
   await t.context.memMongo.stop();
 });
 
-test.serial(
+test(
   "Test getSummary returns correct volunteers and hours",
   async (t) => {
     const mockReq = new MockExpressRequest();
@@ -55,5 +55,24 @@ test.serial(
       "Status code should be 200 OK"
     );
     t.deepEqual(responseData, expectedData);
+  }
+);
+
+test(
+  "Test getSummary returns error when organisation doesn't exist",
+  async (t) => {
+    const mockReq = new MockExpressRequest();
+    const mockRes = new MockExpressResponse();
+
+    mockReq.params = { orgId: "5e73112a7f283c001151efc2", timeframe: "year" };
+
+    await getSummary(mockReq, mockRes);
+    const expectedStatusCode = 404;
+
+
+    t.assert(
+      expectedStatusCode === mockRes.statusCode,
+      "Status code should be 404 NOT FOUND"
+    );
   }
 );

--- a/server/api/statistics/__tests__/statistics.spec.js
+++ b/server/api/statistics/__tests__/statistics.spec.js
@@ -76,3 +76,21 @@ test(
     );
   }
 );
+
+test(
+  "Test getSummary returns error when timeframe doesn't exist",
+  async (t) => {
+    const mockReq = new MockExpressRequest();
+    const mockRes = new MockExpressResponse();
+
+    mockReq.params = { orgId: firstOrgId, timeframe: "jerry" };
+
+    await getSummary(mockReq, mockRes);
+    const expectedStatusCode = 400;
+
+    t.assert(
+      expectedStatusCode === mockRes.statusCode,
+      "Status code should be 400 NOT FOUND"
+    );
+  }
+);

--- a/server/api/statistics/__tests__/statistics.spec.js
+++ b/server/api/statistics/__tests__/statistics.spec.js
@@ -1,0 +1,59 @@
+import test from "ava";
+import MemoryMongo from "../../../util/test-memory-mongo";
+import MockExpressRequest from "mock-express-request";
+import MockExpressResponse from "mock-express-response";
+import { getSummary } from "../statistics.controller";
+import {
+  firstOrgId,
+  organisations,
+  people,
+  members,
+  archivedOpportunities,
+  interestArchives,
+} from "./statistics.fixture";
+const { InterestArchive } = require("../../interest/interest");
+const Member = require("../../member/member");
+const ArchivedOpportunity = require("../../archivedOpportunity/archivedOpportunity");
+const Organisation = require("../../organisation/organisation");
+const Person = require("../../person/person");
+
+test.before("Create a mock database and populate it with data ", async (t) => {
+  t.context.memMongo = new MemoryMongo();
+  await t.context.memMongo.start();
+
+  await Organisation.create(organisations);
+  await Person.create(people);
+  await Member.create(members);
+  await ArchivedOpportunity.create(archivedOpportunities);
+  await InterestArchive.create(interestArchives);
+});
+
+test.after.always(async (t) => {
+  await t.context.memMongo.stop();
+});
+
+test.serial(
+  "Test getSummary returns correct volunteers and hours",
+  async (t) => {
+    const mockReq = new MockExpressRequest();
+    const mockRes = new MockExpressResponse();
+
+    mockReq.params = { orgId: firstOrgId, timeframe: "year" };
+
+    await getSummary(mockReq, mockRes);
+    const responseData = mockRes._getJSON();
+    const expectedStatusCode = 200;
+
+    const expectedData = {
+      avgHoursPerVolunteer: 2.9583333333333335,
+      totalHours: 5.916666666666667,
+      totalVolunteers: 2,
+    };
+
+    t.assert(
+      expectedStatusCode === mockRes.statusCode,
+      "Status code should be 200 OK"
+    );
+    t.deepEqual(responseData, expectedData);
+  }
+);

--- a/server/api/statistics/__tests__/statistics.spec.js
+++ b/server/api/statistics/__tests__/statistics.spec.js
@@ -1,96 +1,95 @@
-import test from "ava";
-import MemoryMongo from "../../../util/test-memory-mongo";
-import MockExpressRequest from "mock-express-request";
-import MockExpressResponse from "mock-express-response";
-import { getSummary } from "../statistics.controller";
+import test from 'ava'
+import MemoryMongo from '../../../util/test-memory-mongo'
+import MockExpressRequest from 'mock-express-request'
+import MockExpressResponse from 'mock-express-response'
+import { getSummary } from '../statistics.controller'
 import {
   firstOrgId,
   organisations,
   people,
   members,
   archivedOpportunities,
-  interestArchives,
-} from "./statistics.fixture";
-const { InterestArchive } = require("../../interest/interest");
-const Member = require("../../member/member");
-const ArchivedOpportunity = require("../../archivedOpportunity/archivedOpportunity");
-const Organisation = require("../../organisation/organisation");
-const Person = require("../../person/person");
+  interestArchives
+} from './statistics.fixture'
+const { InterestArchive } = require('../../interest/interest')
+const Member = require('../../member/member')
+const ArchivedOpportunity = require('../../archivedOpportunity/archivedOpportunity')
+const Organisation = require('../../organisation/organisation')
+const Person = require('../../person/person')
 
-test.before("Create a mock database and populate it with data ", async (t) => {
-  t.context.memMongo = new MemoryMongo();
-  await t.context.memMongo.start();
+test.before('Create a mock database and populate it with data ', async (t) => {
+  t.context.memMongo = new MemoryMongo()
+  await t.context.memMongo.start()
 
-  await Organisation.create(organisations);
-  await Person.create(people);
-  await Member.create(members);
-  await ArchivedOpportunity.create(archivedOpportunities);
-  await InterestArchive.create(interestArchives);
-});
+  await Organisation.create(organisations)
+  await Person.create(people)
+  await Member.create(members)
+  await ArchivedOpportunity.create(archivedOpportunities)
+  await InterestArchive.create(interestArchives)
+})
 
 test.after.always(async (t) => {
-  await t.context.memMongo.stop();
-});
+  await t.context.memMongo.stop()
+})
 
 test(
-  "Test getSummary returns correct volunteers and hours",
+  'Test getSummary returns correct volunteers and hours',
   async (t) => {
-    const mockReq = new MockExpressRequest();
-    const mockRes = new MockExpressResponse();
+    const mockReq = new MockExpressRequest()
+    const mockRes = new MockExpressResponse()
 
-    mockReq.params = { orgId: firstOrgId, timeframe: "year" };
+    mockReq.params = { orgId: firstOrgId, timeframe: 'year' }
 
-    await getSummary(mockReq, mockRes);
-    const responseData = mockRes._getJSON();
-    const expectedStatusCode = 200;
+    await getSummary(mockReq, mockRes)
+    const responseData = mockRes._getJSON()
+    const expectedStatusCode = 200
 
     const expectedData = {
       avgHoursPerVolunteer: 2.9583333333333335,
       totalHours: 5.916666666666667,
-      totalVolunteers: 2,
-    };
+      totalVolunteers: 2
+    }
 
     t.assert(
       expectedStatusCode === mockRes.statusCode,
-      "Status code should be 200 OK"
-    );
-    t.deepEqual(responseData, expectedData);
+      'Status code should be 200 OK'
+    )
+    t.deepEqual(responseData, expectedData)
   }
-);
+)
 
 test(
   "Test getSummary returns error when organisation doesn't exist",
   async (t) => {
-    const mockReq = new MockExpressRequest();
-    const mockRes = new MockExpressResponse();
+    const mockReq = new MockExpressRequest()
+    const mockRes = new MockExpressResponse()
 
-    mockReq.params = { orgId: "5e73112a7f283c001151efc2", timeframe: "year" };
+    mockReq.params = { orgId: '5e73112a7f283c001151efc2', timeframe: 'year' }
 
-    await getSummary(mockReq, mockRes);
-    const expectedStatusCode = 404;
-
+    await getSummary(mockReq, mockRes)
+    const expectedStatusCode = 404
 
     t.assert(
       expectedStatusCode === mockRes.statusCode,
-      "Status code should be 404 NOT FOUND"
-    );
+      'Status code should be 404 NOT FOUND'
+    )
   }
-);
+)
 
 test(
   "Test getSummary returns error when timeframe doesn't exist",
   async (t) => {
-    const mockReq = new MockExpressRequest();
-    const mockRes = new MockExpressResponse();
+    const mockReq = new MockExpressRequest()
+    const mockRes = new MockExpressResponse()
 
-    mockReq.params = { orgId: firstOrgId, timeframe: "jerry" };
+    mockReq.params = { orgId: firstOrgId, timeframe: 'jerry' }
 
-    await getSummary(mockReq, mockRes);
-    const expectedStatusCode = 400;
+    await getSummary(mockReq, mockRes)
+    const expectedStatusCode = 400
 
     t.assert(
       expectedStatusCode === mockRes.statusCode,
-      "Status code should be 400 NOT FOUND"
-    );
+      'Status code should be 400 NOT FOUND'
+    )
   }
-);
+)

--- a/server/api/statistics/statistics.controller.js
+++ b/server/api/statistics/statistics.controller.js
@@ -1,7 +1,5 @@
-const { InterestArchive } = require('../interest/interest')
-const Member = require('../member/member')
-const mongoose = require('mongoose')
 const moment = require('moment')
+const {getMembersWithAttendedInterests} = require('./statistics.lib')
 
 const getSummary = async (req, res) => {
   const { orgId, timeframe } = req.params
@@ -20,73 +18,7 @@ const getSummary = async (req, res) => {
 
   try {
     // the volunteers for an organisation are those that have attended an opportunity
-
-    const membersWithAttendedInterests = await Member.aggregate([
-      // find members in organisation with orgId
-      { $match: { organisation: mongoose.Types.ObjectId(orgId) } },
-      // populate the archived interests for each member
-      {
-        $lookup: {
-          from: InterestArchive.collection.name,
-          localField: 'person',
-          foreignField: 'person',
-          as: 'archivedInterests'
-        }
-      },
-      // filter to have only attended archived interests
-      {
-        $addFields: {
-          archivedInterests: {
-            $filter: {
-              input: '$archivedInterests',
-              cond: {
-                $eq: ['$$archivedInterests.status', 'attended']
-              },
-              as: 'archivedInterests'
-            }
-          }
-        }
-      },
-      // populate archived opportunities for each archived interest
-      {
-        $lookup: {
-          from: 'archivedopportunities',
-          localField: 'archivedInterests.opportunity',
-          foreignField: '_id',
-          as: 'opportunitiesAttended'
-        }
-      },
-      // filter opportunites within the given timeframe
-      {
-        $addFields: {
-          opportunitiesAttended: {
-            $filter: {
-              input: '$opportunitiesAttended',
-              cond: {
-                $gt: [
-                  {
-                    $arrayElemAt: ['$$opportunitiesAttended.date', 0]
-                  },
-                  afterDate
-                ]
-              },
-              as: 'opportunitiesAttended'
-            }
-          }
-        }
-      },
-      // remove members that havent attended opportunities within the timeframe
-      {
-        $match: {
-          opportunitiesAttended: {
-            $exists: true,
-            $not: {
-              $size: 0
-            }
-          }
-        }
-      }
-    ])
+    const membersWithAttendedInterests = await getMembersWithAttendedInterests(orgId, afterDate)
 
     const totalVolunteers = membersWithAttendedInterests.length
     const totalDuration = moment.duration();
@@ -107,7 +39,7 @@ const getSummary = async (req, res) => {
       avgHoursPerVolunteer
     })
   } catch (e) {
-    res.status(500).send(e)
+    res.status(500).send({error: e.message})
   }
 }
 

--- a/server/api/statistics/statistics.controller.js
+++ b/server/api/statistics/statistics.controller.js
@@ -1,5 +1,6 @@
 const moment = require('moment')
 const {getMembersWithAttendedInterests} = require('./statistics.lib')
+const Organisation = require('../organisation/organisation')
 
 const getSummary = async (req, res) => {
   const { orgId, timeframe } = req.params
@@ -18,6 +19,9 @@ const getSummary = async (req, res) => {
 
   try {
     // the volunteers for an organisation are those that have attended an opportunity
+    if(!(await Organisation.exists({_id: orgId}))) {
+      return res.status(404).send({error: "Organisation not found"})
+    }
     const membersWithAttendedInterests = await getMembersWithAttendedInterests(orgId, afterDate)
 
     const totalVolunteers = membersWithAttendedInterests.length

--- a/server/api/statistics/statistics.controller.js
+++ b/server/api/statistics/statistics.controller.js
@@ -89,11 +89,22 @@ const getSummary = async (req, res) => {
     ])
 
     const totalVolunteers = membersWithAttendedInterests.length
+    const totalDuration = moment.duration();
 
-    // TODO: send totalVolunteerHours once opportunity.duration is stable/parseable
+    // accumulate total hours for each opportunity attended by each member
+    membersWithAttendedInterests.forEach(member => {
+      member.opportunitiesAttended.forEach(opportunity => {
+        totalDuration.add(moment.duration(opportunity.duration))
+      })
+    })
+   
+    const totalHours = totalDuration.asHours() 
+    const avgHoursPerVolunteer =  totalVolunteers ? totalHours / totalVolunteers : 0; 
 
     res.send({
-      totalVolunteers
+      totalVolunteers,
+      totalHours,
+      avgHoursPerVolunteer
     })
   } catch (e) {
     res.status(500).send(e)

--- a/server/api/statistics/statistics.controller.js
+++ b/server/api/statistics/statistics.controller.js
@@ -1,9 +1,21 @@
 const moment = require('moment')
 const { getMembersWithAttendedInterests } = require('./statistics.lib')
 const Organisation = require('../organisation/organisation')
+const { Role } = require('../../services/authorize/role')
 
 const getSummary = async (req, res) => {
   const { orgId, timeframe } = req.params
+
+  // authentication
+  const currentUser = req.session.me
+  if (!currentUser || !req.session.isAuthenticated) {
+    return res.status(401).send()
+  }
+
+  // authorisation
+  if (!Array.isArray(currentUser.role) || !currentUser.role.includes(Role.ORG_ADMIN) || !Array.isArray(currentUser.orgAdminFor) || !currentUser.orgAdminFor.includes(orgId)) {
+    return res.status(403).send()
+  }
 
   let afterDate
   switch (timeframe) {

--- a/server/api/statistics/statistics.controller.js
+++ b/server/api/statistics/statistics.controller.js
@@ -1,5 +1,5 @@
 const moment = require('moment')
-const {getMembersWithAttendedInterests} = require('./statistics.lib')
+const { getMembersWithAttendedInterests } = require('./statistics.lib')
 const Organisation = require('../organisation/organisation')
 
 const getSummary = async (req, res) => {
@@ -19,13 +19,13 @@ const getSummary = async (req, res) => {
 
   try {
     // the volunteers for an organisation are those that have attended an opportunity
-    if(!(await Organisation.exists({_id: orgId}))) {
-      return res.status(404).send({error: "Organisation not found"})
+    if (!(await Organisation.exists({ _id: orgId }))) {
+      return res.status(404).send({ error: 'Organisation not found' })
     }
     const membersWithAttendedInterests = await getMembersWithAttendedInterests(orgId, afterDate)
 
     const totalVolunteers = membersWithAttendedInterests.length
-    const totalDuration = moment.duration();
+    const totalDuration = moment.duration()
 
     // accumulate total hours for each opportunity attended by each member
     membersWithAttendedInterests.forEach(member => {
@@ -33,9 +33,9 @@ const getSummary = async (req, res) => {
         totalDuration.add(moment.duration(opportunity.duration))
       })
     })
-   
-    const totalHours = totalDuration.asHours() 
-    const avgHoursPerVolunteer =  totalVolunteers ? totalHours / totalVolunteers : 0; 
+
+    const totalHours = totalDuration.asHours()
+    const avgHoursPerVolunteer = totalVolunteers ? totalHours / totalVolunteers : 0
 
     res.send({
       totalVolunteers,
@@ -43,7 +43,7 @@ const getSummary = async (req, res) => {
       avgHoursPerVolunteer
     })
   } catch (e) {
-    res.status(500).send({error: e.message})
+    res.status(500).send({ error: e.message })
   }
 }
 

--- a/server/api/statistics/statistics.controller.js
+++ b/server/api/statistics/statistics.controller.js
@@ -1,0 +1,73 @@
+const { InterestArchive } = require('../interest/interest')
+const Member = require('../member/member')
+const mongoose = require('mongoose')
+
+const getSummary = async (req, res) => {
+  const { orgId } = req.params
+  // TODO: use timeframe in query
+
+  try {
+    // the volunteers for an organisation are those that have attended an opportunity
+
+    const membersWithAttendedInterests = await Member.aggregate([
+      // find members in organisation with orgId
+      { $match: { organisation: mongoose.Types.ObjectId(orgId) } },
+      // populate the archived interests for each member
+      {
+        $lookup: {
+          from: InterestArchive.collection.name,
+          localField: 'person',
+          foreignField: 'person',
+          as: 'archivedInterests'
+        }
+      },
+      // find members that have at least one attended archived interest
+      {
+        $match: {
+          archivedInterests: {
+            $elemMatch: {
+              status: 'attended'
+            }
+          }
+        }
+      },
+      // filter to have only attended archived interests
+      {
+        $addFields: {
+          archivedInterests: {
+            $filter: {
+              input: '$archivedInterests',
+              cond: {
+                $eq: ['$$archivedInterests.status', 'attended']
+              },
+              as: 'archivedInterests'
+            }
+          }
+        }
+      },
+      // populate archived opportunities for each archived interest
+      {
+        $lookup: {
+          from: 'archivedopportunities',
+          localField: 'archivedInterests.opportunity',
+          foreignField: '_id',
+          as: 'opportunitiesAttended'
+        }
+      }
+    ])
+
+    const totalVolunteers = membersWithAttendedInterests.length
+
+    // TODO: send totalVolunteerHours once opportunity.duration is stable/parseable
+
+    res.send({
+      totalVolunteers
+    })
+  } catch (e) {
+    res.status(500).send(e)
+  }
+}
+
+module.exports = {
+  getSummary
+}

--- a/server/api/statistics/statistics.lib.js
+++ b/server/api/statistics/statistics.lib.js
@@ -1,0 +1,75 @@
+const { InterestArchive } = require('../interest/interest')
+const Member = require('../member/member')
+const mongoose = require('mongoose')
+
+const getMembersWithAttendedInterests = async (orgId, afterDate) =>
+  await Member.aggregate([
+    // find members in organisation with orgId
+    { $match: { organisation: mongoose.Types.ObjectId(orgId) } },
+    // populate the archived interests for each member
+    {
+      $lookup: {
+        from: InterestArchive.collection.name,
+        localField: "person",
+        foreignField: "person",
+        as: "archivedInterests",
+      },
+    },
+    // filter to have only attended archived interests
+    {
+      $addFields: {
+        archivedInterests: {
+          $filter: {
+            input: "$archivedInterests",
+            cond: {
+              $eq: ["$$archivedInterests.status", "attended"],
+            },
+            as: "archivedInterests",
+          },
+        },
+      },
+    },
+    // populate archived opportunities for each archived interest
+    {
+      $lookup: {
+        from: "archivedopportunities",
+        localField: "archivedInterests.opportunity",
+        foreignField: "_id",
+        as: "opportunitiesAttended",
+      },
+    },
+    // filter opportunites within the given timeframe
+    {
+      $addFields: {
+        opportunitiesAttended: {
+          $filter: {
+            input: "$opportunitiesAttended",
+            cond: {
+              $gt: [
+                {
+                  $arrayElemAt: ["$$opportunitiesAttended.date", 0],
+                },
+                afterDate,
+              ],
+            },
+            as: "opportunitiesAttended",
+          },
+        },
+      },
+    },
+    // remove members that havent attended opportunities within the timeframe
+    {
+      $match: {
+        opportunitiesAttended: {
+          $exists: true,
+          $not: {
+            $size: 0,
+          },
+        },
+      },
+    },
+  ]);
+
+  module.exports = {
+    getMembersWithAttendedInterests
+  }

--- a/server/api/statistics/statistics.lib.js
+++ b/server/api/statistics/statistics.lib.js
@@ -3,59 +3,59 @@ const Member = require('../member/member')
 const mongoose = require('mongoose')
 
 const getMembersWithAttendedInterests = async (orgId, afterDate) =>
-  await Member.aggregate([
+  Member.aggregate([
     // find members in organisation with orgId
     { $match: { organisation: mongoose.Types.ObjectId(orgId) } },
     // populate the archived interests for each member
     {
       $lookup: {
         from: InterestArchive.collection.name,
-        localField: "person",
-        foreignField: "person",
-        as: "archivedInterests",
-      },
+        localField: 'person',
+        foreignField: 'person',
+        as: 'archivedInterests'
+      }
     },
     // filter to have only attended archived interests
     {
       $addFields: {
         archivedInterests: {
           $filter: {
-            input: "$archivedInterests",
+            input: '$archivedInterests',
             cond: {
-              $eq: ["$$archivedInterests.status", "attended"],
+              $eq: ['$$archivedInterests.status', 'attended']
             },
-            as: "archivedInterests",
-          },
-        },
-      },
+            as: 'archivedInterests'
+          }
+        }
+      }
     },
     // populate archived opportunities for each archived interest
     {
       $lookup: {
-        from: "archivedopportunities",
-        localField: "archivedInterests.opportunity",
-        foreignField: "_id",
-        as: "opportunitiesAttended",
-      },
+        from: 'archivedopportunities',
+        localField: 'archivedInterests.opportunity',
+        foreignField: '_id',
+        as: 'opportunitiesAttended'
+      }
     },
     // filter opportunites within the given timeframe
     {
       $addFields: {
         opportunitiesAttended: {
           $filter: {
-            input: "$opportunitiesAttended",
+            input: '$opportunitiesAttended',
             cond: {
               $gt: [
                 {
-                  $arrayElemAt: ["$$opportunitiesAttended.date", 0],
+                  $arrayElemAt: ['$$opportunitiesAttended.date', 0]
                 },
-                afterDate,
-              ],
+                afterDate
+              ]
             },
-            as: "opportunitiesAttended",
-          },
-        },
-      },
+            as: 'opportunitiesAttended'
+          }
+        }
+      }
     },
     // remove members that havent attended opportunities within the timeframe
     {
@@ -63,13 +63,13 @@ const getMembersWithAttendedInterests = async (orgId, afterDate) =>
         opportunitiesAttended: {
           $exists: true,
           $not: {
-            $size: 0,
-          },
-        },
-      },
-    },
-  ]);
+            $size: 0
+          }
+        }
+      }
+    }
+  ])
 
-  module.exports = {
-    getMembersWithAttendedInterests
-  }
+module.exports = {
+  getMembersWithAttendedInterests
+}

--- a/server/api/statistics/statistics.routes.js
+++ b/server/api/statistics/statistics.routes.js
@@ -1,0 +1,5 @@
+const { getSummary } = require('./statistics.controller')
+
+module.exports = (server) => {
+  server.get('/api/statistics/summary/:orgId/:timeframe', getSummary)
+}


### PR DESCRIPTION
## I do solemnly swear that I have:
- [x] Run `npm test` and all the tests pass.
- [x] Run `npm run lint` and there are no warnings.
- [x] Not decreased the overall test coverage?
- [x] Included the Jira ID and description in the PR title

## Proposed Changes? 🤔
1. Implement `GET /statistics/summary` API endpoint to retrieve totalHours, totalVolunteers and avgHoursPerVolunteer for the last month/year for an organisation.
2. Implemented unit tests for the endpoint.

## Additional Info.🧐

MongoDB aggregations are used for performance. The document graph can be queried in a single call to the database. Using populate and traversing the document graph would result in many calls to the database (`members X interests X opportunity`), which is grossly inefficient. 

The API schema is `GET /api/statistics/summary/:orgId/:timeframe` and returns an object similar to 
```json
{
    "totalHours": 61.3,
    "totalVolunteers": 5,
    "avgHoursPerVolunteer": 12.26
}
```